### PR TITLE
Eschew links to root page of forge.rlo

### DIFF
--- a/content/about/steering-meeting.md
+++ b/content/about/steering-meeting.md
@@ -10,7 +10,7 @@ the meeting are selected at periodic planning meetings. See the
 [steering meeting procedure][proc] for more details. See [#58850] for
 more information.
 
-[proc]: ../../procedures/steering-meeting
+[proc]: https://forge.rust-lang.org/compiler/steering-meeting.html
 
 See the [compiler team calendar](../../#meeting-calendar) for
 the topics of the next scheduled meetings. There is also a [dedicated

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -16,7 +16,7 @@ headless: true
 
 - **Procedures**
 
-  - Compiler team procedures are documented on the [Rust forge](https://forge.rust-lang.org/)
+  - Compiler team procedures are documented on the [Rust forge](https://forge.rust-lang.org/compiler/index.html)
   - [Crates]({{< relref "/procedures/crates" >}})
   - [Call for participation]({{< relref "/procedures/call-for-participation" >}})
   - [Form new working group]({{< relref "/procedures/form-new-working-group" >}})

--- a/content/procedures/steering-meeting.md
+++ b/content/procedures/steering-meeting.md
@@ -4,4 +4,4 @@ type: docs
 ---
 # Steering meeting
 
-This content has moved to the [Rust forge](https://forge.rust-lang.org/).
+This content has moved to the [Rust forge](https://forge.rust-lang.org/compiler/steering-meeting.html).


### PR DESCRIPTION
Fix #334.

The steering-meeting changes are, I think, obviously better.

The only change I"m not sure about is the change so that "Compiler team
procedures" links to the specific compiler page on forge. The main problem I
have with that is that page itself does not actually document any procedures,
nor even *link* to subpages with such documentation.

 * However, I justify this change by saying that I think in an ideal world, each
   main page would have links to each of its subpages, because often the titles
   alone in the Table-of-Contents on the left-hand side are not really enough
   for a reader who arrives on the forge without any experience or context for
   what they are looking for.