### PR TITLE
Add a "Compile-time Function Evaluation" working group

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -76,6 +76,7 @@ Name                                                      | Status       | Short
 [Polonius](working-groups/polonius/)                      | Active       | Exploring the integration of the "NLL 2.0"-like ["Polonius analysis"][Polonius] into rustc         | [#t-compiler/wg-polonius][polonius_stream]
 [Learning](working-groups/learning/)                      | Active       | Make the compiler easier to learn by ensuring that rustc-guide and api docs are "complete"         | [#t-compiler/wg-learning][learning_stream]
 [Diagnostics](working-groups/diagnostics/)                | Active       | Use crates.io crates for diagnostics rendering and make emitting diagnostics nicer.                | [#t-compiler/wg-diagnostics][diagnostics-stream]
+[Compile-time Function Evaluation][ctfe]                  | Active       | Reduce the number of restrictions on code in a const context.                                      | [#t-compiler/const-eval][const-eval-stream]
 
 [nikomatsakis]: https://github.com/nikomatsakis
 [cramertj]: https://github.com/cramertj
@@ -108,6 +109,8 @@ Name                                                      | Status       | Short
 [learning_stream]: https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-learning
 [Polonius]: https://github.com/rust-lang/polonius
 [diagnostics-stream]: https://rust-lang.zulipchat.com/#narrow/stream/147480-t-compiler.2Fwg-diagnostics
+[ctfe]: working-groups/const-eval/
+[const-eval-stream]: https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval
 
 ## Expert Map
 

--- a/content/experts/map.toml
+++ b/content/experts/map.toml
@@ -55,10 +55,13 @@ experts = ["nikomatsakis", "eddyb"]
 familiar = ["Centril"]
 
 [[areas]]
-name = "miri"
+name = "const-eval"
 directories = [
     "src/librustc/mir/interpret",
     "src/librustc_mir/interpret",
+    "src/librustc_mir/transform/check_consts",
+    "src/librustc_mir/transform/qualify_consts.rs",
+    "src/librustc_mir/transform/promote_consts.rs",
 ]
 crates = []
 experts = ["oli-obk", "RalfJung", "eddyb"]

--- a/content/experts/map.toml
+++ b/content/experts/map.toml
@@ -65,7 +65,7 @@ directories = [
 ]
 crates = []
 experts = ["oli-obk", "RalfJung", "eddyb"]
-familiar = []
+familiar = ["ecstatic-morse"]
 
 [[areas]]
 name = "Diagnostics"

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -38,3 +38,4 @@ headless: true
   - [rls-2.0]({{< relref "/working-groups/rls-2.0" >}})
   - [Self Profile]({{< relref "/working-groups/self-profile" >}})
   - [Traits]({{< relref "/working-groups/traits" >}})
+  - [const-eval]({{< relref "/working-groups/const-eval" >}})

--- a/content/minutes/design-meeting/2019-11-09-unified-dataflow-framework.md
+++ b/content/minutes/design-meeting/2019-11-09-unified-dataflow-framework.md
@@ -1,0 +1,67 @@
+---
+title: Unify Dataflow Frameworks (#202)
+type: docs
+---
+
+# Design Meeting 2019-11-08
+
+[Zulip Stream](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/design.20meeting.202019-11-08)
+
+# Agenda
+
+- Design doc: https://hackmd.io/@39Qr_z9cQhasi25sGjmFnA/Skvd9rztS
+
+
+- Explain the current state of things
+    - We currently have two wholly separate APIs for dataflow, one for bit-vector problems and one that allows arbitrary transfer functions but still restricts the lattice to a powerset of indices.
+    - I want to merge these two to make code more DRY.
+    - The prototype implementation is described pretty thoroughly in the design doc, but maybe go over it a bit?
+
+- Discuss the prototype implementation in general
+    - The prototype is not very ambitious. It mostly preserves the existing `BitDenotation` API  but extends it to arbitrary transfer functions.
+    - Do we want to maintain the status quo? Have two separate implementations forever? Once arbitrary lattices are supported, maybe they won’t fit as nicely into the same API.
+        - OTOH, adding backwards analysis would have to be done in two places.
+    - There have been more ambitious changes attempted. Perhaps we want to do one of these instead? Or at least incorporate some of their ideas into a framework that hews closer to the existing one.
+        - @nagisa worked on a new dataflow framework that works for arbitrary lattices and transfer functions back in 2016.
+        - @eddyb was looking into a simultaneous forwards/backwards dataflow-like thing for NRVO (link?)
+
+- Discuss the prototype in detail (If we decide we still want to go this way)
+    - How do we feel about the `{before_,}*_effect` naming convention? It takes a bit of getting used to, and doesn’t extend nicely to backwards dataflow.
+        - OTOH, having a canonical `statement_effect` which most implementers want to use and a secondary, prefixed effect which is only rarely used is good.
+    - Should we be passing a `mir::Statement` to the `statement` effect methods? What about `mir::Body` to `bits_per_block`?
+    - Should we use specialization to implement this?’
+    - Should the `Analysis` methods take `&self` or `&mut self`?
+        - Some may depend on the results of an earlier dataflow analysis and want to hold a cursor.
+        - However, transfer functions should be pure for a given MIR, so maybe forcing those analyses to use interior mutability is appropriate.
+    - Are we okay with a `ResultsCursor` becoming the common way to inspect results?
+    - How do we implement a zipped `ResultsVisitor`?
+
+- Discuss what extensions to the framework we want to prioritize
+    - Backwards dataflow (currently implemented by hand to do check liveness in generators)
+    - Arbitrary lattices (would make MIR const-propagation more powerful)
+        - OTOH, the current linear const-propagation gets most of the benefits without the overhead of dataflow.
+    - Optimizations:
+        - Don’t cache block transfer functions on acyclic MIR (reduces memory usage)
+        - Extended basic blocks? @Mark-Simulacrum
+
+# Minutes
+  - Background on the need for arbitrary transfer functions for dataflow and const qualification.
+  - Alternatives to the prototype:
+    - Perhaps we could express these more advanced dataflow problems in datalog/datafrog?
+      - nikomatsakis wanted to test more in the polonius repo before committing to this upstream.
+  - The need for `apply_call_return_effect`:
+    - We need some version of this, but not necessarily the current version.
+  - API details
+    - Skipped most of these, since they can be figured out later.
+    - mir_borrowck might benefit from `ResultsCursor` now that it is implemented.
+  - Optimizations/extensions
+    - Some interest in not caching block transfer functions for acyclic MIR.
+      - This is pretty easy, I will prioritize this.
+    - Probably not going to do EBBs anytime soon.
+
+# Conclusions
+  - There was consensus on pursuing some version of the prototype instead of something more radical.
+    - Details will be hashed out in a PR to come.
+    - @ecstaticmorse will pursue this.
+
+

--- a/content/working-groups/const-eval/FAQ.md
+++ b/content/working-groups/const-eval/FAQ.md
@@ -1,0 +1,8 @@
+---
+title: FAQs
+type: docs
+---
+# Frequently Asked Questions (FAQ)
+
+If you have a question, feel free to file an issue or ask in the working group's Zulip stream.
+

--- a/content/working-groups/const-eval/NOTES.md
+++ b/content/working-groups/const-eval/NOTES.md
@@ -1,0 +1,6 @@
+---
+title: Notes
+type: docs
+---
+# Compile-time Function Evaluation (const-eval) Meeting Notes
+This document will contain meeting notes from the const-eval working group.

--- a/content/working-groups/const-eval/_index.md
+++ b/content/working-groups/const-eval/_index.md
@@ -1,0 +1,62 @@
+---
+title: Compile-time Function Evaluation (const-eval) Working Group
+type: docs
+---
+# Compile-time Function Evaluation (const-eval) Working Group
+![working group status: active][status]
+
+This working group aims to relax the restrictions on what code can be evaluated at compile-time
+without introducing unsoundness or increasing compile times.
+
+This is a joint effort with the [lang team][].
+
+- **Leads:** [@oli-obk][oli-obk] and [@RalfJung][]
+- **Meeting Notes:** [All]({{< relref "/working-groups/const-eval/NOTES" >}})
+- **FAQ:** [FAQ]({{< relref "/working-groups/const-eval/FAQ" >}})
+- **Repo:** [const-eval][]
+
+[status]: https://img.shields.io/badge/status-active-brightgreen.svg?style=for-the-badge
+[oli-obk]: https://github.com/oli-obk
+[@RalfJung]: https://github.com/RalfJung
+[lang team]: https://github.com/rust-lang/lang-team
+[const-eval]: https://github.com/rust-rfcs/const-eval
+
+## What is the goal of this working group?
+
+This ultimate goal of this working group is to resolve the issues listed in [#57563][]. In the near
+term, focus will be on enabling complex control flow in const bodies:
+
+- [#49146][]: "Allow `if` and `match` in constants"
+- [#52000][]: "Allow `loop` in constant evaluation"
+
+Simultaneously, this working group will work to specify which operations are legal in a const
+context. This includes determining what code is eligible for [promotion][].
+
+[#49146]: https://github.com/rust-lang/rust/issues/49146
+[#52000]: https://github.com/rust-lang/rust/issues/52000
+[#57563]: https://github.com/rust-lang/rust/issues/57563
+[promotion]: https://github.com/rust-rfcs/const-eval/blob/master/promotion.md
+
+# How can I get involved?
+If you are interested in getting involved in this working group, you should introduce yourself
+in the Zulip stream. You can be added to the GitHub and Zulip
+group for the working group if you are interested in being pinged when there are available tasks.
+
+- **Desired experience level:** Any
+- **Relevant repositories:** [`rust-lang/rust`][repo] and [`rust-lang/miri`][miri]
+- **Zulip stream:** [`#t-compiler/const-eval`][zulip] on Zulip
+
+[repo]: https://github.com/rust-lang/rust
+[miri]: https://github.com/rust-lang/miri
+[zulip]: https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval
+
+## What if I don't have much time?
+If you don't have time to contribute code, consider tagging issues in the `rust` repository so
+the team can find them.
+
+## Are there any resources so I can get up to speed?
+See the [`const-eval`][const-eval] repository for the current rules around const-safety and
+promotion.
+
+## Do I need to attend any meetings?
+We don't have any meetings yet.


### PR DESCRIPTION
This would promote the current [`t-compiler/const-eval`](https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval) zulip channel to a proper working group. I mostly just filled in the sections from the template. The leads have not yet been decided on (although I have suggested @oli-obk and @RalfJung). 

This is marked as a draft as this is still being discussed on [zulip](https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/wg-const-eval).