### PR TITLE
Fix broken link in meta notes.

### DIFF
--- a/working-groups/meta/NOTES.md
+++ b/working-groups/meta/NOTES.md
@@ -3,12 +3,10 @@ This document contains meeting notes from the Meta working group.
 
 ## 2019-02-28: [Meeting][meeting20190228]
 **Written by:** [@spastorino][spastorino]
-[spastorino]: https://github.com/spastorino
 
 - What problems do we want to solve from a compiler team member perspective and from a contributor perspective?
   - Help to grow the team by ensuring that we engage people who've started to get active in rustc?
   - Provide a source of people who can help implement things without needing as much mentoring?
-
 - What does it mean to be a journeyperson?
   - You know something about the compiler?
   - People willing to commit some time to help run things
@@ -17,21 +15,16 @@ This document contains meeting notes from the Meta working group.
   - Start to do reviews?
   - What responsibilities should a journeyperson have?
   - Are journeypeople members of the team or is a journeyperson role considered a stepping stone toward being a member of the team?
-
 - What are the qualifications and expectations for a member of the compiler team?
-
 - What's the difference between journeypeople and team members?
   - Full members know >1 area?
   - Or full members know enough to independently lead a WG in some area?
-
 - What is the process for becoming a journeyperson?
   - Should compiler team members nominate new journeypeople and then confirm it with the rest of the team?
   - Is there some formal mechanism for that?
   - Should compiler team members have a responsibility to mentor their proposed journeypersons through their new responsibilities?
-
 - What is the process for transitioning from a journeyperson role to full membership?
  - Same process as already exists for becoming a full member?
-
 - Is there an ettiquette for journeypeople?
   - What about team members?
 
@@ -68,4 +61,5 @@ This document contains meeting notes from the Meta working group.
 
 [meeting20190228]: https://rust-lang.zulipchat.com/#narrow/stream/185694-t-compiler.2Fwg-meta/topic/meeting.202019.2E02.2E28
 [meeting20190221]: https://rust-lang.zulipchat.com/#narrow/stream/185694-t-compiler.2Fwg-meta/topic/meeting.202019.2E02.2E21
+[spastorino]: https://github.com/spastorino
 [nikomatsakis]: https://github.com/nikomatsakis


### PR DESCRIPTION
You can see on [this page](https://github.com/rust-lang/compiler-team/blob/master/working-groups/meta/NOTES.md) that the link is currently broken.