### PR TITLE
Add a repository for cargo-lockfile-sync

### DIFF
--- a/procedures/crates.md
+++ b/procedures/crates.md
@@ -168,3 +168,4 @@ This section contains the list of existing out-of-tree, compiler team-maintained
   - [`rust-lang/chalk`](https://github.com/rust-lang/chalk/)
   - [`rust-lang/polonius`](https://github.com/rust-lang/polonius/)
   - [`rust-lang/measureme`](https://github.com/rust-lang/measureme/)
+  - [`rust-lang/cargo-lockfile-sync`](https://github.com/rust-lang/cargo-lockfile-sync/)


### PR DESCRIPTION
Originally suggested in https://github.com/rust-lang/rust/issues/57443

This project is a custom crate that is independent of rustc, but will keep our `toml` files in sync with the `lock` files (rationale, see linked issue). Instead of putting that code in-tree, I want it to start out of tree immediately, since it's generally useful.