### PR TITLE
Link to Github view of expert map

### DIFF
--- a/content/experts/_index.md
+++ b/content/experts/_index.md
@@ -6,7 +6,9 @@ type: docs
 
 This document contains the different areas of the compiler and the people that
 are experts in each area. The document is formatted in toml to be machine readable.
-You can find it [here](map.toml).
+You can find it [here][expert-map].
 
 This map is intended to help you figure out who you should ask for help if you
 have questions about how some area works.
+
+[expert-map]: https://github.com/rust-lang/compiler-team/blob/master/content/experts/map.toml


### PR DESCRIPTION
Right now, clicking the link to the expert map downloads it to your machine. This isn't very convenient for viewing (or editing), so this makes it link to the file on Github.

Unfortunately this means we'll have to update the path anytime we move things around. I'm not sure how to get around that.