### PR TITLE
Add experts map to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Name                                               | Leads                      
 [rfc-2229-stream]: https://rust-lang.zulipchat.com/#narrow/stream/189812-t-compiler.2Fwg-rfc-2229
 [mir-opt-stream]: https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt
 
+## Expert Map
+
+If you're interested in figuring out who can answer questions about a
+particular part of the compiler, or you'd just like to know who works on what,
+check out our [experts directory](experts). It contains a listing of the
+various parts of the compiler and a list of people who are experts on each one.
+
 ## Procedures
 
 The [procedures directory](procedures) contains descriptions of various

--- a/experts/MAP.md
+++ b/experts/MAP.md
@@ -1,0 +1,9 @@
+# Expert Map
+
+This document contains the different areas of the compiler and the people that
+are experts in each area. While the expert map is being fleshed out, [you can find it on HackMD][map].
+
+This map is intended to help you figure out who you should ask for help if you
+have questions about how some area works.
+
+[map]: https://hackmd.io/Izvor8KZRiqUgcUyd2CYTw


### PR DESCRIPTION
@nikomatsakis @davidtwco we agreed on adding a document here that links the experts map.

Now I wonder, shouldn't we do the opposite?, I mean, build a table in this repo and link from the hackmd to this place just in case people have the old link.

The downside is that it's a bit more involved to add/remove/change stuff on github because requires a PR. But I guess this is "stable" now?.