### PR TITLE
hair -> thir in experts/map.toml

### DIFF
--- a/content/experts/map.toml
+++ b/content/experts/map.toml
@@ -129,7 +129,7 @@ familiar = ["tmandry"]
 
 [[areas]]
 name = "match/exhaustiveness"
-directories = ["src/librustc_mir_build/hair/pattern"]
+directories = ["src/librustc_mir_build/thir/pattern"]
 crates = []
 experts = ["arielb1", "varkor", "oli-obk", "nadrieril"]
 familiar = []


### PR DESCRIPTION
I was reading through https://rustc-dev-guide.rust-lang.org/mir/construction.html?highlight=hair#thir-and-mir-construction and https://rust-lang.github.io/compiler-team/experts/ and noticed this was outdated