### PR TITLE
Add rustdoc to 'experts' list

### DIFF
--- a/content/experts/map.toml
+++ b/content/experts/map.toml
@@ -266,5 +266,5 @@ directories = [
   "src/tools/rustdoc",
 ]
 crates = []
-experts = ["GuillaumeGomez"]
-familiar = ["jyn514", "Manishearth", "kinnison"]
+experts = ["GuillaumeGomez", "ollie27", "Manishearth"]
+familiar = ["jyn514", "kinnison"]

--- a/content/experts/map.toml
+++ b/content/experts/map.toml
@@ -259,3 +259,12 @@ crates = [
 experts = ["michaelwoerister", "wesleywiser"]
 familiar = []
 
+[[areas]]
+name = "Rustdoc"
+directories = [
+  "src/librustdoc",
+  "src/tools/rustdoc",
+]
+crates = []
+experts = ["GuillaumeGomez"]
+familiar = ["jyn514", "Manishearth", "kinnison"]


### PR DESCRIPTION
I noticed this link from https://github.com/rust-lang/rustc-dev-guide/pull/731/files#diff-a75a5daa4f7310d9e1bebc2021f72c16R26 and saw that rustdoc wasn't here at all!

r? @GuillaumeGomez 

Let me know if I missed anyone, I'm not sure exactly how the rustdoc team is setup.