### PR TITLE
Fix date conversion in meeting checkin assignment

### DIFF
--- a/layouts/shortcodes/checkin-schedule.html
+++ b/layouts/shortcodes/checkin-schedule.html
@@ -44,7 +44,7 @@
 
     function getDateFromWeek(week, year) {
         var day = (2 + (week - 1) * 7);
-        var d = new Date(year, 0, day, 5);
+        var d = new Date(Date.UTC(year, 0, day));
         console.debug("week: ", week, " year: ", year, " day: ", day, ": date: ", d);
         return d;
     }

--- a/layouts/shortcodes/checkin-schedule.html
+++ b/layouts/shortcodes/checkin-schedule.html
@@ -44,15 +44,11 @@
 
     function getDateFromWeek(week, year) {
         var day = (2 + (week - 1) * 7);
-        var d = new Date(Date.UTC(year, 0, day));
-        console.debug("week: ", week, " year: ", year, " day: ", day, ": date: ", d);
-        return d;
+        return new Date(Date.UTC(year, 0, day));
     }
 
     function getDateString(date) {
-        var d = date.toISOString().substring(0, 10);
-        console.debug("getDateString for ", date, " is ", d);
-        return d;
+        return date.toISOString().substring(0, 10);
     }
 
     function updateElementForWeek(week, element, name) {

--- a/layouts/shortcodes/checkin-schedule.html
+++ b/layouts/shortcodes/checkin-schedule.html
@@ -44,11 +44,15 @@
 
     function getDateFromWeek(week, year) {
         var day = (2 + (week - 1) * 7);
-        return new Date(year, 0, day);
+        var d = new Date(year, 0, day, 5);
+        console.debug("week: ", week, " year: ", year, " day: ", day, ": date: ", d);
+        return d;
     }
 
     function getDateString(date) {
-        return date.toISOString().substring(0, 10);
+        var d = date.toISOString().substring(0, 10);
+        console.debug("getDateString for ", date, " is ", d);
+        return d;
     }
 
     function updateElementForWeek(week, element, name) {


### PR DESCRIPTION
@spastorino I've investigated a bit this, this is a tentative patch to rectify how the date is calculated.

I _think_ the issue is when we try to convert to a string a Date such as `Thu Oct 22 2020 00:00:00 GMT+0200` instead of `2020-10-22`, you get `2020-10-21` which *could* be the reason for the off-by-one we experience. 

By adding five hours, we probably compensate for any time zone weirdness and thus converting `Thu Oct 22 2020 05:00:00 GMT+0200` returns `2020-10-22` which in the end is what we want (we don't care about timezones o DST in this calculation).

The visual result is this (at the time of writing):
```
Previous Week: 2020-10-15 - 2020-10-22 Rustc Dev Guide and LLVM
This Week: 2020-10-22 - 2020-10-29 Meta and MIR Optimizations
Next Week: 2020-10-29 - 2020-11-05 Polonius and Polymorphization
```
+1 day compared to what I see on the website:
```
Previous Week: 2020-10-14 - 2020-10-21 Rustc Dev Guide and LLVM
This Week: 2020-10-21 - 2020-10-28 Meta and MIR Optimizations
Next Week: 2020-10-28 - 2020-11-04 Polonius and Polymorphization
```

I'll follow the next two days (Wed 27th and Thu 28th) is the our "custom week" starts on the correct day (i.e. Thursday). If yes, I think we can merge (after removing the debug).

Please feel free to have a look and give me feedback, thanks!

@davidtwco also an opinion from you is more than welcome if you have a chance, as I've touched your code without too much context :-)