### PR TITLE
Add Meta WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ working groups are listed below:
 Name                                               | Leads                                                   | Short Description                                                | Start Date    | Status       | Zulip Stream                          | Regular meetings                                  | Labels       |
 ----                                               | -----                                                   | -----------------                                                | ----------    | ------       | ------------                          | --------                                  | ------       |
 [Async-await](working-groups/async-await/) | [@nikomatsakis][nikomatsakis] and [@cramertj][cramertj] | Implementing async-await                               | February 2019     | Active | [#t-compiler/wg-async-await][async-await_stream]      | N/A | A-async-await |
+[Meta](working-groups/meta/) | [@nikomatsakis][nikomatsakis], [@davidtwco][davidtwco] and [@spastorino][spastorino] | How compiler team organizes itself                        | February 2019     | Active | [#t-compiler/wg-meta][meta_stream]      | N/A | N/A |
 [Non-lexical lifetimes (NLL)](working-groups/nll/) | [@nikomatsakis][nikomatsakis] and [@pnkfelix][pnkfelix] | Implementing non-lexical lifetimes                               | June 2017     | Winding down | [#t-compiler/wg-nll][nll_stream]      | [Weekly, in Zulip][] (optional) | A-NLL, NLL-* |
 [Traits](working-groups/traits/) | [@nikomatsakis][nikomatsakis] | Improving the trait-system design + implementation | February 2019 | Active       | [#t-compiler/wg-traits][traits_stream] | [Weekly, in Zulip][] (optional)                                      | A-traits          |
 [RLS 2.0](working-groups/rls-2.0/)                 | [@matklad][matklad]                                     | Experimenting with a new compiler architecture tailored for IDEs | February 2019 | Active       | [#t-compiler/wg-rls2.0][rls20_stream] | N/A                                       | N/A          |
@@ -62,6 +63,8 @@ Name                                               | Leads                      
 [cramertj]: https://github.com/cramertj
 [matklad]: https://github.com/matklad
 [pnkfelix]: https://github.com/pnkfelix
+[davidtwco]: https://github.com/davidtwco
+[spastorino]: https://github.com/spastorino
 
 [Weekly, in Zulip]: #meeting-calendar
 [nll_stream]: https://rust-lang.zulipchat.com/#narrow/stream/122657-t-compiler.2Fwg-nll

--- a/working-groups/meta/FAQ.md
+++ b/working-groups/meta/FAQ.md
@@ -1,0 +1,3 @@
+# Frequently Asked Questions (FAQ)
+
+Looks like no questions have been asked yet! If you have a question, feel free to file an issue or ask in the working group's Zulip stream.

--- a/working-groups/meta/NOTES.md
+++ b/working-groups/meta/NOTES.md
@@ -1,0 +1,36 @@
+# Meta Meeting Notes
+This document contains meeting notes from the Meta working group.
+
+## 2019-02-21:
+**Written by:** [@nikomatsakis][nikomatsakis]
+
+**Purpose of meeting**:
+
+- Clarify the “scope” of the meta working group.
+  - What problems does the meta working group aim to solve?
+  - What problems do we want to avoid creating? (e.g. bureaucracy, administrative overhead)
+- Discuss working group “bootstrap process”
+  - What should each working group define?
+  - What structure should a WG “check-in” have?
+  - Can we produce a “WG Template” that I can then pass around to folks to fill out?
+- What are the most actionable ideas and can we rank those?
+- Which ideas would be better suited for more “discussion meetings”?
+  - Steering meetings? Or should we use those for something else
+
+**Working Group Components**:
+
+- Zulip Stream(s)
+- Zulip User Group (`WG-compiler-foo`)
+- GitHub Team? Someway for people to get notifications
+- GitHub Labels
+- Contact points:
+  - Leads
+  - Compiler team liason — who will present
+  - Maybe others that you can ping on Zulip to ask questions
+  
+- Across team:
+  - Some kind of table summarizing WGs
+
+
+- Membership (default):
+  - We want to avoid any sort of formal membership to a working group. Instead a wg has leads and interested folk can subscribe to it to receive notifications on GitHub issues and in Zulip.

--- a/working-groups/meta/NOTES.md
+++ b/working-groups/meta/NOTES.md
@@ -1,7 +1,8 @@
 # Meta Meeting Notes
 This document contains meeting notes from the Meta working group.
 
-## 2019-02-21:
+## 2019-02-21: [Meeting][meeting20190221]
+
 **Written by:** [@nikomatsakis][nikomatsakis]
 
 **Purpose of meeting**:
@@ -27,10 +28,9 @@ This document contains meeting notes from the Meta working group.
   - Leads
   - Compiler team liason — who will present
   - Maybe others that you can ping on Zulip to ask questions
-  
 - Across team:
   - Some kind of table summarizing WGs
-
-
 - Membership (default):
   - We want to avoid any sort of formal membership to a working group. Instead a wg has leads and interested folk can subscribe to it to receive notifications on GitHub issues and in Zulip.
+
+[triage20190222]: https://rust-lang.zulipchat.com/#narrow/stream/122657-t-compiler.2Fwg-nll/topic/weekly.20meeting.202019.2E02.2E20/near/158880485

--- a/working-groups/meta/README.md
+++ b/working-groups/meta/README.md
@@ -3,7 +3,7 @@
 
 This working group is dedicated to fleshing out the details of how the compiler team will organize itself.
 
-- **Leads:** [@nikomatsakis][nikomatsakis]
+- **Leads:** [@nikomatsakis][nikomatsakis], [@davidtwco][davidtwco] and [@spastorino][spastorino]
 - **Meeting Notes:** [All](NOTES.md)
 
 [status]: https://img.shields.io/badge/status-active-brightgreen.svg?style=for-the-badge
@@ -99,3 +99,5 @@ group for the working group if you are interested in being pinged when there are
 [zulip]: https://rust-lang.zulipchat.com/#narrow/stream/185694-t-compiler.2Fwg-meta
 
 [nikomatsakis]: https://github.com/nikomatsakis
+[davidtwco]: https://github.com/davidtwco
+[spastorino]: https://github.com/spastorino

--- a/working-groups/meta/README.md
+++ b/working-groups/meta/README.md
@@ -1,7 +1,7 @@
 # Meta Working Group
 ![working group status: active][status]
 
-This working group is dedicated to fleshout details of how the compiler team will organize itself.
+This working group is dedicated to fleshing out the details of how the compiler team will organize itself.
 
 - **Leads:** [@nikomatsakis][nikomatsakis]
 - **Meeting Notes:** [All](NOTES.md)

--- a/working-groups/meta/README.md
+++ b/working-groups/meta/README.md
@@ -11,10 +11,80 @@ This working group is dedicated to fleshing out the details of how the compiler 
 ## What is the goal of this working group?
 This working group aims to accomplish the following:
 
-- Organizing working groups
-- Organizing rustc calendar
-- Organizing videos and lectures
-- Organizing communication between members
+- How to organize compiler team calendar?
+  - One calendar for everything or one per working group?
+- How to organize videos so people can find them?
+  - e.g. playlists on YouTube, rustc-guide chapter
+  - How do we make it easy to add them?
+    - Some are specific to a working group or limited subset of contributors?
+- How to run open-ended tasks?
+  - e.g. lecture series, triage, rustc “university”
+- What is the role of the steering meeting?
+  - In-depth discussion of topics that come up during the week?
+  - Judge newer proposals?
+  - Decide if the set of working groups should change?
+  - When should we post agendas?
+- How should we get “inbound” prioritization requests?
+  - e.g. if embedded working group has something they want or someone has a cool idea (pipelined compilation)
+  - Use the steering meeting?
+- Expert list
+  - Where should this be found?
+    - This is related to “Advertising” the compiler team point below.
+  - How should it be maintained?
+  - What qualifies as expert?
+- Journeypeople
+  - What should the name of this group be?
+  - Criteria for membership?
+  - Equivalent to r+ rights?
+  - “Expiration” after some time?
+  - How to make this a useful concept?
+    - Relevant Q: what problem does this aim to solve?
+  - Other clarifications:
+    - Are journeypeople members of the compiler team or is this a step toward being a member of the team?
+    - What is the expected conduct of a journeyperson? Does this change at all? Are there more expectations?
+    - How can journeypeople be useful to existing full compiler team members?
+- Managing the mundane (ensuring everyone is added everywhere)
+  - Interaction with `rust-lang/team` repository/effort by pietroalbini.
+  - Need to work out what all the things people need access to are.
+- Working groups
+  - What guidelines should exist for working groups?
+    - e.g. effective meetings, note taking, check-ins at steering meetings, etc.
+  - Directory structure in `rust-lang/compiler-team` repository
+    - `index.md` and some other files already exist
+    - Do we want more than this?
+  - Assessing progress
+    - Can we encourage working groups to set goals as part of their regular triage?
+    - Goal: Leave check-in meeting feeling energized with clear ideas of next steps.
+- Design documents
+  - How can we encourage up-front design and documentation?
+    - How much is too much?
+  - e.g. pipelined compilation, parallel rustc
+  - How does this interact with the rustc-guide?
+- API documentation
+  - Should there be a working group focusing on this?
+- Async vs sync communication
+  - Which is really easier?
+  - Harder to make decisions over async.
+    - Async can be easier for for non-native speakers.
+    - Hard to keep up if too many commitments.
+  - Sync can help throttle the volume.
+    - Encourgages congeniality and cooperation.
+    - Time zones are hard.
+- “Advertising” the compiler team
+  - How to publicize the working groups and ways to contribute to the compiler team’s work?
+    - e.g. landing page (website or `rust-lang/compiler-team` repo)
+  - What information is useful for people looking to contribute?
+    - When meetings are held, what is the purpose of each meeting, who should attend, where are the meetings held?
+    - Who is the best person to contact about specific areas in the compiler? What is the best way to contact them?
+    - What working groups are available? What is working group X doing? Where can I find a working group? Who is in a working group? Are there meetings? Do I need to attend? Do I need any prior experience? Are there resources that would help me get up to speed? Are there labels on the issues for this working group? Who is leading the working group?
+    - What working groups might start in future? How can I register my interest in them?
+    - What are best practices for contributing? (inspired by: youtu.be/voXVTjwnn-U?t=1862)
+- Documenting compiler team practices and policies
+  - What is and isn’t the team responsible for?
+  - What are the policies are regarding third party crates, crate maintainership, etc.?
+  - What are the compiler team’s roadmap and goals for the year?
+- Triage tasks
+  - Processes for future compatibility warnings
 
 # How can I get involved?
 If you are interested in getting involved in this working group, you should try attend a meeting and

--- a/working-groups/meta/README.md
+++ b/working-groups/meta/README.md
@@ -1,0 +1,31 @@
+# Meta Working Group
+![working group status: active][status]
+
+This working group is dedicated to fleshout details of how the compiler team will organize itself.
+
+- **Leads:** [@nikomatsakis][nikomatsakis]
+- **Meeting Notes:** [All](NOTES.md)
+
+[status]: https://img.shields.io/badge/status-active-brightgreen.svg?style=for-the-badge
+
+## What is the goal of this working group?
+This working group aims to accomplish the following:
+
+- Organizing working groups
+- Organizing rustc calendar
+- Organizing videos and lectures
+- Organizing communication between members
+
+# How can I get involved?
+If you are interested in getting involved in this working group, you should try attend a meeting and
+introduce yourself or send a message in the Zulip stream. You can be added to the GitHub and Zulip
+group for the working group if you are interested in being pinged when there are available tasks.
+
+- **Desired experience level:** Any
+- **Relevant repositories:** [`rust-lang/compiler-team`][repo]
+- **Zulip stream:** [`#t-compiler/wg-meta`][zulip] on Zulip
+
+[repo]: https://github.com/rust-lang/compiler-team
+[zulip]: https://rust-lang.zulipchat.com/#narrow/stream/185694-t-compiler.2Fwg-meta
+
+[nikomatsakis]: https://github.com/nikomatsakis

--- a/working-groups/meta/README.md
+++ b/working-groups/meta/README.md
@@ -9,7 +9,7 @@ This working group is dedicated to fleshing out the details of how the compiler 
 [status]: https://img.shields.io/badge/status-active-brightgreen.svg?style=for-the-badge
 
 ## What is the goal of this working group?
-This working group aims to accomplish the following:
+This working group aims to discuss and answer the following unresolved questions:
 
 - How to organize compiler team calendar?
   - One calendar for everything or one per working group?


### PR DESCRIPTION
@nikomatsakis @davidtwco I've followed what the template suggests but I've figured out that it's a bit different to the style that the rest of the working groups are using. Unsure if we should migrate the rest or what's the idea.

In the NOTES.md file, I've used what we had on paper. It probably lacks a lot of info. Should I just read the meeting and do a brief recap?.

In the README.md check mainly the goals of the WG and I'm not sure who leads the working group so I've added only @nikomatsakis for now.