### PR TITLE
Add relabel command to triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,3 +5,5 @@ open_extra_text = "cc @rust-lang/compiler @rust-lang/compiler-contributors"
 # can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
 zulip_stream = 233931
 zulip_ping = "T-compiler"
+
+[relabel]


### PR DESCRIPTION
Hi,

as per my question on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/triagebot.20.60relabel.60.20command.20for.20rust-lang.2Fcompiler-team.20repo), having the bot respond to a `label` command would help me a bit :-)

thanks