### PR TITLE
Kick off discussion about extracting bit primitives

### DIFF
--- a/procedures/crates.md
+++ b/procedures/crates.md
@@ -169,3 +169,4 @@ This section contains the list of existing out-of-tree, compiler team-maintained
   - [`rust-lang/polonius`](https://github.com/rust-lang/polonius/)
   - [`rust-lang/measureme`](https://github.com/rust-lang/measureme/)
   - [`rust-lang/cargo-lockfile-sync`](https://github.com/rust-lang/cargo-lockfile-sync/)
+  - bit-primitives


### PR DESCRIPTION
This is my first contribution to rust, so feel free to point me to the right direction if I do something unconventionally.

Rust ticket: rust-lang/rust#50592

For context, data types I could find:

```
bit_set.rs:27:pub struct BitSet<T: Idx> {
bit_set.rs:294:pub struct BitIter<'a, T: Idx> {
bit_set.rs:348:pub struct SparseBitSet<T: Idx> {
bit_set.rs:644:pub struct GrowableBitSet<T: Idx> {
bit_set.rs:695:pub struct BitMatrix<R: Idx, C: Idx> {
bit_set.rs:886:pub struct SparseBitMatrix<R, C>
bit_set.rs:453:pub enum HybridBitSet<T: Idx> {
```

Decisions to be made:

- [ ] whether it pays off to extract them at all (if not, close the rust ticket?)
- [ ] crate name (the one currently commited is just a placeholder)
- [ ] repository location (the crates included in this document use rust-lang, but the rust ticket mentions rust-lang-nursery)

@rfcbot merge