### PR TITLE
Ping compiler team and contributors when creating an MCP

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,7 @@
 [major-change]
 second_label = "final-comment-period"
 meeting_label = "to-announce"
+open_extra_text = "cc @rust-lang/compiler @rust-lang/compiler-contributors"
 # can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
 zulip_stream = 233931
 zulip_ping = "T-compiler"


### PR DESCRIPTION
This makes rustbot send the ping instead of the author of the MCP, making it possible for non-org-members to successfully ping the teams.

Would supersede #369.
Blocked on rust-lang/triagebot#914.