### PR TITLE
CC @rust-lang/compiler and @rust-lang/compiler-contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/major_change.md
+++ b/.github/ISSUE_TEMPLATE/major_change.md
@@ -38,3 +38,4 @@ You can read [more about Major Change Proposals on forge][MCP].
 [MCP]: https://forge.rust-lang.org/compiler/mcp.html
 [forge]: https://forge.rust-lang.org/
 
+cc @rust-lang/compiler, @rust-lang/compiler-contributors


### PR DESCRIPTION
Mention `@rust-lang/compiler` and `@rust-lang/compiler-contributors` to alert people on GitHub (as well as Zulip) of new MCPs.