### PR TITLE
Add missing grammar directory to experts map

### DIFF
--- a/content/docs/experts/map.toml
+++ b/content/docs/experts/map.toml
@@ -58,7 +58,7 @@ who = ["petrochenkov", "estebank"]
 
 [[experts]]
 area = "Grammar"
-directories = []
+directories = ["src/grammar"]
 who = ["qmx", "centril", "eddyb"]
 
 [[experts]]


### PR DESCRIPTION
This is part of #87, would be nice if others can jump in and suggest missing parts too :).