### PR TITLE
Remove wg-polonius from compiler meeting check-ins

### DIFF
--- a/layouts/shortcodes/checkin-schedule.html
+++ b/layouts/shortcodes/checkin-schedule.html
@@ -56,10 +56,6 @@
            url: "https://github.com/rust-lang/team/blob/master/teams/wg-mir-opt.toml"
        },
        {
-           name: "Polonius",
-           url: "https://github.com/rust-lang/team/blob/master/teams/wg-polonius.toml"
-       },
-       {
            name: "Polymorphization",
            url: "https://github.com/rust-lang/team/blob/master/teams/wg-polymorphization.toml"
        },


### PR DESCRIPTION
With the sprint model that we use, the Polonius working group has relatively infrequent activity, so much so that the check-ins at the compiler meetings happen before any substantial work has been completed. 

A lot of the times there's little to report, so this PR removes the WG from the check-in rotation, as we've discussed before with @nikomatsakis.

r? @nikomatsakis 

---
Note: I apparently didn't have to change the "magic number" so that the expected order for other WGs remains the same. Here's a screenshot of how this PR looks locally: the next 4 WGs are the same [as mentioned on the website](https://rust-lang.github.io/compiler-team/about/triage-meeting/)

![image](https://user-images.githubusercontent.com/247183/115466023-c2c84700-a22f-11eb-9e57-81cf9a44651e.png)


