### PR TITLE
Add weekly compiler team triage meeting notes for 2019-11-21

### DIFF
--- a/content/minutes/triage-meeting/2019-11-21.md
+++ b/content/minutes/triage-meeting/2019-11-21.md
@@ -1,0 +1,56 @@
+---
+title: 2019.11.21
+type: docs
+---
+
+# 2019-11-21
+
+## Announcements
+
+- perf.rust-lang.org is switching to a new benchmarking server so all of the old data is being removed to avoid skewed comparisons.
+
+- The constant propagation MIR optimization pass is [on by default][const_prop_on] which provides some improvements to debug and release compile times.
+
+- [@pnkfelix] wrote a blog post about [minimizing rustc bugs][minimizing_rustc_bugs].
+
+## Backport nominations
+
+- "Do not ICE on trait aliases with missing obligations” [#66392]
+  - Accepted for stable backport
+
+- "Fix ICE when trying to suggest Type<> instead of Type()" [#66390]
+  - Accepted for stable backport
+
+- “Do not ICE on recovery from unmet associated type bound obligation” [#66388]
+  - Accepted for stable backport
+
+- “find_deprecation: deprecation attr may be ill-formed meta.” [#66381]
+  - Accepted for stable backport
+
+- “parser: don’t use unreachable!() in fn unexpected.” [#66361]
+  - Accepted for stable backport
+
+## Working group sync
+
+### [wg-traits]
+
+- [@Alexander Regueiro] is very close to landing support for trait object upcasts.
+
+- Chalk is being refactored with the goal of revamping how the rustc integration works so they share a lot more code.
+
+- [@Jack Huey] has been fixing the handling of coinduction logic and generally refactoring the chalk engine.
+
+- Work has been proceeding to fix a soundess hole related to `dyn Trait` ([#57893])
+
+[@Alexander Regueiro]: https://github.com/alexreg
+[@Jack Huey]: https://github.com/jackh726
+[@pnkfelix]: https://github.com/pnkfelix
+[#57893]: https://github.com/rust-lang/rust/issues/57893
+[#66361]: https://github.com/rust-lang/rust/pull/66361
+[#66381]: https://github.com/rust-lang/rust/pull/66381
+[#66388]: https://github.com/rust-lang/rust/pull/66388
+[#66390]: https://github.com/rust-lang/rust/pull/66390
+[#66392]: https://github.com/rust-lang/rust/pull/66392
+[const_prop_on]: https://github.com/rust-lang/rust/pull/66074
+[minimizing_rustc_bugs]: http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns
+[wg-traits]: https://rust-lang.github.io/compiler-team/working-groups/traits


### PR DESCRIPTION
Sorry for the lateness on this; it's been a busy few weeks and I'm working on getting caught up.