### PR TITLE
Fix compilation with latest hugo

### DIFF
--- a/content/working-groups/parallel-rustc/_index.md
+++ b/content/working-groups/parallel-rustc/_index.md
@@ -8,7 +8,7 @@ type: docs
 - **Leads:** [@Zoxc][Zoxc], [@aturon][aturon]
 - **Meeting Notes:** [All]({{< relref "/working-groups/parallel-rustc/NOTES" >}})
 - **Minutes:**
-    - [2019.05.10]({{< relref "/working-groups/parallel-rustc/minutes/2019.05.10" >}})
+    - [2019.05.10]({{< relref "/working-groups/parallel-rustc/minutes/2019.05.10.md" >}})
 - **FAQ:** [FAQ]({{< relref "/working-groups/parallel-rustc/FAQ" >}})
 
 [Zoxc]: https://github.com/Zoxc

--- a/content/working-groups/polonius/_index.md
+++ b/content/working-groups/polonius/_index.md
@@ -22,14 +22,14 @@ crate to define the full borrow check analysis.
 
 - **Leads:** [@nikomatsakis][nikomatsakis], [@lqd][lqd]
 - **Meeting Notes:**
-    - [2019.03.07 Meeting]({{< relref "/working-groups/polonius/minutes/2019.03.07-meeting" >}})
-    - [2019.04.23 Meeting]({{< relref "/working-groups/polonius/minutes/2019.04.23-meeting" >}})
-    - [2019.04.30 Meeting]({{< relref "/working-groups/polonius/minutes/2019.04.30-meeting" >}})
-    - [2019.05.07 Meeting]({{< relref "/working-groups/polonius/minutes/2019.05.07-meeting" >}})
-    - [2019.05.14 Meeting]({{< relref "/working-groups/polonius/minutes/2019.05.14-meeting" >}})
-    - [2019.05.28 Meeting]({{< relref "/working-groups/polonius/minutes/2019.05.28-meeting" >}})
-    - [2019.06.04 Meeting]({{< relref "/working-groups/polonius/minutes/2019.06.04-meeting" >}})
-    - [2019.06.11 Meeting]({{< relref "/working-groups/polonius/minutes/2019.06.11-meeting" >}})
+    - [2019.03.07 Meeting]({{< relref "/working-groups/polonius/minutes/2019.03.07-meeting.md" >}})
+    - [2019.04.23 Meeting]({{< relref "/working-groups/polonius/minutes/2019.04.23-meeting.md" >}})
+    - [2019.04.30 Meeting]({{< relref "/working-groups/polonius/minutes/2019.04.30-meeting.md" >}})
+    - [2019.05.07 Meeting]({{< relref "/working-groups/polonius/minutes/2019.05.07-meeting.md" >}})
+    - [2019.05.14 Meeting]({{< relref "/working-groups/polonius/minutes/2019.05.14-meeting.md" >}})
+    - [2019.05.28 Meeting]({{< relref "/working-groups/polonius/minutes/2019.05.28-meeting.md" >}})
+    - [2019.06.04 Meeting]({{< relref "/working-groups/polonius/minutes/2019.06.04-meeting.md" >}})
+    - [2019.06.11 Meeting]({{< relref "/working-groups/polonius/minutes/2019.06.11-meeting.md" >}})
 - **Screencasts**: [YouTube Playlist](https://www.youtube.com/playlist?list=PL85XCvVPmGQitE2CBzf-gERSqeXo59NQG)
 - **FAQ:** [FAQ]({{< relref "/working-groups/polonius/FAQ" >}})
 

--- a/content/working-groups/rfc-2229/_index.md
+++ b/content/working-groups/rfc-2229/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 - **Leads:** [@blitzerr][Blitzerr], [@nikomatsakis][Niko]
 - **Meeting Notes:** 
-    - [2019.03.05 Roadmap Plan]({{< relref "/working-groups/rfc-2229/minutes/2019.03.05-roadmap-plan" >}})
+    - [2019.03.05 Roadmap Plan]({{< relref "/working-groups/rfc-2229/minutes/2019.03.05-roadmap-plan.md" >}})
 - **FAQ:** [FAQ]({{< relref "/working-groups/rfc-2229/FAQ" >}})
 
 ## Status

--- a/content/working-groups/rustc-dev-guide/_index.md
+++ b/content/working-groups/rustc-dev-guide/_index.md
@@ -9,16 +9,16 @@ This working group aims to make the compiler easier to learn by ensuring that ru
 
 - **Leads:**  [@spastorino][spastorino] and [@mark-i-m][markim]
 - **Meeting Notes:** 
-    - [2019.05.14 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.05.14-meeting" >}})
-    - [2019.05.28 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.05.28-meeting" >}})
-    - [2019.06.11 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.06.11-meeting" >}})
-    - [2019.06.25 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.06.25-meeting" >}})
-    - [2019.07.09 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.07.09-meeting" >}})
-    - [2019.07.23 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.07.23-meeting" >}})
-    - [2019.08.06 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.08.06-meeting" >}})
-    - [2019.08.20 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.08.20-meeting" >}})
-    - [2019.09.17 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.09.17-meeting" >}})
-    - [2019.10.01 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.10.01-meeting" >}})
+    - [2019.05.14 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.05.14-meeting.md" >}})
+    - [2019.05.28 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.05.28-meeting.md" >}})
+    - [2019.06.11 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.06.11-meeting.md" >}})
+    - [2019.06.25 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.06.25-meeting.md" >}})
+    - [2019.07.09 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.07.09-meeting.md" >}})
+    - [2019.07.23 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.07.23-meeting.md" >}})
+    - [2019.08.06 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.08.06-meeting.md" >}})
+    - [2019.08.20 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.08.20-meeting.md" >}})
+    - [2019.09.17 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.09.17-meeting.md" >}})
+    - [2019.10.01 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.10.01-meeting.md" >}})
 - **Agenda:** [Agenda]({{< relref "/working-groups/rustc-dev-guide/minutes/agenda" >}})
 - **FAQ:** [FAQ]({{< relref "/working-groups/rustc-dev-guide/FAQ" >}})
 


### PR DESCRIPTION
Starting v0.65, hugo server emits errors for page not found. This fixes the issue, tested with latest version `Hugo Static Site Generator v0.75.1/extended darwin/amd64`

My understanding is this is because of `publishResources` that was introduced in https://github.com/gohugoio/hugo/releases/tag/v0.65.0. I wasn't able to make it work using the config flags.

My approach is documented as valid way of using `relref` here: https://gohugo.io/content-management/cross-references/