### PR TITLE
suggest people limit title length in MCP template

### DIFF
--- a/.github/ISSUE_TEMPLATE/major_change.md
+++ b/.github/ISSUE_TEMPLATE/major_change.md
@@ -13,6 +13,8 @@ assignees: ''
 
 *Your proposal doesn't have to be long. It should however be in sufficient detail that people familiar with the code can clearly envision what you are planning to do. Be sure to link to any relevant issues, PRs, or other sources.*
 
+*When picking a title (that is, when replacing the "(My major change proposal)" text above), keep in mind that Zulip truncates text that extends beyond a certain length, replacing the truncated suffix with "…" in the topic name it creates. Therefore, consider keeping your title to <= 40 characters, if possible.*
+
 # Mentors or Reviewers
 
 *If you have a reviewer or mentor in mind for this work, mention then


### PR DESCRIPTION
After seeing what Zulip produced for [a recent MCP topic](https://zulip-archive.rust-lang.org/233931tcompilermajorchanges/42921CIshouldexercisesubsetoftestsundecompilerteam439.html), I figured it might be good to nudge people in the right direction here.