### PR TITLE
Add parser directories to experts map

### DIFF
--- a/content/docs/experts/map.toml
+++ b/content/docs/experts/map.toml
@@ -73,7 +73,11 @@ familiar = []
 
 [[areas]]
 name = "Parser"
-directories = []
+directories = [
+    "src/libsyntax/ast.rs",
+    "src/libsyntax/parse",
+    "src/libsyntax/util",
+]
 crates = []
 experts = ["petrochenkov", "estebank"]
 familiar = ["Centril"]


### PR DESCRIPTION
This is the directories structure suggested by @Centril 