### PR TITLE
link WG teams to rust-lang/team repo

### DIFF
--- a/content/working-groups/async-await/_index.md
+++ b/content/working-groups/async-await/_index.md
@@ -8,7 +8,7 @@ type: docs
 This working group is focused around implementation/design of the "foundations" for Async I/O.
 This includes the `async-await` language feature but also the core `Future` trait and adapters.
 
-- **Leads:** [@tmandry][tmandry] and [@nikomatsakis][nikomatsakis].
+- **Team:** [wg-async-foundations on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-async-foundations.toml).
 - **Zulip stream:** [#wg-async-foundations][zulip] on Zulip
 
 **See the [wg-async-foundations repo][repo] for more information and how to get involved.**

--- a/content/working-groups/diagnostics/_index.md
+++ b/content/working-groups/diagnostics/_index.md
@@ -8,7 +8,7 @@ type: docs
 This working group aims to make rustc better at telling the user
 why the compiler isn’t smart enough to understand their code yet.
 
-- **Leads:** [@oli-obk][oli-obk] [@estebank][estebank]
+- **Team:** [wg-diagnostics on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-diagnostics.toml)
 - **Meeting Notes:** [All]({{< relref "/working-groups/diagnostics/NOTES" >}})
 - **Meeting Driver Plan:** [On Hackmd](https://hackmd.io/T9yQwLQ0SIOguR1auo3SHQ)
 - **FAQ:** [All]({{< relref "/working-groups/diagnostics/FAQ" >}})

--- a/content/working-groups/llvm/_index.md
+++ b/content/working-groups/llvm/_index.md
@@ -11,7 +11,7 @@ type: docs
 This working group encompasses work in LLVM upstream fixing the issues and implementing features
 that matter to Rust:
 
-- **Leads:** Preliminarily [@nagisa][nagisa]
+- **Team:** [wg-llvm on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-llvm.toml)
 - **Meeting Notes:** [All]({{< relref "/working-groups/llvm/NOTES" >}})
 - **FAQ:**[All]({{< relref "/working-groups/llvm/FAQ" >}})
 

--- a/content/working-groups/meta/_index.md
+++ b/content/working-groups/meta/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 This working group is dedicated to fleshing out the details of how the compiler team will organize itself.
 
-- **Leads:** [@nikomatsakis][nikomatsakis], [@davidtwco][davidtwco] and [@spastorino][spastorino]
+- **Team:** [wg-meta on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-meta.toml)
 - **[Planning document][planning]**
 - **Meeting Notes:**[All]({{< relref "/working-groups/meta/NOTES" >}})
 - **FAQ:** [All]({{< relref "/working-groups/meta/FAQ" >}})

--- a/content/working-groups/mir-opt/_index.md
+++ b/content/working-groups/mir-opt/_index.md
@@ -8,7 +8,7 @@ type: docs
 This working group aims to implement MIR optimizations and do the groundwork necessary to enable
 writing MIR optimizations.
 
-- **Leads:** [@oli-obk][oli-obk]
+- **Team:** [wg-mir-opt on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-mir-opt.toml)
 - **Meeting Notes:** [All]({{< relref "/working-groups/mir-opt/NOTES" >}})
 - **FAQ:** [FAQ]({{< relref "/working-groups/mir-opt/FAQ" >}})
 

--- a/content/working-groups/nll/_index.md
+++ b/content/working-groups/nll/_index.md
@@ -14,7 +14,7 @@ This working group aims to implement non-lexical lifetimes (NLL), as described i
 > to eliminate many common cases where small, function-local code modifications would be required
 > to pass the borrow check.
 
-- **Leads:** [@nikomatsakis][nikomatsakis] and [@pnkfelix][pnkfelix]
+- **Team:** [wg-nll on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-nll.toml)
 - **Meeting Notes:** [All]({{< relref "/working-groups/nll/NOTES" >}})
 - **FAQ:** [FAQ]({{< relref "/working-groups/nll/FAQ" >}})
 

--- a/content/working-groups/parallel-rustc/_index.md
+++ b/content/working-groups/parallel-rustc/_index.md
@@ -5,7 +5,7 @@ type: docs
 # parallel-rustc Working Group
 ![working group status: active][status]
 
-- **Leads:** [@Zoxc][Zoxc], [@aturon][aturon]
+- **Team:** [wg-parallel-rustc on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-parallel-rustc.toml)
 - **Meeting Notes:** [All]({{< relref "/working-groups/parallel-rustc/NOTES" >}})
 - **Minutes:**
     - [2019.05.10]({{< relref "/working-groups/parallel-rustc/minutes/2019.05.10.md" >}})

--- a/content/working-groups/parselib/_index.md
+++ b/content/working-groups/parselib/_index.md
@@ -8,7 +8,7 @@ type: docs
 The goal of the working group is to librarify rustc parser and share it between
 rustc and rust-analyzer.
 
-- **Leads/members:** See [rust-lang/team][team]
+- **Team:** [wg-parselib on rust-lang/team][team]
 
 [status]: https://img.shields.io/badge/status-active-brightgreen.svg?style=for-the-badge
 

--- a/content/working-groups/pgo/_index.md
+++ b/content/working-groups/pgo/_index.md
@@ -3,12 +3,12 @@ title: Profile-Guided Optimization (PGO) Working Group
 type: docs
 ---
 # Profile-Guided Optimization (PGO) Working Group
-![working group status: active][status]
+![working group status: retired][status]
 
 This working group aims to implement profile-guided optimization (PGO) in the
 Rust compiler.
 
-- **Leads:** [@michaelwoerister][michaelwoerister]
+- **Team:** [wg-pgo on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-pgo.toml)
 - **Meeting Notes:** [All]({{< relref "/working-groups/pgo/NOTES" >}})
 - **FAQ:** [FAQ]({{< relref "/working-groups/pgo/FAQ" >}})
 

--- a/content/working-groups/polonius/_index.md
+++ b/content/working-groups/polonius/_index.md
@@ -20,7 +20,7 @@ since then in terms of its implementation details and efficiency, and
 one of the goals of the working group is to extend the scope of the
 crate to define the full borrow check analysis.
 
-- **Leads:** [@nikomatsakis][nikomatsakis], [@lqd][lqd]
+- **Team:** [wg-polonius on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-polonius.toml)
 - **Meeting Notes:**
     - [2019.03.07 Meeting]({{< relref "/working-groups/polonius/minutes/2019.03.07-meeting.md" >}})
     - [2019.04.23 Meeting]({{< relref "/working-groups/polonius/minutes/2019.04.23-meeting.md" >}})

--- a/content/working-groups/polymorphization/_index.md
+++ b/content/working-groups/polymorphization/_index.md
@@ -8,7 +8,7 @@ type: docs
 This working group aims to implement an analysis to detect when functions could remain polymorphic
 during code generation.
 
-- **Leads/members:** See [rust-lang/team][team]
+- **Team:** [wg-polymorphization on rust-lang/team][team]
 
 [status]: https://img.shields.io/badge/status-active-brightgreen.svg?style=for-the-badge
 

--- a/content/working-groups/prioritization/_index.md
+++ b/content/working-groups/prioritization/_index.md
@@ -8,7 +8,7 @@ type: docs
 
  Triaging bugs, mainly deciding if bugs are critical (potential release blockers) or not.
 
-- **Leads:**  [@spastorino][spastorino] and [@wesleywiser][wesleywiser]
+- **Team:** [wg-prioritization on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-prioritization.toml)
 
 [status]: https://img.shields.io/badge/status-active-brightgreen.svg?style=for-the-badge
 [spastorino]: https://github.com/spastorino

--- a/content/working-groups/rfc-2229/_index.md
+++ b/content/working-groups/rfc-2229/_index.md
@@ -5,7 +5,7 @@ type: docs
 # rfc-2229 Working Group
 ![working group status: active][status]
 
-- **Leads/Members:** See [rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-rfc-2229.toml)
+- **Team:** [wg-rfc-2229 on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-rfc-2229.toml)
 - **Meeting Notes:** 
     - Check [meetings.md](https://github.com/rust-lang/project-rfc-2229/blob/master/meetings.md) for latest meetings notes and video recordings.
     - Old: [2019.03.05 Roadmap Plan]({{< relref "/working-groups/rfc-2229/minutes/2019.03.05-roadmap-plan.md" >}})

--- a/content/working-groups/rls-2.0/_index.md
+++ b/content/working-groups/rls-2.0/_index.md
@@ -4,6 +4,7 @@ type: docs
 ---
 # rls-2.0 Working Group
 
+- **Team:** [wg-rls-2 on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-rls-2.toml)
 - **Notes:** [All]({{< relref "/working-groups/rls-2.0/NOTES" >}})
 - **FAQs:** [FAQ]({{< relref "/working-groups/rls-2.0/FAQ" >}})
 

--- a/content/working-groups/rustc-dev-guide/_index.md
+++ b/content/working-groups/rustc-dev-guide/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 This working group aims to make the compiler easier to learn by ensuring that rustc-dev-guide and api docs are "complete".
 
-- **Leads:**  [@spastorino][spastorino] and [@mark-i-m][markim]
+- **Team:** [wg-rustc-dev-guide on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-rustc-dev-guide.toml)
 - **Meeting Notes:** 
     - [2019.05.14 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.05.14-meeting.md" >}})
     - [2019.05.28 Meeting]({{< relref "/working-groups/rustc-dev-guide/minutes/2019.05.28-meeting.md" >}})

--- a/content/working-groups/self-profile/_index.md
+++ b/content/working-groups/self-profile/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 This working group aims to improve the `-Z self-profile` `rustc` option which can aid in profiling the compiler during compilation.
 
-- **Leads:** [@michaelwoerister][michaelwoerister] and [@wesleywiser][wesleywiser]
+- **Team:** [wg-self-profile on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-self-profile.toml)
 - **Meeting Notes:** [All]({{< relref "/working-groups/self-profile/NOTES" >}})
 - **FAQ:** [FAQ]({{< relref "/working-groups/self-profile/FAQ" >}})
 

--- a/content/working-groups/traits/_index.md
+++ b/content/working-groups/traits/_index.md
@@ -4,7 +4,7 @@ type: docs
 ---
 # Traits Working Group
 
-- **Leads:** [@nikomatsakis][nikomatsakis] and [@jackh726][jackh726]
+- **Team:** [wg-traits on rust-lang/team](https://github.com/rust-lang/team/blob/master/teams/wg-traits.toml)
 
 [nikomatsakis]: https://github.com/nikomatsakis
 [jackh726]: https://github.com/jackh726

--- a/layouts/shortcodes/checkin-schedule.html
+++ b/layouts/shortcodes/checkin-schedule.html
@@ -27,7 +27,7 @@
     // When adding/removing working groups adjust magic number to match the
     // current order we see on the page.
     var wgs = [
-        "Async/Await",
+        "Async Foundations",
         "Diagnostics",
         "Rustc Dev Guide",
         "LLVM",
@@ -38,7 +38,24 @@
         "RFC 2229",
         "RLS 2.0",
         "Self-Profile",
-        "Traits",
+        "Traits"
+    ];
+    // For each working group, add a link to its rust-lang/team toml file,
+    // in the same order as the `wgs` array above, so that the people using the schedule
+    // can see the wg members to ping.
+    var links = [
+        "https://github.com/rust-lang/team/blob/master/teams/wg-async-foundations.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-diagnostics.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-rustc-dev-guide.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-llvm.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-meta.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-mir-opt.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-polonius.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-polymorphization.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-rfc-2229.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-rls-2.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-self-profile.toml",
+        "https://github.com/rust-lang/team/blob/master/teams/wg-traits.toml"
     ];
     var count = wgs.length % 2 === 0 ? wgs.length : wgs.length + 1;
 
@@ -54,10 +71,13 @@
     function updateElementForWeek(week, element, name) {
         var index = (week + magic_number) * 2 % count;
         var names = [index, index + 1].map(i => wgs[i]);
+        var tomls = [index, index + 1].map(i => links[i]);
 
-        var message = names[0];
+        var message;
         if ((typeof names[1]) !== "undefined") {
-            message = names[0] + " and " + names[1];
+            message = `<a href="${tomls[0]}" target="_blank">${names[0]}</a> and <a href="${tomls[1]}" target="_blank">${names[1]}</a>`;
+        } else {
+            message = `<a href="${tomls[0]}" target="_blank">${names[0]}</a>`;
         }
 
         document.getElementById(element + "-name").innerHTML = message;


### PR DESCRIPTION
Link the rust-lang/team TOML files to have up-to-date members and leads when doing the meeting triage

(also mark wg-pgo as retired matching the document's contents)

r? @spastorino 