### PR TITLE
Update Polonius meeting notes

### DIFF
--- a/content/docs/working-groups/polonius/_index.md
+++ b/content/docs/working-groups/polonius/_index.md
@@ -24,6 +24,8 @@ crate to define the full borrow check analysis.
     - [2019.05.07 Meeting]({{< relref "/docs/working-groups/polonius/minutes/2019.05.07-meeting" >}})
     - [2019.05.14 Meeting]({{< relref "/docs/working-groups/polonius/minutes/2019.05.14-meeting" >}})
     - [2019.05.28 Meeting]({{< relref "/docs/working-groups/polonius/minutes/2019.05.28-meeting" >}})
+    - [2019.06.04 Meeting]({{< relref "/docs/working-groups/polonius/minutes/2019.06.04-meeting" >}})
+    - [2019.06.11 Meeting]({{< relref "/docs/working-groups/polonius/minutes/2019.06.11-meeting" >}})
 - **Screencasts**: [YouTube Playlist](https://www.youtube.com/playlist?list=PL85XCvVPmGQitE2CBzf-gERSqeXo59NQG)
 - **FAQ:** [FAQ]({{< relref "/docs/working-groups/polonius/FAQ" >}})
 

--- a/content/docs/working-groups/polonius/minutes/2019.03.07-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.03.07-meeting.md
@@ -2,6 +2,7 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E03.2E07)
 - A [Paper document](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) for the WIP roadmap
 
@@ -16,6 +17,7 @@ We then described a possible follow-up task, focusing on Polonius completeness: 
 We also spent time talking about next steps in documentation, whether in talks ([Niko]) or written docs ([Rémy]).
 
 Possible talks:
+
 - a walkthrough of a more complex theoretical example.
 - a more practical walkthrough with a focus on the concrete parts of the Polonius computation: interfacing with rustc and transferring data, computing the analysis' datalog rules, how datafrog works, etc.
 
@@ -25,6 +27,7 @@ The final points were more about cross-cutting concerns applicable to all WGs: h
 
 ----
 The major next steps we decided on were:
+
 - [Matthew] will write mentoring instructions for the [hybrid algorithm task](https://github.com/rust-lang/polonius/issues/100).
 - [Niko] and [Albin] will prepare the follow-up walkthrough of Polonius (the specific time, and contents). 
 - [Niko] will review the [subset relation PR](https://github.com/rust-lang/polonius/pull/99).

--- a/content/docs/working-groups/polonius/minutes/2019.04.23-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.04.23-meeting.md
@@ -2,12 +2,14 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E04.2E23)
 - A [Paper document](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) for the WIP roadmap
 
 ---
 
 In this meeting, we started with a short review of the previous week's work:
+
 - [Albin] continued work on implementing liveness in Polonius, and finalized [#105](https://github.com/rust-lang/polonius/pull/105), which is now ready to be merged into a new `polonius-engine` release.
 - [Niko] wrote up [notes](https://github.com/rust-lang/polonius/issues/104#issuecomment-485011791) describing the second part of the liveness effort: modifying rustc to emit `var_used` and `var_defined` facts for the previous PR. [Albin] has already started working on these rustc steps.
 - [Rémy] landed the tiny [#106](https://github.com/rust-lang/polonius/pull/106).
@@ -20,6 +22,7 @@ A useful task was mentioned for the near future: going through the Polonius fail
 
 ----
 For the following week:
+
 - [Albin] will continue on the liveness fact generation in rustc.
 - [Rémy] will continue work on the `Hybrid` variant optimization.
 - [@lokalmatador] will familiarize with the steps [Niko] wrote, with available help from the rest of the WG.

--- a/content/docs/working-groups/polonius/minutes/2019.04.30-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.04.30-meeting.md
@@ -2,12 +2,14 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E04.2E30).
 - The [WIP Roadmap](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) Paper.
 
 ---
 
 In this meeting, we started with a short review of the previous week's work:
+
 - [Albin] continued work on implementing liveness in [Polonius](https://github.com/rust-lang/polonius/pull/105), and opened the [rustc](https://github.com/rust-lang/rust/pull/60266) part of this work: generating the facts needed by the Polonius computation.
 - [Niko] wrote up some more [notes](https://github.com/rust-lang/polonius/issues/104#issuecomment-488076424) on continuing the liveness work: the next major part being computing the `region_live_at` facts in Polonius analyses instead of rustc.
 - [Rémy] continued the previous week's work of using the results of `LocInsensitive` in `DatafrogOpt` via the `Hybrid` analysis, especially looking for changes in behaviour using polonius and rustc's tests, and ran into the task mentioned the week before: the rustc ui test suite under polonius has more failures than expected.
@@ -16,15 +18,18 @@ In this meeting, we started with a short review of the previous week's work:
 Since the liveness work is a bit complex, has many moving parts, and is generally hard to test, we [talked](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E04.2E30/near/164566587) about correctness, testing, rustc's test suite and the need to have a reasonable test suite in general. A first step will be to look into rustc's test suite failures, `ignore`ing irrelevant tests or add `bless`ed output, at the very least to track changes and regressions more easily.
 
 The WIP plan about polonius features and rustc integration/subsumption looks clear:
+
 - liveness, which we are actively working on now.
 - moves, which should hopefully be smaller, has precedent in the work on Lark, and could be partially/possibly applicable to rustc.
 - regions and region logic, for which we have started working on the easier parts, but also crosses paths with the [traits WG and chalk effort](https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/meeting.202019.2E04.2E29/near/164478317) for the more complex ones.
 
 Useful future tasks we mentioned:
+
 - after the inaugural talk, it'd be useful to continue the "explaining Polonius" series of videos/talks, focusing on the analysis rules and examples to learn, or remember, why they are the way they are.
 
 ----
 For the following week:
+
 - [Albin] will continue on liveness.
 - [Rémy] will look at the rustc tests in more detail.
 - [Niko] will prepare the next steps in the liveness, to stay ahead of [Albin]'s progress.

--- a/content/docs/working-groups/polonius/minutes/2019.05.07-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.05.07-meeting.md
@@ -2,23 +2,27 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E05.2E07).
 - The [WIP Roadmap](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) Paper.
 
 ---
 
 In this shorter meeting, we spent most of the time on the previous week's work:
+
 - [Niko] has written more [notes](https://github.com/rust-lang/polonius/issues/104#issuecomment-489681898) and [steps](https://github.com/rust-lang/polonius/issues/104#issuecomment-489691804) for implementing liveness. With these, most of liveness is described (modulo the specifics of `drop`) :tada:. 
 - [Albin] smoothly continued work on computing liveness in Polonius in [#105](https://github.com/rust-lang/polonius/pull/105), and rustc's [#60266](https://github.com/rust-lang/rust/pull/60266): finishing up last week's steps about the beginning of fact generation, and preparing to emit the ones needed to compute the `region_live_at` relation.
 - [Rémy] started looking at rustc's test suite behaviour under `--compare-mode polonius` in more detail. While initially the number of failures looked [big](https://github.com/rust-lang/rust/compare/master...lqd:polonius_tests), [Matthew] mentioned their in-review PR [#60171](https://github.com/rust-lang/rust/pull/60171), which would contain most of the differences seen in these initial runs, as it unifies the NLL mode under which both of these test modes are ran.
 - [@lokalmatador] successfully got rustc building and prepared for profiling.
 
 Useful future tasks we mentioned:
+
 - even though we always think about the topic, we noticed analyzing the test suite, tests and correctness, are tasks which should actually be mentioned in the Roadmap.
 - the polonius compare-mode likely has little or no documentation, fixing that would be important as part of the general documentation effort needed by the project.
 
 ----
 For the following week:
+
 - [Albin] will continue on liveness.
 - To get ahead of the liveness game, [Niko] will look at and describe more of the `drop` specifics.
 - [Rémy] will continue on the rustc test suite results, especially on top of [#60171](https://github.com/rust-lang/rust/pull/60171). But also write the previous meetings' notes they forgot to do (but as you can attest, dear reader/reviewer, got done eventually).

--- a/content/docs/working-groups/polonius/minutes/2019.05.14-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.05.14-meeting.md
@@ -2,12 +2,14 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E05.2E14).
 - The [WIP Roadmap](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) Paper.
 
 ---
 
 A recap of last week's work:
+
 - [Niko] and [Albin] went through a lot of details of liveness, in the dedicated Zulip thread ([around this point](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/liveness.20polonius.23104/near/165238306)). 
 - With the previous week's steps, and these conversations, [Albin] has continued the work on liveness, and is now _basically done_ :tada:. With the 2 PRs, Polonius is able to compute the same `region_live_at` facts as rustc. The remaining work being mostly clean-up, various minor fixes, more testing, and finally, reviews. The remaining tasks are listed in [this comment](https://github.com/rust-lang/polonius/issues/104#issuecomment-492380520).
 - [Rémy] has continued looking at the rustc test suite under Polonius. As expected, over [#60171](https://github.com/rust-lang/rust/pull/60171), there are less than 20 failures. A first pass at analyzing the results is available [here](https://hackmd.io/CjYB0fs4Q9CweyeTdKWyEg) with links to the necessary information (test source, NLL/polonius outputs, diff) to categorize the failures but the TL;DR is: some of them are trivially fixable (being artifacts of test construction, and identical under NLLs and Polonius), some are duplicates or similar to of other failures, a lot are simply different diagnostics, and a handful need more in-depth investigation to understand the difference in behaviour, if it's a bug, and so on. More information will generally be available in [the dedicated thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/rustc.20compare-mode.20polonius).
@@ -15,13 +17,16 @@ A recap of last week's work:
 - On the more administrative side of things, [Rémy] wrote up the meeting notes from the previous weeks, updated the roadmap to [add testing and validation](https://paper.dropbox.com/doc/Polonius-Roadmap--AdKXqkTdIxkM3zh3xZmuZ4RmAg-hk3a9ynduUN2gk1A0NNTF#:uid=569313235802426695258068&h2=Extending-Polonius-to-cover-th), as we mentioned during last week's meeting.
 
 Useful information:
+
 - various members will be absent at different points in the upcoming weeks. There may not necessarily be a meeting sometimes (TBD), but async updates will be available on Zulip in any case.
 
 Useful future tasks we mentioned:
+
 - with the liveness work about to land, we mentioned some important optimizations rustc has about liveness (in particular, trying to _avoid_ computing it unless it is necessary), and that Polonius (or its inputs) will surely need as well. This topic was discussed at [this point in the meeting thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E05.2E14/near/165653374).
 
 ----
 For the following week:
+
 - [Albin] will tackle the remaining final liveness.
 - [Rémy] will continue on the rustc test suite results (fix the trivial differences, etc) and time permitting, help with the final liveness tasks.
 - [@lokalmatador] will continue their benchmarking endeavour.

--- a/content/docs/working-groups/polonius/minutes/2019.05.28-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.05.28-meeting.md
@@ -2,6 +2,7 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E05.2E28).
 - The [WIP Roadmap](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) Paper.
 
@@ -9,7 +10,7 @@ Relevant links:
 
 This week, we discussed the following topics:
 
-#### 1. Profiling and fact generation
+### 1. Profiling and fact generation
 
 [@lokalmatador] has made some progress on the profiling tasks: WIP branch is [here](https://github.com/rust-lang/rust/compare/master...lokalmatador:polonius_profiling) gathering timing data for parts of NLLs and Polonius using rustc's `-Z self-profile` API.
 
@@ -22,7 +23,7 @@ It was also deemed "nice to have" but not high priority compared to the rest of 
 
 A bug in `measureme`'s `summarize` tool seemed to be blocking progress, but was later found to be a problem in data gathering, and which has since been fixed. Complete discussion available in the dedicated Zulip thread around [this point](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/profiling/near/166400364).
 
-#### 2. Liveness
+### 2. Liveness
 
 [Albin] has been putting the finishing touches on the liveness work, which is ready to review and land. 
 
@@ -34,7 +35,7 @@ Most of the tasks mentioned in a previous meeting, and this [summary github comm
 
 A summary of the liveness work is "it works but does not produce exactly the same `region_live_at` facts as rustc does today" (and this is also one of the last tasks in the list). This is because rustc also takes initialization into account, while the Polonius liveness work does not do so yet. This is indeed the next step in Polonius' roadmap, and a nice segue into the last topic discussed in this meeting.
 
-#### 3. Move/overwrite analysis
+### 3. Move/overwrite analysis
 
 As this is the next item to tackle, [Niko] and [Albin] will schedule a recorded video chat session next week, about how the current borrow checker tracks moves and initialization, and how to move this over to Polonius.
 

--- a/content/docs/working-groups/polonius/minutes/2019.06.04-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.06.04-meeting.md
@@ -2,6 +2,7 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E06.2E04).
 - The [WIP Roadmap](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) Paper.
 
@@ -9,7 +10,7 @@ Relevant links:
 
 This week, we discussed the following topics:
 
-#### 1. Liveness
+### 1. Liveness
 
 To help with reviewing [polonius#105](https://github.com/rust-lang/polonius/pull/105), some last minutes changes were discussed:
 - the older facts recorded in the Polonius dataset (the `inputs` directory) needed regenerating. This creates a huge diff for review, so separating those out to be "rubberstamped" would be interesting.
@@ -18,17 +19,17 @@ To help with reviewing [polonius#105](https://github.com/rust-lang/polonius/pull
 In general, we'll still need to check rustc's testsuite when the liveness work is merged. That ties into the other ongoing work about checking our current `-Z polonius` behaviour in those tests (especially now that [#60171](https://github.com/rust-lang/rust/pull/60171) has been merged). 
 
 
-#### 2. Profiling and performance
+### 2. Profiling and performance
 
 With the previous problems related to `measureme`/`summarize` fixed, [@lokalmatador] has continued work on profiling, and has been gathering early results.
 
-#### 3. Move/initialization analysis
+### 3. Move/initialization analysis
 
 [Niko] and [Albin] have [recorded a call](https://www.youtube.com/watch?v=ilv9V-328HI) discussing how rustc ensures all data used is initialized, and how to integrate these checks in Polonius. 
 
 Note: the screen recording is "paused" for a bit at the beginning (until around minute 14), as notes were broadcast on the Paper website, but [this](https://paper.dropbox.com/doc/Polonius-and-initialization-mNvR4jqITCdsJDUMEhFbv) is the document they discuss and take notes in.
 
-#### 4. Proposal: stop tracking subset relations along the CFG
+### 4. Proposal: stop tracking subset relations along the CFG
 
 [Niko] and [Aaron Weiss] (who works on the [Oxide formal model](https://aaronweiss.us/pubs/draft19-oxide.pdf) of Rust's ownership and borrowing) came up with a proposal to avoid tracking `subset` relations.
 
@@ -39,6 +40,7 @@ There are more details at the beginning of the dedicated Zulip thread — [aroun
 ---
 
 This week, the plan is:
+
 - [@lokalmatador] will continue gathering profiling data.
 - [Niko] will review and land the liveness PR, and release the new polonius version to crates.io.
 - [Albin] will update the [rustc liveness PR](https://github.com/rust-lang/rust/pull/60266) after that, and mark it from "WIP" to "ready to review". They also will do a public presentation about Polonius next week and will prepare for that.

--- a/content/docs/working-groups/polonius/minutes/2019.06.11-meeting.md
+++ b/content/docs/working-groups/polonius/minutes/2019.06.11-meeting.md
@@ -2,6 +2,7 @@
 ---
 
 Relevant links:
+
 - The meeting happened in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/meeting.202019.2E06.2E11).
 - The [WIP Roadmap](https://paper.dropbox.com/doc/Polonius-Roadmap--AY6C806s~AZK~e7wagmys2_wAg-hk3a9ynduUN2gk1A0NNTF) Paper.
 
@@ -9,7 +10,7 @@ Relevant links:
 
 This week, we worked on — and discussed — the following topics:
 
-#### 1. Proposal: stop tracking subset relations along the CFG
+### 1. Proposal: stop tracking subset relations along the CFG
 
 [Niko] wrote up an issue with more details about the proposal: [issue #107](https://github.com/rust-lang/polonius/issues/107). We also discussed it more in the dedicated zulip thread, around [this point](https://rust-lang.zulipchat.com/#narrow/stream/186049-t-compiler.2Fwg-polonius/topic/subset.20relations.20and.20polonius/near/167407904).
 
@@ -21,7 +22,7 @@ Some more exploratory work is planned around these refinements, and also around 
 
 To prepare for the call on this topic, [Rémy] tried implementing a quick [prototype and examples](https://github.com/rust-lang/polonius/compare/master...lqd:variant_prototype). As of this writing, it seems to work on the simpler example datasets from the Polonius repository, but not on the more realisic use-case (`clap`) so more bugfixing will be needed. [Rémy] also wrote a [short report](https://hackmd.io/EqECXcd7TIGj97lVNc4dhw?view) about those quick explorations.
 
-#### 2. Call about `subset` relations, the proposal, Oxide
+### 2. Call about `subset` relations, the proposal, Oxide
 
 We had a [recorded video call](https://www.youtube.com/watch?v=mAUGvNgZYtw) about the specifics of the `subset` relation, its role and why it was propagated along the CFG. We then talked in more detail about the proposal refinement(s), and finished with a comparison between the Polonius model and the Oxide model.
 
@@ -29,11 +30,11 @@ To follow along the video: the paper document we used to record notes and exampl
 
 Huge thanks to everyone involved, it was super interesting and fun!
 
-#### 3. Profiling and performance
+### 3. Profiling and performance
 
 [@lokalmatador] has been successfully gathering early results :tada: (for example, [this profiling data](https://rust-lang.zulipchat.com/user_uploads/4715/C7fHB1wgXXWWxNrd1N8sbRy1/measurements.zip) comes from some of examples in the Polonius repository). The next steps will then be to collect some data from the official rustc benchmarking suite.
 
-#### 4. Rustc test failures under Polonius
+### 4. Rustc test failures under Polonius
 
 [Rémy] has (slowly) continued work on analyzing the `ui` test suite failures under Polonius. Now that [Matthew]'s [PR #60171](https://github.com/rust-lang/rust/pull/60171) has landed: the WIP branch was rebased into a more stable state.
 
@@ -41,7 +42,7 @@ New failures were unfortunately found, but most of the simpler differences were 
 
 There are still a couple of simple cases left (differences in diagnostics only, for example) before looking at the remaining more complicated cases, but those seem to be actual "regressions" somewhere (probably divergences between the Polonius facts, NLL constraints, and assumptions about MIR).
 
-#### 5. Liveness
+### 5. Liveness
 
 :tada: [polonius#105](https://github.com/rust-lang/polonius/pull/105) has landed :tada:
 


### PR DESCRIPTION
This:
- adds a couple of Polonius meetings which were missed in the website transition
- adapt the markdown in the meeting notes from what Github allowed to what Hugo expects (e.g. lists, some h3/h4 section titles)