### PR TITLE
Remove WG-prioritization checkin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ planning documents and minutes.
 You are probably looking [for the rendered website](https://rust-lang.github.io/compiler-team/) instead.
 
 ### Building the website
-You'll need to install [Hugo](https://github.com/gohugoio/hugo#choose-how-to-install) to build the
-website locally, you can then run the following commands to set the website up:
+You'll need to install [Hugo](https://github.com/gohugoio/hugo#choose-how-to-install) (ensure to get Hugo extended version for SCSS support) to build the website locally, you can then run the following commands to set the website up:
 
 ```
 git clone git@github.com:rust-lang/compiler-team.git

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -5,7 +5,7 @@ headless: true
   - [Code of Conduct]({{< relref "/about/CODE_OF_CONDUCT" >}})
   - [Chat Platform]({{< relref "/about/chat-platform" >}})
   - [Steering Meeting]({{< relref "/about/steering-meeting" >}})
-  - [Triage Meeting] ({{< relref "/about/triage-meeting" >}})
+  - [Triage Meeting]({{< relref "/about/triage-meeting" >}})
 - **Minutes**
 
   - [Design Meetings]({{< relref "/minutes/design-meeting" >}})

--- a/layouts/shortcodes/checkin-schedule.html
+++ b/layouts/shortcodes/checkin-schedule.html
@@ -35,7 +35,6 @@
         "MIR Optimizations",
         "Polonius",
         "Polymorphization",
-        "Prioritization",
         "RFC 2229",
         "RLS 2.0",
         "Self-Profile",


### PR DESCRIPTION
Discussed this with @spastorino on Zulip.

The `WG-prioritization` does not usually report during the compiler meeting (only when it is needed), so we can remove it from the regular scheduling.

**Notice**: due to the way the checkins are rotated, to avoid duplicated checkins from other WG, this PR should not be merged before **Friday October, 9th 2020**

Unrelated small changes:
- add a notice in the README to use the extended Hugo version for local testing
- fix a minor typo in the markdown