### PR TITLE
make link to rendered website easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Compiler Team
 This repository contains a static site that details the procedures, policies, working groups,
 planning documents and minutes.
+
 You are probably looking [for the rendered website](https://rust-lang.github.io/compiler-team/) instead.
 
 ### Building the website

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Compiler Team
 This repository contains a static site that details the procedures, policies, working groups,
 planning documents and minutes.
+You are probably looking [for the rendered website](https://rust-lang.github.io/compiler-team/) instead.
 
-## Getting Started
+### Building the website
 You'll need to install [Hugo](https://github.com/gohugoio/hugo#choose-how-to-install) to build the
 website locally, you can then run the following commands to set the website up:
 


### PR DESCRIPTION
I came to this repo from https://www.rust-lang.org/governance/teams/compiler. I read the README five times scanning for the link to the rendered website until I realized it is up *above* the directory listing. I think this would have helped. :)