### PR TITLE
Drop unreferenced footnoted link to forge

### DIFF
--- a/.github/ISSUE_TEMPLATE/major_change.md
+++ b/.github/ISSUE_TEMPLATE/major_change.md
@@ -31,8 +31,8 @@ The main points of the [Major Change Process][MCP] are as follows:
 
 You can read [more about Major Change Proposals on forge][MCP].
 
+[MCP]: https://forge.rust-lang.org/compiler/mcp.html
+
 # Comments
 
 **This issue is not meant to be used for technical discussion. There is a Zulip stream for that. Use this issue to leave procedural comments, such as volunteering to review, indicating that you second the proposal (or third, etc), or raising a concern that you would like to be addressed.**
-
-[MCP]: https://forge.rust-lang.org/compiler/mcp.html

--- a/.github/ISSUE_TEMPLATE/major_change.md
+++ b/.github/ISSUE_TEMPLATE/major_change.md
@@ -36,5 +36,3 @@ You can read [more about Major Change Proposals on forge][MCP].
 **This issue is not meant to be used for technical discussion. There is a Zulip stream for that. Use this issue to leave procedural comments, such as volunteering to review, indicating that you second the proposal (or third, etc), or raising a concern that you would like to be addressed.**
 
 [MCP]: https://forge.rust-lang.org/compiler/mcp.html
-[forge]: https://forge.rust-lang.org/
-


### PR DESCRIPTION
There are two links to the MCP, one of which used to link to the top-level forge page. The footnoted URL for the top-level forge page was unreferenced.
