### PR TITLE
Add type layout area to experts map

### DIFF
--- a/content/experts/map.toml
+++ b/content/experts/map.toml
@@ -116,7 +116,16 @@ directories = [
 ]
 crates = []
 experts = ["eddyb", "oli-obk", "nagisa"]
-familiar = ["wesleywiser", "spastorino"]
+familiar = ["wesleywiser", "spastorino", "tmandry"]
+
+[[areas]]
+name = "Type layout"
+directories = [
+    "src/librustc/ty/layout.rs",
+]
+crates = []
+experts = ["eddyb", "oli-obk", "nagisa"]
+familiar = ["tmandry"]
 
 [[areas]]
 name = "match/exhaustiveness"
@@ -174,7 +183,7 @@ name = "dataflow"
 directories = []
 crates = []
 experts = ["pnkfelix", "nikomatsakis"]
-familiar = []
+familiar = ["tmandry"]
 
 [[areas]]
 name = "AST-borrow checker"


### PR DESCRIPTION
I asked someone who could review a type layout change, and they mentioned the listed names.