### PR TITLE
Add all T-compiler past meetings agenda

### DIFF
--- a/meetings-agenda/T-compiler Meeting Agenda 2020-03-12.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-03-12.md
@@ -1,0 +1,59 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-03-12
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+ * [Planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html) tomorrow (March 13th)
+ * Rust 1.42 is released today
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+* Use TypeRelating for instantiating query responses [#69591][] :back: / :hand:
+
+[#69591]: https://github.com/rust-lang/rust/pull/69591
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+No PR's S-waiting-on-team this time.
+
+## Issues of Note
+
+- [52 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) and [32 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [3 P-high and 1 P-medium regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- [ ] "Compiler incorrectly assumes int will never be one" [#69841][]
+- [ ] "ICE in collect_and_partition_mono_items" [#69785][]
+- [ ] "ICE: src/librustc/middle/region.rs:1037: Encountered greater count 28" [#69307][]
+- [ ] "Replace our fragile safety scheme around erroneous constants" [#67191][]
+- [ ] "ICE field: higher-rank trait bound (HRTB) `for<'a> ...` hits OutputTypeParameterMismatch in librustc/traits/codegen" [#62529][]
+
+[#69841]: https://github.com/rust-lang/rust/issues/69841
+[#69785]: https://github.com/rust-lang/rust/issues/69785
+[#69307]: https://github.com/rust-lang/rust/issues/69307
+[#67191]: https://github.com/rust-lang/rust/issues/67191
+[#62529]: https://github.com/rust-lang/rust/issues/62529
+
+## WG checkins
+
+WG-nll: nothing to share and the wg should be removed from the rotation.
+WG-parallel-rustc: no updates.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-03-19.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-03-19.md
@@ -1,0 +1,57 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-03-19
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- We are in the process of forming a WG-prioritization working group.
+  - Focus: mainly on deciding if bugs are critical (potential release blockers) or not.
+  - There's a [new WG-prioritization stream](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization) where pre-triage is going to happen from now on.
+- [Poll] Should we remove I-nominated on toolstate breakage issues?.
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- can_begin_literal_or_bool: `true` on `"-"? lit` NTs. [#70058](https://github.com/rust-lang/rust/pull/70058) :back: / :hand:
+
+
+Already beta accepted ...
+- Use TypeRelating for instantiating query responses [#69591](https://github.com/rust-lang/rust/pull/69591)
+
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+No PR's S-waiting-on-team this time.
+
+## Issues of Note
+
+- [54 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) and [32 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-high and 4 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [5 P-high and 1 P-medium regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- [ ] "rustc segfault" [#70117](https://github.com/rust-lang/rust/issues/70117)
+- [ ] "ICE using associated type from higher ranked trait" [#70120](https://github.com/rust-lang/rust/issues/70120)
+
+## WG checkins
+
+WG-PGO: working group is retired.
+WG-pipelining: working group is disbanded.
+
+We should remove both from rotation, also nll and probably check the status of all the working groups.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-03-26.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-03-26.md
@@ -1,0 +1,57 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-03-26
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- As per last week discussion, we are going to stop tagging as I-nominated on toolstate breakage [#70407](https://github.com/rust-lang/rust/pull/70407)
+  - Please check if the conclusion stated on Santiago's comment there is what we want. 
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "Fix smaller issues with invalid placeholder type errors" [#70369] :back: / :hand: / :shrug: 
+- "Account for bad placeholder types in where clauses" [#70294] :back: / :hand: / :shrug: 
+- "Fix ICE caused by truncating a negative ZST enum discriminant" [#70126] :back: / :hand: / :shrug: 
+- "Ensure HAS_FREE_LOCAL_NAMES is set for ReFree" [#69956] :back: / :hand: / :shrug: 
+
+[#70369]: https://github.com/rust-lang/rust/pull/70369
+[#70294]: https://github.com/rust-lang/rust/pull/70294
+[#70126]: https://github.com/rust-lang/rust/pull/70126
+[#69956]: https://github.com/rust-lang/rust/pull/69956
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time. :tada: 
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+No PR’s S-waiting-on-team this time. :tada: 
+
+## P-high Issues of Note
+
+- [50 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) (4 less than last week)
+- [30 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee) (2 less than last week)
+- [3 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-high and 3 P-medium regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- [x] "Compiler incorrectly assumes int will never be one" [#69841](https://github.com/rust-lang/rust/issues/69841)
+- [ ] "Add cryptographic hash of source files in debug info" [#69718](https://github.com/rust-lang/rust/pull/69718)
+- [ ] "Box<dyn FnOnce> doesn't respect self alignment" [#68304](https://github.com/rust-lang/rust/pull/68304)
+
+## WG checkins
+
+WG-learning and WG-LLVM.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-04-02.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-04-02.md
@@ -1,0 +1,70 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-04-02
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Do we agree on adding an `I-prioritize` like label?
+  - So we can have I-nominated for let's discuss this and I-prioritize as a request for prioritization.
+  - Should it be `I-prioritize`, `P-prioritize` or maybe `WG-prioritization`?.
+- Tomorrow: Design meeting: cranelift backend for rustc
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "Fix "since" field for `Once::is_complete`'s `#[stable]` attribute" [#70018](https://github.com/rust-lang/rust/pull/70018) :back: / :hand:
+- "parse_and_disallow_postfix_after_cast: account for `ExprKind::Err`." [#70556](https://github.com/rust-lang/rust/pull/70556) :back: / :hand:
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+- "Remove -Z no-landing-pads flag" [#70175](https://github.com/rust-lang/rust/pull/70175)
+  - FCPed 2 days ago with 8 :+1: out of 13
+  - In disposition-merge state
+
+## Issues of Note
+
+- [51 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) (1 more than last week)
+- [28 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee) (2 less than last week)
+- [2 P-high and 2 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [2 P-high and 4 P-medium regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+
+### Unassigned stable to beta regressions
+
+- "no_mangle causes compilation errors with async-await on armv7-linux-androideabi and aarch64-linux-android targets" [#70098](https://github.com/rust-lang/rust/issues/70098) 
+
+### Unassigned stable to nightly regressions
+
+- "internal compiler error: cannot relate region: LUB(ReErased, ReErased)" [#70608](https://github.com/rust-lang/rust/issues/70608)
+  - This one is nominated anyway.
+- "Some macro errors now include file names into the standard library (JSON)." [#70396](https://github.com/rust-lang/rust/issues/70396)
+- "file not found for module" [#70314](https://github.com/rust-lang/rust/issues/70314)
+- "Regression in error message quality for macro_rules involving $:ident" [#69604](https://github.com/rust-lang/rust/issues/69604)
+- "Compiler error while compiling Winrt" [#66402](https://github.com/rust-lang/rust/issues/66402)
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- [ ] "Box<dyn FnOnce> doesn't respect self alignment" [#68304](https://github.com/rust-lang/rust/issues/68304)
+- [ ] "internal compiler error: cannot relate region: LUB(ReErased, ReErased)" [#70608](https://github.com/rust-lang/rust/issues/70608)
+- [ ] "regression: assertion failed: data.is_empty()" [#70445](https://github.com/rust-lang/rust/issues/70445)
+- [ ] "internal compiler error: no type for local variable" [#70594](https://github.com/rust-lang/rust/issues/70594)
+- [ ] "Should enum discriminants have generics in scope?" [#70453](https://github.com/rust-lang/rust/issues/70453)
+
+## WG checkins
+
+WG-Meta: 
+WG-MIR-Opt:

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-04-09.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-04-09.md
@@ -1,0 +1,69 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-04-09
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow we have our [planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html)
+- WG-prioritization has created two labels
+  - `I-prioritize` so we can ask for prioritization using that label and leave `I-nominated` to nominate issues for discussion. [Read the thread for more info](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/I-nominated.20vs.20I-prioritize)
+  - `P-critical`, this will be critical priority issues. We are in the process of documenting our scheme properly but use your judgement and more or less the idea of a critical bug is one that potentially blocks a release.
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "macro_rules: `NtLifetime` cannot start with an identifier" [#70768](https://github.com/rust-lang/rust/issues/70768) :back: / :hand:
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+- Fix staticlib name for *-pc-windows-gnu targets [#70937](https://github.com/rust-lang/rust/pull/70937)
+    - Needs a decision that we want to go ahead with this fix.
+- A big options clean-up [#70729](https://github.com/rust-lang/rust/pull/70729) (also in `Nominated Issues` list)
+    - Waiting on @estebank, @matthewjasper, @nagisa and @pnkfelix to check their boxes or provide concerns.
+- Move LLVM bitcode destination [#70458](https://github.com/rust-lang/rust/pull/70458)
+    - Waiting on final comment period to elapse.
+- Remove -Z no-landing-pads flag [#70175](https://github.com/rust-lang/rust/pull/70175)
+    - Waiting on final comment period to elapse.
+- Add Option to Force Unwind Tables [#69984](https://github.com/rust-lang/rust/pull/69984)
+    - Waiting on @Zoxc, @cramertj and @pnkfelix to check their boses or provide concerns.
+- Add error codes duplicates check [#68639](https://github.com/rust-lang/rust/pull/68639)
+    - Waiting on something from `wg-diagnostics`?
+- Ensure all iterations in Rayon iterators run in the presence of panics [#68171](https://github.com/rust-lang/rust/pull/68171)
+    - Needs a decision that we want to go ahead with this change (possibly from `wg-parallel-rustc`).
+
+## Issues of Note
+
+- [0 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+) and [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [49 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) (2 less than last week)
+- [27 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee) (1 less than last week)
+- [1 P-high and 3 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [3 P-high, 3 P-medium, 3 from T-rustdoc regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- [ ] "Compile regression "cannot infer an appropriate lifetime for lifetime parameter"" [#70917](https://github.com/rust-lang/rust/issues/70917)
+- [ ] "PhantomData<T> no longer dropck?" [#70841](https://github.com/rust-lang/rust/issues/70841)
+- [ ] "A big options clean-up" [#70729](https://github.com/rust-lang/rust/pull/70729) (also in `PR's S-waiting-on-team` list)
+- [ ] "ICEs should always print the top of the query stack." [#70953](https://github.com/rust-lang/rust/issues/70953)
+- [ ] "[WIP] Rename mir::Rvalue to Op." [#70928](https://github.com/rust-lang/rust/pull/70928)
+- [ ] "WIP toward LLVM Code Coverage for Rust" [#70680](https://github.com/rust-lang/rust/pull/70680)
+- [ ] "Use the niche optimization if other variant are small enough" [#70477](https://github.com/rust-lang/rust/pull/70477)
+
+## WG checkins
+
+WG-Rustc-Dev-Guide and WG-LLVM.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-04-16.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-04-16.md
@@ -1,0 +1,73 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-04-16
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Next Thursday, April 23rd we are releasing 1.43
+- [MCP RFC is pending](https://github.com/rust-lang/rfcs/pull/2904)
+- Automate compiler development [#272](https://github.com/rust-lang/compiler-team/issues/272)
+  - We have `@rustbot seconded` support
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "Do not reuse post LTO products when exports change" [#71131](https://github.com/rust-lang/rust/pull/71131) :back: / :hand:
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+- "Add Option to Force Unwind Tables" [#69984](https://github.com/rust-lang/rust/pull/69984) 
+  - In FCP, Disposition to merge.
+- "A big options clean-up" [#70729](https://github.com/rust-lang/rust/pull/70729)
+  - In FCP, disposition to merge.
+- "Remove -Z no-landing-pads flag" [#70175](https://github.com/rust-lang/rust/pull/70175)
+  - FCP finished, disposition to merge.
+- "Move LLVM bitcode destination" [#70458](https://github.com/rust-lang/rust/pull/70458)
+  - FCP finished, disposition to merge and needs a reviewer.
+
+## Issues of Note
+
+- [1 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+) (1 more than last week)
+- [45 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) (4 less than last week)
+  - [26 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee) (1 less than last week)
+- [2 P-high and 2 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - The 2 P-medium are unassigned
+- [2 P-high, 2 P-medium and 1 T-rustdoc regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - All of them are unassigned
+
+
+### P-critical
+
+- "`static FOO:Foo=FOO;` doesn't cause cycle error for zero-sized-type with no public constructor." [#71078](https://github.com/rust-lang/rust/pull/71078)
+  - This issue is assigned to @oli
+
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- [ ] "[WIP] Rename mir::Rvalue to Op." [#70928](https://github.com/rust-lang/rust/issues/70928)
+  - In FCP, disposition to close.
+- [ ] "Should enum discriminants have generics in scope?" [#70453](https://github.com/rust-lang/rust/issues/70453)
+  - In FCP, disposition to merge.
+- [ ] "Add support for parsing with rust-analyzer instead of librustc_parse #70761" [#70761](https://github.com/rust-lang/rust/pull/70761)
+  - Nominated for discussion, maybe needs an MCP. 
+
+
+## WG checkins
+
+WG-meta: let's check with @nikomatsakis to see if he wants to mention something but we had a checkin recently.
+WG-Mir-Opt: Mir Opt skips this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-04-23.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-04-23.md
@@ -1,0 +1,80 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-04-23
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Today we are releasing Rust 1.43.0
+- Tomorrow (Friday) we will have a compiler team meeting about ["Standard library implementation ownership" #267](https://github.com/rust-lang/compiler-team/issues/267)
+- There are 5 major changes proposals
+  - [Decentralize queries #277](https://github.com/rust-lang/compiler-team/issues/277)
+  - [Major change proposal: Support collecting all identifiers encountered during compilation #276](https://github.com/rust-lang/compiler-team/issues/276)
+  - [Move `src/test/run-fail` tests to UI #274](https://github.com/rust-lang/compiler-team/issues/274)
+  - [Integration of the Cranelift backend with rustc #270](https://github.com/rust-lang/compiler-team/issues/270)
+  - [[major change] MIR librarification #233](https://github.com/rust-lang/compiler-team/issues/233)
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "[beta] fix failing const validation" [#71441](https://github.com/rust-lang/rust/pull/71441) :back: / :hand:
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+- "Add Option to Force Unwind Tables" [#69984](https://github.com/rust-lang/rust/pull/69984) 
+  - FCP finished, disposition to merge.
+- "Remove -Z no-landing-pads flag" [#70175](https://github.com/rust-lang/rust/pull/70175)
+  - FCP finished, disposition to merge.
+
+## Issues of Note
+
+### Short Summary
+
+- [1 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+) (same as last week)
+- [43 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) (2 less than last week)
+  - [22 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee) (4 less than last week)
+- [1 P-high, 2 P-medium, 1 P-low, 2 T-libs and 1 T-rustdoc regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - The only assigned is the P-high one. One of the T-libs and the T-rustdoc are unassigned.
+- [3 P-high, 3 P-medium, 1 P-low and 1 T-libs regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - Only 2 P-high are assigned.
+- [69 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [24 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+### P-critical
+
+- "`static FOO:Foo=FOO;` doesn't cause cycle error for zero-sized-type with no public constructor." [#71078](https://github.com/rust-lang/rust/pull/71078)
+  - This issue is assigned to @oli
+  - This is `P-critical` but is not going to be included in 1.43.0. `P-critical` means that it potentially blocks the release and this time it didn't block it.
+  - Should this one be beta-nominated after the nightly to beta promotion happens? (If PR #71078 lands before promotion then point is moot.)
+
+### Unassigned P-high regressions
+
+- "`broken MIR` `NoSolution` sized array initialiser with addition in generic tuple destructure" [#71344](https://github.com/rust-lang/rust/issues/71344)
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "`unsized_locals` fails to uphold alignment requirements" [#71416](https://github.com/rust-lang/rust/issues/71416)
+  - We need to discuss about a possible solution for this one.
+- "Debuginfo tests are not running" [#47163](https://github.com/rust-lang/rust/issues/47163)
+  - According to @jonas-schievink, we have not been able to run these tests for over 2 years. There are some PRs by @tromey. It's not clear if [#71428](https://github.com/rust-lang/rust/pull/71428) fixes this problem entirely or partially.
+- "Rename mir::Rvalue to Op." [#70928](https://github.com/rust-lang/rust/pull/70928)
+  - We discussed this one last week. It would be good to mention that the discussion keeps going and Zulip may be a good place for it.
+
+## WG checkins
+
+WG-parallel-rustc: @simulacrum mentioned that there are no updates.
+WG-polonius: @lqd shared [this](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/weekly.20meeting.202020-04-23.20.2354818/near/194978584).

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-04-30.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-04-30.md
@@ -1,0 +1,104 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-04-30
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- There are 3 major changes proposals 
+  - Implement LLVM-compatible source-based code coverage [#278](https://github.com/rust-lang/compiler-team/issues/278)
+  - illumos toolchain builds [#279](https://github.com/rust-lang/compiler-team/issues/279)
+  - Inline assembly [#280](https://github.com/rust-lang/compiler-team/issues/280)
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "Quick and dirty fix of the unused_braces lint" [#71517](https://github.com/rust-lang/rust/pull/71517) :back: / :hand:
+- "normalize field projection ty to fix broken MIR issue" [#71488](https://github.com/rust-lang/rust/pull/71488) :back: / :hand:
+- "fix error code in E0751.md" [#71426](https://github.com/rust-lang/rust/pull/71426) :back: / :hand:
+- "Remove some `Vec` allocations to improve performance" [#71268](https://github.com/rust-lang/rust/pull/71268) :back: / :hand:
+
+T-libs ones ...
+
+- "Update stdarch submodule" [#71495](https://github.com/rust-lang/rust/pull/71495) :back: / :hand:
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+T-libs ones ...
+
+- "Update stdarch submodule" [#71495](https://github.com/rust-lang/rust/pull/71495) :back: / :hand:
+- "avx512 support regression in 1.43" [#71473](https://github.com/rust-lang/rust/issues/71473) :back: / :hand:
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+- "Add Option to Force Unwind Tables" [#69984](https://github.com/rust-lang/rust/pull/69984)
+  - FCP finished, disposition to merge.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+) (one more than last week)
+  - [both are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee) (one more than last week)
+- [42 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+) (one less than last week)
+  - [21 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee) (one less than last week)
+- [1 P-high, 2 P-medium, 1 P-low, 1 T-libs regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - The only assigned is the P-high one.
+- [2 P-high, 3 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - Both P-high are assigned and one P-low is assigned too.
+- [71 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [25 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+There are 1 more `P-critical` issue and 1 less `P-high` issues in comparison with last week.
+
+### P-critical
+
+- "rust-analyser segfault with lto=thin, linker=lld-link" [#71504](https://github.com/rust-lang/rust/issues/71504)
+  - Unassigned.
+- "Unsoundness due to variance of trait objects WRT associated types" [#71550](https://github.com/rust-lang/rust/issues/71550)
+  - Unassigned.
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "Unsoundness due to variance of trait objects WRT associated types" [#71550](https://github.com/rust-lang/rust/issues/71550)
+  - This is a very bad issue, already listed as P-critical
+- ~~"`unsized_locals` fails to uphold alignment requirements" [#71416](https://github.com/rust-lang/rust/issues/71416)~~
+  - (@pnkfelix opened some fresh sub-issues.)
+
+## WG checkins
+
+WG-Polymorphization by @davidtwco:
+
+> I can't remember where the polymorphisation work was last time I gave an update at the meeting, so to remind everyone, the polymorphisation working group is for tracking my master's project - implementing an analysis that will detect when generic parameters are unused, and then reducing monomorphisation as a result.
+>
+> #69749 has a working implementation of polymorphisation (I've paused working on it until my exams are over), which we've run perf on and gotten mixed results - there are some interesting interactions with LTO on one benchmark configuration, and some cases see 3-5% improvements, but some are worse-off (normally by 1-2%). There's probably some room for improvement yet.
+
+WG-prioritization by @spastorino:
+
+This is the first checkin from WG Prioritization.
+
+- [The group is formally formed](https://rust-lang.github.io/compiler-team/working-groups/prioritization/)
+  - Main goal is to triaging bugs, mainly deciding if bugs are critical (potential release blockers) or not.
+  - Route bugs to folks who can fix them.
+  - Build the agenda for these meetings.
+  - Among other things :)
+- We have [some plans](https://hackmd.io/P3yvagSSS7yAI2QxhLfPtQ?view) and [procedures](https://hackmd.io/pHb6eTZ2Sjy6XZmwXZHIBA?view) documented.
+- We've created I-prioritize and splitted the meaning of it with I-nominated for easier request for prioritization.
+- We've created P-critical and defined the [different priority levels](https://hackmd.io/7NRRbq62TnaezW7-n15cDw) this is still WIP.
+- We're trying to have all this process async
+  - When someone tags `I-prioritize` a Zulip topic is automatically created requesting for prioritization of the issue in question so we can prioritize async.
+  - @rustbot prioritize works too for non-members
+  - We should do the same for beta/stable backports, I-nominated, S-waiting-on-team
+  - We're also trying to automate with commands our meetings and this one in particular.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-05-07.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-05-07.md
@@ -1,0 +1,95 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-05-07
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Today we are making a point release, 1.43.1 :tada:
+- Remember to fill State of the Compiler Team form by end of today (Thursday). Niko and Felix need time to review before Friday's steering meeting. (You should have links to separate non-anonymous and anonymized feedback forms in your email.)
+- On friday we have our [Compiler Team Planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html).
+- There is 1 major change proposal
+  - "intern predicates, introduce forall/implies" [#285](https://github.com/rust-lang/compiler-team/issues/285)
+
+## Beta-acceptances from past week
+
+- "fix error code in E0751.md" [#71426](https://github.com/rust-lang/rust/pull/71426) was unlaterally beta-accepted by @pnkfelix
+- "resolve: Relax fresh binding disambiguation slightly to fix regression" [#71846](https://github.com/rust-lang/rust/pull/71846) was unilaterally beta-accepted by @pnkfelix 
+- "Do not try to find binop method on RHS `TyErr`" [#71810](https://github.com/rust-lang/rust/pull/71810) was unilaterally beta-accepted by @pnkfelix 
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "Update the `cc` crate" [#71882](https://github.com/rust-lang/rust/pull/71882) :back: / :hand:
+
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+No PR's waiting on team this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [1 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [40 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+)
+  - [20 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-high, 4 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - The only assigned is the P-high one.
+- [1 P-high, 3 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - The only assigned is the P-high one.
+- [69 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [24 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+There are 1 less `P-critical` issues and 2 less `P-high` issues in comparison with last week.
+
+### P-critical
+
+- "Unsoundness due to variance of trait objects WRT associated types" [#71550](https://github.com/rust-lang/rust/issues/71550)
+  - This issue is assigned to @spastorino and has a PR open.
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "Unsoundness due to variance of trait objects WRT associated types" [#71550](https://github.com/rust-lang/rust/issues/71550)
+- "Rustc overflow its stack when using impl Trait and the struct containing the function itself" [#69096](https://github.com/rust-lang/rust/issues/69096)
+- "rust-lld since 1.38 overlaps .text with .rodata for embedded arm target" [#65391](https://github.com/rust-lang/rust/issues/65391)
+- "Compile-time stack overflow when trait impl contains extern crate" [#55779](https://github.com/rust-lang/rust/issues/55779)
+- ~~"repr(packed) allows invalid unaligned loads" [#27060](https://github.com/rust-lang/rust/issues/27060)~~ (pnkfelix added by accident)
+
+
+
+## WG checkins
+
+@**WG-rls2.0** checkin by @**matklad**:
+
+> Checkin text
+
+@**WG-self-profile** checkin by @**Wesley Wiser**:
+
+Things have settled down quite a lot since the last check-in.
+We achieved our MVP goal and since then, lots of people have been using the tools either directly or via the perf.rlo integration.
+
+I think the only major news is that we have documentation everwhere that has been requested:
+  * GitHub readme files for each individual tool.
+  * `rustc -Zhelp` has some short help text describing the options.
+  * The Unstable Book has [more complete](https://doc.rust-lang.org/unstable-book/compiler-flags/self-profile.html) documentation about the `-Z` flags.
+  * Rustc Dev Guide has a [mention](https://rustc-dev-guide.rust-lang.org/profiling.html).
+  
+I also wrote a rather extensive post on the [Inside-Rust blog](https://blog.rust-lang.org/inside-rust/2020/02/25/intro-rustc-self-profile.html) about the tooling including a complete step-by-step tutorial.
+
+While there additional polish that could be done, there are no remaining "must-have" features that I'm aware of.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-05-14.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-05-14.md
@@ -1,0 +1,91 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-05-14
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- We have a design meeting tomorrow: "survey overview and discussion"
+- Major Changes Proposals:
+  - Seconded proposals (in FCP)
+    - "Implement LLVM-compatible source-based code coverage" [#278](https://github.com/rust-lang/compiler-team/issues/278)
+    - "Inline assembly" [#280](https://github.com/rust-lang/compiler-team/issues/280)
+    - "intern predicates, introduce forall/implies" [#285](https://github.com/rust-lang/compiler-team/issues/285)
+    - "Reintegrate chalk into rustc" [#289](https://github.com/rust-lang/compiler-team/issues/289) (NEW)
+  - New proposals (not seconded)
+    - "RFC 2229 implementation plan" [#292](https://github.com/rust-lang/compiler-team/issues/292)
+  - Old proposals (not seconded)
+    - "Integration of the Cranelift backend with rustc" [#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "illumos toolchain builds" [#279](https://github.com/rust-lang/compiler-team/issues/279)
+
+## Beta-nominations
+
+[T-compiler beta noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "Fix hang in lexical_region_resolve" [#72087](https://github.com/rust-lang/rust/pull/72087) :back: / :hand:
+- "Fix E0284 to not use incorrect wording" [#71960](https://github.com/rust-lang/rust/pull/71960) :back: / :hand:
+
+
+## Stable-nominations
+
+[T-compiler stable noms](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler+)
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler+)
+
+No PR's waiting on team this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [1 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [42 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+)
+  - [22 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-high and 3 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - There is only 1 P-high assigned.
+- [4 P-medium and 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - There is only 1 P-medium assigned.
+- [71 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [25 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+There are the same `P-critical` issues and 2 more `P-high` issues in comparison with last week.
+
+### P-critical
+
+- "Unsoundness due to variance of trait objects WRT associated type" [#71550](https://github.com/rust-lang/rust/issues/71550)
+  - This issue is assigned to @spastorino and has a PR open.
+  - We've run crater and got a bunch of results.
+  - Niko is investigating possibilities and started a [HackMD with regressions if PR applies](https://hackmd.io/CxycII6iT8iFjbMr0eQcEQ).
+
+### Unassigned P-high regressions
+
+- "`forbid` overwritten by later `allow` on the same "scope level"" [#70819](https://github.com/rust-lang/rust/issues/70819)
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "vec macro into_boxed codegen regression" [#71861](https://github.com/rust-lang/rust/issues/71861)
+- "'rustc' panicked at 'failed to lookup `SourceFile` in new context'" [#70924](https://github.com/rust-lang/rust/issues/70924)
+
+`libs-impl` nominations ...
+
+- "Regression in usable type complexity: overflow representing the type `...`" [#71359](https://github.com/rust-lang/rust/issues/71359)
+- "`nth_back()` for `Zip` returns wrong values" [#68536](https://github.com/rust-lang/rust/issues/68536)
+- "Backtrace is <unknown> for dynamic library loaded through dlopen using absolute file path for rust >= 1.37.0 on OSX" [#67599](https://github.com/rust-lang/rust/issues/67599)
+  - See [Alex comment](https://github.com/rust-lang/rust/issues/67599#issuecomment-628687241) maybe there's no point in keeping this one nominated.
+
+## WG checkins
+
+@**WG-traits** checkin by @**nikomatsakis**:
+
+> Checkin text

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-05-21.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-05-21.md
@@ -1,0 +1,110 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-05-21
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- We have a design meeting tomorrow: "codegen unit partitioning"
+- Major Changes Proposals:
+  - Seconded proposals (in FCP)
+    - "Implement LLVM-compatible source-based code coverage" [#278](https://github.com/rust-lang/compiler-team/issues/278)
+    - "Inline assembly" [#280](https://github.com/rust-lang/compiler-team/issues/280)
+    - "intern predicates, introduce forall/implies" [#285](https://github.com/rust-lang/compiler-team/issues/285)
+    - "Reintegrate chalk into rustc" [#289](https://github.com/rust-lang/compiler-team/issues/289) (NEW)
+    - "RFC 2229 implementation plan" [#292](https://github.com/rust-lang/compiler-team/issues/292) (NEW)
+  - New proposals (not seconded)
+    - "create windows target group" [#293](https://github.com/rust-lang/compiler-team/issues/293)
+    - "Remove Spans from HIR" [#294](https://github.com/rust-lang/compiler-team/issues/294)
+  - Old proposals (not seconded)
+    - "Integration of the Cranelift backend with rustc" [#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "illumos toolchain builds" [#279](https://github.com/rust-lang/compiler-team/issues/279)
+
+## Beta-nominations
+
+No beta nominations this time for `T-compiler` and `libs-impl`.
+
+There's one about `T-rustdoc` ...
+
+- "Bump pulldown-cmark" [#71682](https://github.com/rust-lang/rust/pull/71682) 
+
+## Stable-nominations
+
+No stable nominations this time.
+
+## PR's S-waiting-on-team
+
+No PR's waiting on team this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [41 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+)
+  - [21 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [3 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - There is only one P-high assigned.
+- [0 P-high, 4 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - There is only one P-medium assigned.
+- [72 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [25 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+There is one more `P-critical` issues and one less `P-high` issues in comparison with last week.
+
+### P-critical
+
+- "Unsoundness due to variance of trait objects WRT associated types" [#71550](https://github.com/rust-lang/rust/issues/71550)
+  - This issue is assigned to @spastorino and has an PR open.
+  - We've run crater and got a bunch of results.
+  - Niko is investigating possibilities and started a [HackMD with regressions if PR applies](https://hackmd.io/CxycII6iT8iFjbMr0eQcEQ).
+- "Trait object with non-static lifetime is accepted where static lifetime is expected and required" [#72315](https://github.com/rust-lang/rust/issues/72315)
+  - This issue is assigned to @matthewjasper
+  - This issue may be a variation of the previous one
+  - Needs mcve and we need to find out if it's a dupe of the previous one. 
+
+### Unassigned P-high regressions
+
+- "`forbid` overwritten by later `allow` on the same "scope level"" [#70819](https://github.com/rust-lang/rust/issues/70819)
+- "'rustc' panicked at 'failed to lookup `SourceFile` in new context'" [#70924](https://github.com/rust-lang/rust/issues/70924)
+  - This one is also nominated
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "'rustc' panicked at 'failed to lookup `SourceFile` in new context'" [#70924](https://github.com/rust-lang/rust/issues/70924)
+  - Incremental compilation regression
+  - There are reproduction steps and the [PR where this regressed identified](https://github.com/rust-lang/rust/issues/70924), PR by @eddyb.
+- "vec macro into_boxed codegen regression" [#71861](https://github.com/rust-lang/rust/issues/71861)
+  - codegen regression
+  - Cleanup Crew is pinged
+  - Unsure how much would we be able to discuss with the given information
+
+[libs-impl I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+
+- "Integer overflow on String::drain() with an inclusive range" [#72237](https://github.com/rust-lang/rust/issues/72237)
+  - There are a bunch of methods in stdlib with this same problem.
+- "Regression in usable type complexity: overflow representing the type `...`" [#71359](https://github.com/rust-lang/rust/issues/71359)
+  - Regression from beta to stable in a [rollup](https://github.com/rust-lang/rust/pull/70943)
+- "`nth_back()` for `Zip` returns wrong values" [#68536](https://github.com/rust-lang/rust/issues/68536)
+- "Backtrace is <unknown> for dynamic library loaded through dlopen using absolute file path for rust >= 1.37.0 on OSX" [#67599](https://github.com/rust-lang/rust/issues/67599)
+
+## WG checkins
+
+@**WG-traits** checkin by @**nikomatsakis**:
+
+> Checkin text
+
+@**WG-async-foundations** checkin by @**nikomatsakis**:
+
+> Checkin text
+
+@**WG-diagnostics** checkin by @**estebank**:
+
+> Checkin text

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-05-28.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-05-28.md
@@ -1,0 +1,160 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-05-28
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow (Friday 29th) we have a [design meeting: Compiler team 2020-2021 roadmap](https://github.com/rust-lang/compiler-team/issues/287)
+- Major Changes Proposals:
+  - Seconded proposals (in FCP)
+    - "Reintegrate chalk into rustc" [#289](https://github.com/rust-lang/compiler-team/issues/289)
+    - "RFC 2229 implementation plan" [#292](https://github.com/rust-lang/compiler-team/issues/292)
+    - "create windows working group" [#293](https://github.com/rust-lang/compiler-team/issues/293)
+    - "Remove Spans from HIR" [#294](https://github.com/rust-lang/compiler-team/issues/294)
+    - "move leak-check to during coherence, candidate eval" [#295](https://github.com/rust-lang/compiler-team/issues/295)
+    - "Introduce `ty_error`/`ty_error_with_message`/`ty_error_const` to construct error type or const" [#297](https://github.com/rust-lang/compiler-team/issues/297) (NEW)
+  - New proposals (not seconded)
+    - "Make `CONTRIBUTING.md` into a series of tutorials" [#296](https://github.com/rust-lang/compiler-team/issues/296)
+  - Old proposals (not seconded)
+    - "Integration of the Cranelift backend with rustc" [#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "illumos toolchain builds" [#279](https://github.com/rust-lang/compiler-team/issues/279)
+
+## Beta-nominations
+
+No beta nominations this time for `T-compiler` and `libs-impl`.
+
+## Stable-nominations
+
+No stable nominations this time for `T-compiler` and `libs-impl`.
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+
+- "Print environment variables accessed by rustc as special comments into depinfo files" [#71858](https://github.com/rust-lang/rust/pull/71858)
+  - In FCP, disposition to merge.
+
+No PR’s waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [5 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [40 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+)
+  - [17 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - Both P-high are assigned.
+- [3 P-critical, 1 P-high, 3 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - There is only 1 P-critical assigned.
+- [73 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [21 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+There are 3 more `P-critical` issues and 1 less `P-high` issues in comparison with last week.
+
+### P-critical
+
+- "Unsoundness due to variance of trait objects WRT associated types" [#71550](https://github.com/rust-lang/rust/issues/71550)
+  - This issue is assigned to @spastorino and has an [PR open](https://github.com/rust-lang/rust/pull/71896).
+  - Crater run from the fix suggested 16 non-spurious regressions.
+  - Niko suspects we should land the PR, at the start of a release cycle.
+- "Trait object with non-static lifetime is accepted where static lifetime is expected and required" [#72315](https://github.com/rust-lang/rust/issues/72315)
+  - This issue is related to the previous one, and fixed by the same PR.
+- "LLVM error: "Instruction does not dominate all uses!" on Windows" [#72470](https://github.com/rust-lang/rust/issues/72470)
+  - It is also a regression
+      - supposedly injected by [PR #71840](https://github.com/rust-lang/rust/pull/71840)
+      - (assign to matthew jasper?)
+  - Rejects valid code.
+  - It's windows only.
+  - This seems to indicate incorrect MIR being generated.
+- "Incorrect non-exhaustive pattern error" [#72476](https://github.com/rust-lang/rust/issues/72476)
+  - It is also a regression.
+      - supposedly injected by [PR #71930](https://github.com/rust-lang/rust/pull/71930)
+      - (assign to Nadrieril?)
+      - Has [an open PR](https://github.com/rust-lang/rust/pull/72506) that likely will fix the issue.
+  - Rejects valid code.
+  - Really quickly detected (2 days).
+  - Seems to be a problem when pattern matching on structs/enums which contain a projection.
+- "error: expected identifier when building time-macros-impl v0.1.1" [#72545](https://github.com/rust-lang/rust/issues/72545)
+  - It is also a regression.
+  - Detected on day one.
+  - Affects at least time, wasm-bindgen and syn.
+  - It was also reported as https://github.com/rust-lang/rust/issues/72608
+
+### Unassigned P-high regressions
+
+- "ICE in _match.rs:1184:21 when building "gfx-backend-metal" on Nightly" [#72467](https://github.com/rust-lang/rust/issues/72467)
+  - There's [a PR](https://github.com/rust-lang/rust/pull/72506) that may fix this issue.
+
+## Performance logs
+
+Triage done by njn.
+
+Regressions
+- [Update to LLVM 10](https://github.com/rust-lang/rust/pull/67759) ([instructions](https://perf.rust-lang.org/compare.html?start=0aa6751c19d3ba80df5b0b02c00bf44e13c97e80&end=82911b3bba76e73afe2881b732fe6b0edb35d5d3&stat=instructions:u)):
+  Lots of grumbling about this. wg-prioritization will consider at their next meeting?
+- [Intern predicates](https://github.com/rust-lang/rust/pull/72055) ([instructions](https://perf.rust-lang.org/compare.html?start=9310e3bd4f425f84fc27878ebf2bda1f30935a63&end=d9417b385145af1cabd0be8a95c65075d2fc30ff&stat=instructions:u)):
+  @lcnr has promised a follow-up to at least partly fix it, currently in
+  [#72494](https://github.com/rust-lang/rust/pull/72494).
+
+Improvements
+- [Remove ReScope](https://github.com/rust-lang/rust/pull/72362 ([instructions](https://perf.rust-lang.org/compare.html?start=3137f8e2d141d7d7c65040a718a9193f50e1282e&end=52b605c8cb2f730e607de0777a694cd1b9bb3e15&stat=instructions:u))
+- [Dumb NRVO](https://github.com/rust-lang/rust/pull/72205) ([instructions](https://perf.rust-lang.org/compare.html?start=963bf528292d8f97104515e32908e30c2467b6a8&end=7f79e98c0356642db62e5113327e436c951e843d&stat=instructions:u))
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- Should we backout LLVM 10?
+  - Update to LLVM 10 [#67759](https://github.com/rust-lang/rust/pull/67759)
+  - It's generating slower code.
+- "tag/niche terminology cleanup" [#72497](https://github.com/rust-lang/rust/pull/72497)
+
+[libs-impl I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+
+- "`nth_back()` for `Zip` returns wrong values" [#68536](https://github.com/rust-lang/rust/issues/68536)
+- "Backtrace is <unknown> for dynamic library loaded through dlopen using absolute file path for rust >= 1.37.0 on OSX" [#67599](https://github.com/rust-lang/rust/issues/67599)
+
+## WG checkins
+
+@**WG-rustc-dev-guide** checkin by @**spastorino**:
+
+>Accomplished:
+>
+>- [Overview chapter is now merged](https://github.com/rust-lang/rustc-dev-guide/pull/633)
+>    - [You can view it here](https://rustc-dev-guide.rust-lang.org/overview.html)
+>- Resolved tech debt:
+>    - [Added some notes from estabank about diagnostics](https://github.com/rust-lang/rustc-dev-guide/pull/524)
+>    - [Added more notes from ehuss about diagnostics](https://github.com/rust-lang/rustc-dev-guide/pull/716)
+>    - [Added some guidelines from ehuss on CLI flags](https://github.com/rust-lang/rustc-dev-guide/pull/717)
+>    - [Clean up the trait-solving chapters](https://github.com/rust-lang/rustc-dev-guide/pull/679)
+>    - [Make it possible to link to specific items in the glossary](https://github.com/rust-lang/rustc-dev-guide/pull/662)
+>    - [Finally finished the macro expansion chapter from discussions with petrochenkov (this is a long-standing hole)](https://github.com/rust-lang/rustc-dev-guide/pull/683)
+>    - [Added some (limited) notes about parallel compilation](https://github.com/rust-lang/rustc-dev-guide/pull/695)
+>    - [Added and updated notes on `rustc_interface` (thanks to georgewfraser)](https://rustc-dev-guide.rust-lang.org/rustc-driver.html)
+>    - [Resolved some old TODOs around the type system](https://github.com/rust-lang/rustc-dev-guide/pull/697)
+>    - [Added "Debugging rustc type layouts" (thanks Ralf!)](https://github.com/rust-lang/rustc-dev-guide/pull/720)
+>- [39 merged PRs](https://github.com/rust-lang/rustc-dev-guide/pulls?page=1&q=is%3Aclosed+closed%3A%3E2020-04-08)
+>- [15 closed issues (a few were very long-standing)](https://github.com/rust-lang/rustc-dev-guide/issues?q=is%3Aissue+is%3Aclosed+closed%3A%3E2020-04-08+)
+>
+>We've also had a few discussions to flesh out the guide vs forge content.
+>
+>Next steps:
+>
+>- Focus on triaging issues in the repo for a full sprint
+>    - Try to close/consolidate old issues, resolve low-hanging fruit
+>- Do a second pass about the organization of the guide
+>    - Re-visit part 1, decide what we want to keep vs the forge vs the compiler-team repo
+>    - Want to have a "Getting started" section at the front that has relatively straight-forward list of commands to do common things; move some content there from CONTRIBUTING.md
+>    - Thinking about an instrospection section that contains debugging/profiling/walkthrough/tools/etc.
+
+@**WG-llvm** checkin by @**nagisa**:
+
+> No updates
+

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-06-04.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-06-04.md
@@ -1,0 +1,171 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-06-04
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Today: 1.44 will be released :tada:
+- Tomorrow (Friday): We have our [planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html); you should [submit proposals!](https://forge.rust-lang.org/compiler/steering-meeting/submit.html)
+- Major Changes Proposals:
+  - Seconded proposals (in FCP)
+    - "RFC 2229 implementation plan" [#292](https://github.com/rust-lang/compiler-team/issues/292)
+    - "create windows working group" [#293](https://github.com/rust-lang/compiler-team/issues/293)
+    - "Remove Spans from HIR" [#294](https://github.com/rust-lang/compiler-team/issues/294)
+    - "move leak-check to during coherence, candidate eval" [#295](https://github.com/rust-lang/compiler-team/issues/295)
+    - "Introduce `ty_error`/`ty_error_with_message`/`ty_error_const` to construct error type or const" [#297](https://github.com/rust-lang/compiler-team/issues/297)
+    - "`mv src/lib{std,core,alloc,test,etc} std/lib{std,core,alloc,test,etc}`" [#298](https://github.com/rust-lang/compiler-team/issues/298)
+    - "Preserve `PlaceContext` through projections" [#300](https://github.com/rust-lang/compiler-team/issues/300)
+  - New proposals (not seconded)
+    - No new not seconded proposals
+  - Old proposals (not seconded)
+    - "Integration of the Cranelift backend with rustc" [#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "illumos toolchain builds" [#279](https://github.com/rust-lang/compiler-team/issues/279)
+    - "Make `CONTRIBUTING.md` into a series of tutorials" [#296](https://github.com/rust-lang/compiler-team/issues/296)
+
+## Beta-nominations
+
+No beta nominations this time for [`T-compiler`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler), [`libs-impl`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3Alibs-impl) and [`T-rustdoc`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-rustdoc).
+
+## Stable-nominations
+
+No stable nominations this time for [`T-compiler`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler), [`libs-impl`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3Alibs-impl) and [`T-rustdoc`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-rustdoc).
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+
+- "Print environment variables accessed by rustc as special comments into depinfo files" [#71858](https://github.com/rust-lang/rust/pull/71858)
+  - In FCP, disposition-merge
+  - Assigned to @**simulacrum** 
+- "Don't emit structure padding members if no padding is required." [#72541](https://github.com/rust-lang/rust/pull/72541)
+  - This is also nominated for T-compiler
+  - This needs discussion from some people with LLVM knowledge
+  - It sounds like eddyb is saying supporting SPIR-V isn't viable so we shouldn't take this patch regardless.
+  - Assigned to @**eddyb**
+- "Implement `--extern-location`" [#72603](https://github.com/rust-lang/rust/pull/72603)
+  - This is also nominated for T-compiler and T-cargo
+  - What process should we follow with this? MCP/RFC?
+  - Assigned to @**Matthew Jasper**
+
+No [libs-impl S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl).
+
+## Issues of Note
+
+### Short Summary
+
+- [4 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [37 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+)
+  - [16 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [3 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - All of them are unassigned.
+- [2 P-critical, 4 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - Only the P-criticals are assigned.
+- [71 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [17 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+There is one less `P-critical` issues and 3 less `P-high` issues in comparison with last week.
+
+### P-critical
+
+- "Unsoundness due to variance of trait objects WRT associated types" [#71550](https://github.com/rust-lang/rust/issues/71550)
+  - This issue is assigned to @**spastorino** and has an [PR open](https://github.com/rust-lang/rust/pull/71896).
+  - Crater run from the fix suggested 16 non-spurious regressions.
+  - Niko suspects we should land the PR, at the start of a release cycle.
+  - We are starting a new cycle, so should we merge?.
+- "Trait object with non-static lifetime is accepted where static lifetime is expected and required" [#72315](https://github.com/rust-lang/rust/issues/72315)
+  - This issue is related to the previous one, and fixed by the same [PR](https://github.com/rust-lang/rust/pull/71896).
+- "LLVM error: "Instruction does not dominate all uses!" on Windows" [#72470](https://github.com/rust-lang/rust/issues/72470)
+  - Assigned to @**pnkfelix**
+  - It is also a regression
+      - supposedly injected by [PR #71840](https://github.com/rust-lang/rust/pull/71840)
+  - Rejects valid code.
+  - It's windows only.
+  - This seems to indicate incorrect MIR being generated.
+  - We've decided to revert.
+- "ICE when structurally matching a struct containing an associated type on latest Nightly." [#72896](https://github.com/rust-lang/rust/issues/72896)
+  - Detected one day after the nightly release
+  - Breaks valid code
+  - Assigned to @**lcnr** 
+
+### Unassigned P-high regressions
+
+There are no unassigned P-high regressions.
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+Regressions
+- Nothing of note!
+
+Improvements
+- [perf: Revert accidental inclusion of a part of #69218](https://github.com/rust-lang/rust/pull/71996)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=2873165725c15e96dae521a412065c144d9c7a25&end=664fcd3f046e2a6824602da0fad81e3e2bb0d409&stat=instructions:u))
+- [Pass more `Copy` types by value.](https://github.com/rust-lang/rust/pull/72494)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=664fcd3f046e2a6824602da0fad81e3e2bb0d409&end=45127211566c53bac386b66909a830649182ab7a&stat=instructions:u)):
+  This fixes part of the regression from
+  [#72055](https://github.com/rust-lang/rust/pull/72055) from last week.
+- [Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/72778)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=91fb72a8a9f53de2bcc5638c1358fcb552dba8ce&end=74e80468347471779be6060d8d7d6d04e98e467f&stat=instructions:u))
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "tag/niche terminology cleanup" [#72497](https://github.com/rust-lang/rust/pull/72497)
+  - Nominated to determine if this is the terminology we want to use.
+  - Assigned to @**eddyb**
+- "Don't emit structure padding members if no padding is required." [#72541](https://github.com/rust-lang/rust/pull/72541)
+  - Nominated to determine if this is a patch we want to take. 
+      - @**eddyb** writes: "I don't think supporting SPIR-V is a plausible goal for the Rust LLVM backend, given all the limitations I've heard about. It would require a lot of transformation of anything involving memory IIRC."
+  - Assigned to @**eddyb**
+- "Implement `--extern-location`" [#72603](https://github.com/rust-lang/rust/pull/72603)
+  - Nominated:
+      - to determine what process should we follow with this. MCP/RFC?
+      - for visbility on the feature and to elicit review feedback.
+  - Assigned to @**Matthew Jasper**  
+- "Cycle error through variance computation when using `-> _`." [#72730](https://github.com/rust-lang/rust/issues/72730)
+    - (This is an issue)
+    - @**eddyb** nominated "for discussion (on the topic of variance of "function item" types)."
+
+[libs-impl I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+
+- "`nth_back()` for `Zip` returns wrong values" [#68536](https://github.com/rust-lang/rust/issues/68536)
+  - Nominated to determine how can we fix this problem and to raise awareness of it.
+
+## WG checkins
+
+@*T-compiler/WG-meta* checkin by @**nikomatsakis** and @**spastorino**:
+
+>- Merged the MCP RFC
+>- Proposed meeting and elaborated some on the idea of "areas" of the compiler
+>- Renamed ICE Breaker groups to notify groups
+>- Working on creating a Windows notification group -- will likely pull the trigger soon
+
+@*WG-mir-opt* checkin by @**oli**:
+
+>## Major things
+>* "dumb" NRVO optimization #72205
+>* Const prop now works on user variables #71518 
+>* Thread local storage accesses are now a dedicated runtime operation (mir rvalue) #71192
+>* Unused reads of discriminants are now removed, just like unused normal reads #70595 
+>* SimplifyLocals optimization is now run repeatedly to a fixed point #70755
+>* All mir-opt tests are now `--bless`able #70721
+>* Fearlessly optimize away constants #70820
+>* mir-opt-level 0 doesn't run optional optimizations anymore #70073
+>* MIR drop generation at MIR building time reworked into a structured scheme instead of ad-hoc generation #71840
+>* `Operand::Copy` of `&mut T` is unsound #72093 #72820
+>    * We now have a dedicated MIR validation pass that checks whether the result of your optimizations upholds a bunch of invariants. Please encode all  invariants you can think of in this pass in addition to documentation.
+>
+>## Interesting snippets
+>* MIR can have multiple `return` terminators and everything is fine #72563
+>* Make mir dumps less noisy #71200
+>* More aggressively const prop aggregates, mutable variables and field accesses #72135 #71953
+>* The `return` terminator is now treated as a read from `_0` (the return place)  #72048
+>* SimplifyArmIdentity can now run on mir-opt-level 1 #69756

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-06-11.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-06-11.md
@@ -1,0 +1,136 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-06-11
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Major Changes Proposals:
+  - New accepted proposals
+     - "`mv src/lib{std,core,alloc,test,etc} std/lib{std,core,alloc,test,etc}`" [#298](https://github.com/rust-lang/compiler-team/issues/298)
+- Seconded proposals (in FCP)
+  - "illumos toolchain builds" [#279](https://github.com/rust-lang/compiler-team/issues/279)
+  - "Make `CONTRIBUTING.md` into a series of tutorials" [#296](https://github.com/rust-lang/compiler-team/issues/296)
+  - "Preserve `PlaceContext` through projections" [#300](https://github.com/rust-lang/compiler-team/issues/300)
+  - "Make lang-items private" [#301](https://github.com/rust-lang/compiler-team/issues/301) (NEW)
+  - "`#[deny(unsafe_op_in_unsafe_fn)]` in liballoc" [#306](https://github.com/rust-lang/compiler-team/issues/306) (NEW)
+- New proposals (not seconded)
+  - "--extern-location to specify where an --extern dependency is defined" [#303](https://github.com/rust-lang/compiler-team/issues/303)
+  - "Support const parameters in type dependent paths" [#304](https://github.com/rust-lang/compiler-team/issues/304)
+- Old proposals (not seconded)
+  - "Integration of the Cranelift backend with rustc" [#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [#277](https://github.com/rust-lang/compiler-team/issues/277)
+- This week, and for future Thursday meetings, we will start presenting the WG checkins at the *start* of the meeting. Starting now. :wink:
+
+### WG checkins
+
+> @*WG-parallel-rustc* is inactive.
+
+> @*WG-polonius* has nothing to share this time.
+
+## Beta-nominations
+
+[`T-compiler`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-compiler)
+
+- "normalize adt fields during structural match checking" [#72897](https://github.com/rust-lang/rust/pull/72897) :back: / :hand:
+  - Beta fix for [this P-critical issue](https://github.com/rust-lang/rust/issues/72896)
+- "Revert pr 71840" [#72989](https://github.com/rust-lang/rust/pull/72989) :back: / :hand:
+  - Beta fix for [this P-critical issue](https://github.com/rust-lang/rust/issues/72470) by reverting [this PR](https://github.com/rust-lang/rust/pull/71840)
+- "Fix link error with #[thread_local] introduced by #71192" [#73065](https://github.com/rust-lang/rust/pull/73065) :back: / :hand:
+  - This PR is nominated but is not merged yet
+- "Revert #71956" [#73153](https://github.com/rust-lang/rust/pull/73153) :back: / :hand:
+  - This fixes on beta [this P-critical issue](https://github.com/rust-lang/rust/issues/73137) by reverting [this PR](https://github.com/rust-lang/rust/pull/71956)
+
+No beta nominations this time for [`libs-impl`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3Alibs-impl) and [`T-rustdoc`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Abeta-nominated+label%3AT-rustdoc).
+
+## Stable-nominations
+
+No stable nominations this time for [`T-compiler`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-compiler), [`libs-impl`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3Alibs-impl) and [`T-rustdoc`](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3Astable-nominated+label%3AT-rustdoc).
+
+* https://github.com/rust-lang/rust/pull/73238
+* simulacrum is thinking to unilaterally accept these changes for stable backport (but if people object, we can discuss).
+
+## PR's S-waiting-on-team
+
+[T-compiler S-waiting-on-team](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+
+- "Implement `--extern-location`" [#72603](https://github.com/rust-lang/rust/pull/72603)
+  - This was already discussed last week
+  - [an MCP was filled](https://github.com/rust-lang/compiler-team/issues/303) for this one
+  - Assigned to @**Matthew Jasper** and @**nikomatsakis**
+- "`#[deny(unsafe_op_in_unsafe_fn)]` in liballoc" [#72709](https://github.com/rust-lang/rust/pull/72709)
+  - Feels like a policy question
+  - [An MCP was filed](https://github.com/rust-lang/compiler-team/issues/306) for this one.
+  - @**nikomatsakis** is in favor of landing it
+
+
+## Issues of Note
+
+### Short Summary
+
+- [3 P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [39 P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+)
+  - [17 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 5 P-medium regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+  - There is only 1 P-critical and 1 P-medium assigned.
+- [1 P-critical, 4 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+  - Only the P-critical is assigned.
+- [70 regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+  - [14 of those are not prioritized](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-stable+-label%3AP-critical+-label%3AP-high+-label%3AP-medium+-label%3AP-low).
+
+There is 1 less `P-critical` issues and 2 more `P-high` issue in comparison with last week.
+
+### P-critical
+
+- "LLVM error: "Instruction does not dominate all uses!" on Windows" [#72470](https://github.com/rust-lang/rust/issues/72470)
+  - This has been fixed by this [PR](https://github.com/rust-lang/rust/pull/72989)
+  - This [should probably not be `P-critical` anymore](https://github.com/rust-lang/rust/issues/72470#issuecomment-642271780)
+- "Double Drop on Rust beta" [#73137](https://github.com/rust-lang/rust/issues/73137)
+  - This has been fixed by this [PR](https://github.com/rust-lang/rust/pull/73153)
+  - This [should probably not be `P-critical` anymore](https://github.com/rust-lang/rust/issues/73137#issuecomment-642279433)
+- "Slice index becomes wrong (beta regression)" [#73223](https://github.com/rust-lang/rust/issues/73223)
+  - This is a regression from stable to beta
+  - [It's also a fairly easy to trigger miscompilation](https://github.com/rust-lang/rust/issues/73223#issuecomment-642530618)
+  - [Regressed PR was identified](https://github.com/rust-lang/rust/pull/69756)
+  - Assigned to @**Wesley Wiser** who is already on it
+
+### Unassigned P-high regressions
+
+No unassigned P-high regressions this time.
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+Regressions:
+- [Update LLVM submodule to include lld NOLOAD fix](https://github.com/rust-lang/rust/pull/73072#issuecomment-640225441)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=450abe80f193ccefbfcd48214d70520f2d507f0e&end=a2fc33e0c87a258542cd12d6ffae52c43aa3785a&stat=instructions:u)):
+  A small regression in debug builds due to LLVM. Pulling in [this LLVM
+  change](https://reviews.llvm.org/D80964) may fix it.
+- [Rollup of 5 pull requests](https://github.com/rust-lang/rust/pull/73081#issuecomment-640951745)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=9c1857fad849ad56d38327b9bc11377a0bdbb4cf&end=450abe80f193ccefbfcd48214d70520f2d507f0e&stat=instructions:u))
+
+Improvements:
+- None.
+
+## Nominated Issues
+
+[T-compiler I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "Backtraces don't work during ICE" [#71060](https://github.com/rust-lang/rust/issues/71060)
+    - Nominated because: "Rustc ICE backtraces are totally broken on windows-gnu (Tier 1) platform."
+    - Assigned: No one
+    - @**Alex Crichton** has a partial fix downstream. He says [there are three potential ways to fix this for rustc](https://github.com/rust-lang/rust/issues/71060#issuecomment-642203477).
+- "`#[deny(unsafe_op_in_unsafe_fn)]` in liballoc" [#72709](https://github.com/rust-lang/rust/pull/72709)
+    - Nominated for discussion by @**nikomatsakis**: Do we want to make use of the new `unsafe_op_in_unsafe_fn` lint? 
+    - Assigned: @**Mark-Simulacrum**
+    - Some reviews have already been done. It seems like we just want to see if anyone disagrees with landing this.
+
+[libs-impl I-nominated](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+
+- "`nth_back()` for `Zip` returns wrong values" [#68536](https://github.com/rust-lang/rust/issues/68536)
+  - Nominated to determine how can we fix this problem and to raise awareness of it.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-06-18.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-06-18.md
@@ -1,0 +1,177 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-06-18
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Major Changes Proposals:
+  - New accepted proposals
+    - "Preserve `PlaceContext` through projections" [#300](https://github.com/rust-lang/compiler-team/issues/300)
+    - "Make lang-items private" [#301](https://github.com/rust-lang/compiler-team/issues/301)
+  - Seconded proposals (in FCP)
+    - "illumos toolchain builds" [#279](https://github.com/rust-lang/compiler-team/issues/279)
+    - "Make `CONTRIBUTING.md` into a series of tutorials" [#296](https://github.com/rust-lang/compiler-team/issues/296)
+    - "Support const parameters in type dependent paths" [#304](https://github.com/rust-lang/compiler-team/issues/304)
+    - "`#[deny(unsafe_op_in_unsafe_fn)]` in liballoc" [#306](https://github.com/rust-lang/compiler-team/issues/306)
+  - New proposals (not seconded)
+    - "Move Rust provided objects, libraries and binaries meant for self-contained linkage to separate directory" [#310](https://github.com/rust-lang/compiler-team/issues/310)
+    - "RISC-V Linux Tier 2 Host support" [#312](https://github.com/rust-lang/compiler-team/issues/312)
+    - "Switch from libbacktrace to gimli" [#313](https://github.com/rust-lang/compiler-team/issues/313)
+  - Old proposals (not seconded)
+    - "Integration of the Cranelift backend with rustc" [#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "--extern-location to specify where an --extern dependency is defined" [#303](https://github.com/rust-lang/compiler-team/issues/303)
+
+- Unilateral beta backport approvals
+    - "Make novel structural match violations not a `bug`" [#73446](https://github.com/rust-lang/rust/pull/73446)
+    - "Don't create impl candidates when obligation contains errors" [#73005](https://github.com/rust-lang/rust/pull/73005)
+
+### WG checkins
+
+@*WG-prioritization* checkin by @**spastorino**:
+>- We are now executing our process fully async and have bi-weekly planning/steering meetings to think about things to improve.
+>- We've prioritized all `I-unsound 💥` issues for `T-compiler` and `libs-impl`.
+>  - From now on, new issues tagged with `I-unsound 💥` will automatically add `I-prioritize` and then request prioritization to the wg.
+>- There are not unprioritized regressions anymore :tada:
+>  - We've prioritized all `regression-from-stable-to-stable` issues for `T-compiler` and `libs-impl`.
+>  - From now on new issues tagged with `regression-from-stable-to-stable` will automatically add `I-prioritize` and then request prioritization to the wg.
+>  - Same happens for `regression-from-stable-to-beta` and `regression-from-stable-to-nightly`.
+>- We are in the process of automating most of our procedure.
+
+@*WG-rfc-2229* checkin by @**nikomatsakis**:
+> * We've created a repository to track the issues and work, [rust-lang/project-rfc-2229](https://github.com/rust-lang/project-rfc-2229)
+> * Currently doing some core refactorings, improving the "HIR place" datastructure to /IU be sufficiently precise, and refactoring how closures represent captures to use that instead of individual variables
+
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Ensure stack when building MIR for matches" [#72941](https://github.com/rust-lang/rust/pull/72941)
+  - [Fixes stack overflow](https://github.com/rust-lang/rust/issues/72933)
+- "Fix link error with #[thread_local] introduced by #71192" [#73065](https://github.com/rust-lang/rust/pull/73065)
+  - Fixes an error introduced by "[Make TLS accesses explicit in MIR #71192 ](https://github.com/rust-lang/rust/pull/71192)"
+- "Reoder order in which MinGW libs are linked to fix recent breakage" [#73184](https://github.com/rust-lang/rust/pull/73184)
+  - "Recent upstream mingw-w64 changes made libmsvcrt depend on libmingwex breaking compilation in some cases when using external MinGW."
+- "Allow inference regions when relating consts" [#73225](https://github.com/rust-lang/rust/pull/73225)
+  - Fixes ICE "generator_interior.rs impossible case reached" [#73050](https://github.com/rust-lang/rust/issues/73050)
+- "Disable the `SimplifyArmIdentity` pass" [#73262](https://github.com/rust-lang/rust/pull/73262)
+  - This is the beta nomination for a `P-critical` issue.
+- "linker: Never pass `-no-pie` to non-gnu linkers" [#73384](https://github.com/rust-lang/rust/pull/73384)
+  - Fixes "linking error: unknown agrument `-no-pie`" [#73370](https://github.com/rust-lang/rust/issues/73370)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+There are no issues this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+There are no issues this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+There are no issues this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+There are no issues this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+There are no issues this time.
+
+:back: / :shrug: / :hand:
+
+## PR's S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Implement `--extern-location`" [#72603](https://github.com/rust-lang/rust/pull/72603)
+  - This was already discussed last week
+  - [an MCP is pending](https://github.com/rust-lang/compiler-team/issues/303)
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+There are no issues this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [49 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [26 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 1 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 1 P-high, 4 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 14 P-high, 45 P-medium, 4 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Slice index becomes wrong (beta regression)" [#73223](https://github.com/rust-lang/rust/issues/73223)
+  - It's a regression from stable to beta
+  - [PR is merged already on nightly](https://github.com/rust-lang/rust/pull/73262)
+  - It's beta nominated
+- "ICE: could not fully normalize" [#73249](https://github.com/rust-lang/rust/issues/73249)
+  - It's a regression from stable to nightly
+  - [It has a PR already r+ed](https://github.com/rust-lang/rust/pull/73257)
+- "ICE: MIR const-checker found novel structural match violation" [#73431](https://github.com/rust-lang/rust/issues/73431) 
+  - ICE when matching with a trait constant
+  - Beta regression caused by [#67343](https://github.com/rust-lang/rust/pull/67343) (@**ecstatic-morse**)
+  - Breaks previously accepted code, should be fixed and backported before it gets to stable
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+There are no issues this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+There are no issues this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "Unreasonably long (and useless) error message doing modulo on non-existent variable: overflow evaluating the requirement `typenum::UInt<typenum::UInt..." [#72839](https://github.com/rust-lang/rust/issues/72839)
+  - [PR is merged already](https://github.com/rust-lang/rust/pull/73005)
+  - It's already beta accepted
+  - So this is waiting for a beta backport
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+There are no issues this time.
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+Some bustage involving Cargo meant that some merges in this period didn't get measured.
+
+Regressions:
+- [Rollup of 10 pull requests](https://github.com/rust-lang/rust/pull/73367#issuecomment-644456094) ([instructions](https://perf.rust-lang.org/compare.html?start=ce6d3a73b514e9649e57cee812ad129bb2112016&end=d4ecf31efc2309fb6df8c2a8af9aaf8176ab1c8d&stat=instructions:u)):
+  Regressed up to 3.5% on multiple benchmarks. Maybe [#71824](https://github.com/rust-lang/rust/pull/71824) is the cause?
+- [Disable the `SimplifyArmIdentity` pass](https://github.com/rust-lang/rust/pull/73262#issuecomment-644451010) ([instructions](https://perf.rust-lang.org/compare.html?start=7c78a5f97de07a185eebae5a5de436c80d8ba9d4&end=f4fbb93113aa4f0a0cd08e74afb35381bbfbc7f0&stat=instructions:u)):
+  A small regression on a couple of benchmarks from disabling a buggy pass,
+  which may be re-enabled in the future?
+- A small regression occurred for `syn-opt`, but I can't tell which PR was
+  responsible because the improvement occurred in one of the merges that wasn't
+  measured due to the Cargo bustage.
+
+Improvements:
+- Some huge improvements occurred for `clap-rs-opt`, but I can't tell which PR was responsible because the improvement occurred in one of the merges that wasn't measured due to the Cargo bustage.
+- [Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/73316#issuecomment-644453724) ([instructions](https://perf.rust-lang.org/compare.html?start=1fb612bd15bb3ef098fd24c20d0727de573b4410&end=06e47688bf15d0215edbe05b21603062f6d2eb5d&stat=instructions:u)):
+  A small improvement on `many-assoc-items`, and a tiny regression on a couple of other benchmarks.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Type mismatching cased by duplicate associated type resolution" [#59326](https://github.com/rust-lang/rust/issues/59326)
+  - Unassigned P-high regression
+  - Culprit likely to be [#56837](https://github.com/rust-lang/rust/pull/56837)
+- "Incorrect compilation / STATUS_ACCESS_VIOLATION when linking with lld with target-cpu set" [#72145](https://github.com/rust-lang/rust/issues/72145)
+  - Metabug: "Use lld by default on x64 msvc windows" [#71520](https://github.com/rust-lang/rust/issues/71520)
+- "mv std libs to std/" [#73265](https://github.com/rust-lang/rust/pull/73265)
+  - PR to move the stdlib crates to the `std/` folder
+  - [Proposes](https://github.com/rust-lang/rust/pull/73265#issuecomment-643416610) the following directory structure: `std/<crate>/src/*.rs` (i.e. one `src/` folder per crate)
+- "f32::powi on Windows returns different results between 1.44 and 1.45 beta" [#73420](https://github.com/rust-lang/rust/issues/73420)
+  - Nominated with intention of raising awareness of this LLVM 10 change and to discuss briefly what to do. Do we want to add some relnotes?.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+There are no issues this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-06-25.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-06-25.md
@@ -1,0 +1,222 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-06-25
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Design meeting tomorrow (Friday): Areas of the compiler [compiler-team#288](https://github.com/rust-lang/compiler-team/issues/288)
+- Major Changes Proposals:
+  - New accepted proposals
+    - "Make `CONTRIBUTING.md` into a series of tutorials" [#296](https://github.com/rust-lang/compiler-team/issues/296)
+    - "Preserve `PlaceContext` through projections" [#300](https://github.com/rust-lang/compiler-team/issues/300)
+    - "Make lang-items private" [#301](https://github.com/rust-lang/compiler-team/issues/301)
+    - "`#[deny(unsafe_op_in_unsafe_fn)]` in liballoc" [#306](https://github.com/rust-lang/compiler-team/issues/306)
+  - Seconded proposals (in FCP)
+    - "illumos toolchain builds" [#279](https://github.com/rust-lang/compiler-team/issues/279)
+    - "Support const parameters in type dependent paths" [#304](https://github.com/rust-lang/compiler-team/issues/304)
+    - "`#![deny(unsafe_op_in_unsafe_fn)]` in libcore and libstd" [#317](https://github.com/rust-lang/compiler-team/issues/317)
+    - "-Zmir-opt-level Reform" [#319](https://github.com/rust-lang/compiler-team/issues/319)
+    - "Move CONTRIBUTING.md to rustc-dev-guide and instead point to Getting Started" [#320](https://github.com/rust-lang/compiler-team/issues/320)
+  - New proposals (not seconded)
+    - "Add future-incompat entries to json diagnostic output" [#315](https://github.com/rust-lang/compiler-team/issues/315)
+    - "MCP: Reorganize the rust-lang/rust repo directory structure" [#316](https://github.com/rust-lang/compiler-team/issues/316)
+    - "Portable SIMD project group" [#321](https://github.com/rust-lang/compiler-team/issues/321)
+  - Old proposals (not seconded)
+    - "Integration of the Cranelift backend with rustc" [#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "--extern-location to specify where an --extern dependency is defined" [#303](https://github.com/rust-lang/compiler-team/issues/303)
+    - "Move Rust provided objects, libraries and binaries meant for self-contained linkage to separate directory" [#310](https://github.com/rust-lang/compiler-team/issues/310)
+    - "RISC-V Linux Tier 2 Host support" [#312](https://github.com/rust-lang/compiler-team/issues/312)
+    - "Switch from libbacktrace to gimli" [#313](https://github.com/rust-lang/compiler-team/issues/313)
+
+### WG checkins
+
+@*WG-rls2.0* checkin by @**matklad**:
+>#### [RFC2912](https://github.com/rust-lang/rfcs/pull/2912) progress:
+>
+>* protocol conformance problems mostly fixed (there are no incompats which are known to cause significant issues, there might be some de-jure bugs though)
+>* all protocol extensions are documented at: https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md
+>  * Upstream issues: https://github.com/microsoft/language-server-protocol/issues/created_by/matklad
+>  * Subscribe to https://github.com/rust-analyzer/rust-analyzer/issues/4604 to receive notifications about new extensions.
+>* shipping via rustup is in progress: https://github.com/rust-lang/rust/pull/72978
+>  * currently soft-blocked on someone figuring out building from vendored sources (needs just impl work)
+>* initial support of rust-analyzer in the official rust-lang extension (using rust-analyzer extension is still recommended though)
+>
+>#### Org progress:
+>
+>* @**Jonas Schievink** joined rust-analyzer.
+>  We finally have a shared expert between rustc and rust-analyzer, :tada:
+>* Rate of PRs exceeds review capacity.
+>* Official help and discussion forum category: https://users.rust-lang.org/c/ide/14
+>
+>#### Impl progress:
+>
+>* Documentation for features is now generated from the source code, and contains links to the source code:
+>  https://rust-analyzer.github.io/manual.html#features.
+>* (as of yesterday) new semantic-less IR (`ItemTree`) to avoid repeated reparsing of files.
+>* A bunch of perf & memory usage improvements.
+>* Semantic syntax highlighting of doc comments.
+>* Chalk updates and various assorted fixes to the type inference.
+>* Better support for non-cargo based projects.
+>* New (final hopefully?) implementation of Virtual File System
+
+@*WG-self-profile* checkin by @**Wesley Wiser**:
+> - Some other Rust projects have shown interest in using `measureme` in their crates.
+>   Boa, a JavaScript interpreter written in Rust, has done the integration [with some cool results](https://github.com/boa-dev/boa/pull/317#issuecomment-636464496).
+> - We've made a few small changes to the `summarize` command output to hide columns that are rustc specific when that data isn't present.
+> - @**Wesley Wiser** has started working on a tool to "blame" compile time to `DefId`s.
+>   - It's too early to really show anything off because it barely works at all.
+>   - One major issue is that we can't see inside LLVM so ~80% of compilation time for crates tested so far is just blamed to LLVM. That's not particularly useful.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Change how compiler-builtins gets many CGUs" [#73136](https://github.com/rust-lang/rust/pull/73136)
+  - Fixes [#73135](https://github.com/rust-lang/rust/issues/73135), a `P-medium` performance regression.
+  - Changes how compiler builtins are built.
+  - Only 1 addition and 9 deletions to the compiler, and one new option in `Cargo.toml`.
+- "Reoder order in which MinGW libs are linked to fix recent breakage" [#73184](https://github.com/rust-lang/rust/pull/73184)
+  - "Recent upstream mingw-w64 changes made libmsvcrt depend on libmingwex breaking compilation in some cases when using external MinGW."
+  - This one [was discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-06-18.20.2354818/near/201275224). We decided to wait a week.
+  - According to @**Vadim Petrochenkov** ["CI has old mingw and this PR passed it."](https://github.com/rust-lang/rust/pull/73184#issuecomment-646078056)
+- "Perform obligation deduplication to avoid buggy `ExistentialMismatch`" [#73485](https://github.com/rust-lang/rust/pull/73485)
+  - Not merged yet into master.
+  - Fixes a `P-high` stable regression from 1.33.0, #59326, rejecting previously valid code. See [MCVE](https://github.com/rust-lang/rust/issues/59326#issuecomment-645911137).
+  - Changes from this PR are very minimal, with 13 additions and 3 deletions.
+  - [Tested to incur no performance regression.](https://perf.rust-lang.org/compare.html?start=e55d3f9c5213fe1a25366450127bdff67ad1eca2&end=c9f613bb7aaebcb256e34b959196f56f62ca74c8)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- "rustdoc: Fix doc aliases with crate filtering" [#73644](https://github.com/rust-lang/rust/pull/73644)
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Perform obligation deduplication to avoid buggy `ExistentialMismatch`" [#73485](https://github.com/rust-lang/rust/pull/73485)
+  - Was also beta nominated.
+  - Not merged yet into master.
+  - Fixes a `P-high` stable regression from 1.33.0, #59326, rejecting previously valid code. See [MCVE](https://github.com/rust-lang/rust/issues/59326#issuecomment-645911137).
+  - Changes from this PR are very minimal, with 13 additions and 3 deletions.
+  - [Tested to incur no performance regression.](https://perf.rust-lang.org/compare.html?start=e55d3f9c5213fe1a25366450127bdff67ad1eca2&end=c9f613bb7aaebcb256e34b959196f56f62ca74c8)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Implement `--extern-location`" [#72603](https://github.com/rust-lang/rust/pull/72603)
+  - This was discussed 2 weeks ago
+  - [an MCP is pending](https://github.com/rust-lang/compiler-team/issues/303) and waiting to be seconded
+  - [According to @**nikomatsakis** it seems that it have reached a stopping point](https://github.com/rust-lang/compiler-team/issues/303#issuecomment-647584102)
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs wiating on libs-impl this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [48 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [27 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 1 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 4 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 14 P-high, 44 P-medium, 4 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Slice index becomes wrong (beta regression)" [#73223](https://github.com/rust-lang/rust/issues/73223)
+  - It's a regression from stable to beta
+  - [PR is merged already on nightly](https://github.com/rust-lang/rust/pull/73262)
+  - It's beta accepted, so this is waiting for the actual backport
+- "ICE: MIR const-checker found novel structural match violation" [#73431](https://github.com/rust-lang/rust/issues/73431)
+  - ICE when matching with a trait constant
+  - Beta regression caused by [#67343](https://github.com/rust-lang/rust/pull/67343) (@**ecstatic-morse**)
+  - [PR is merged already on nightly](https://github.com/rust-lang/rust/pull/73446)
+  - It's beta accepted, so this is waiting for the actual backport
+- "cannot create local mono-item for DefId" [#73537](https://github.com/rust-lang/rust/issues/73537)
+  - [Labeled as `P-critical` to raise awareness](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/I-prioritize.20.2373537.20cannot.20create.20local.20mono-item.20for.20DefId)
+  - [This seems to be fixed seeing some of the latest comments](https://github.com/rust-lang/rust/issues/73537#issuecomment-649364509), still needs a test.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "Unreasonably long (and useless) error message doing modulo on non-existent variable: overflow evaluating the requirement `typenum::UInt<typenum::UInt…" [#72839](https://github.com/rust-lang/rust/issues/72839)
+  - [PR is merged already](https://github.com/rust-lang/rust/pull/73005)
+  - It's already beta accepted
+  - So this is waiting for a beta backport
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- No unassigned P-high nightly regressions this time.
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs).
+Latest revision: 6bb3dbfc6c6d8992d08431f320ba296a0c2f7498.
+
+*Lots of improvements this week!* :tada:
+
+Having done this for a few weeks now, I see that close to half of the PRs with significant performance effects are rollups.
+
+Regressions
+- None.
+
+Improvements
+- [Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/73563#issuecomment-647319856)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=f455e46eae1a227d735091091144601b467e1565&end=7058471adec80a2a1e6092443e08546768c9c894&stat=instructions:u), [max-rss](https://perf.rust-lang.org/compare.html?start=f455e46eae1a227d735091091144601b467e1565&end=7058471adec80a2a1e6092443e08546768c9c894&stat=max-rss)):
+  Up to 33.6% instruction wins on a stress test, and up to 10.3% instructions
+  wins on several real-world benchmarks. Also a max-rss win.
+  [#72788](https://github.com/rust-lang/rust/pull/72788) may be the cause?
+- [Cache flags and escaping vars for predicates](https://github.com/rust-lang/rust/pull/73180#issuecomment-647824906)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=a8cf3991177f30694200002cd9479ffbbe6d9a1a&end=1a4e2b6f9c75a0e21722c88a0e3b610d6ffc3ae3&stat=instructions:u)):
+  Up to 4.9% wins across numerous benchmarks.
+- [store `ObligationCause` on the heap](https://github.com/rust-lang/rust/pull/72962#issuecomment-647822868)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=f315c35a77e40bd11ce81fedc0556be0f410bbf4&end=c8a9c340de32cb70c8bad8af1a4474f805c5a969&stat=instructions:u)):
+  Up to 3.5% wins across numerous benchmarks.
+- [Upgrade Chalk](https://github.com/rust-lang/rust/pull/72936#issuecomment-647829776)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=349f6bfb11d73ebb6a272f9a3d00883484f8218c&end=a8cf3991177f30694200002cd9479ffbbe6d9a1a&stat=instructions:u)):
+  Up to 1.5% wins across numerous benchmarks.
+- [Rollup of 13 pull requests](https://github.com/rust-lang/rust/pull/73511#issuecomment-647828029)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=2d8bd9b74dc0cf06d881bac645698ccbcf9d9c5e&end=34c5cd9a64d8537236626c4ccbed39a924cd38e2&stat=instructions:u)):
+  Up to 1.5% wins across numerous benchmarks.
+- [Rollup of 16 pull requests](https://github.com/rust-lang/rust/pull/73528#issuecomment-647827323)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=34c5cd9a64d8537236626c4ccbed39a924cd38e2&end=033013cab3a861224fd55f494c8be1cb0349eb49&stat=instructions:u)):
+  Up to 3.4% wins on `wg-grammar`, little change elsewhere.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Type mismatching cased by duplicate associated type resolution" [#59326](https://github.com/rust-lang/rust/issues/59326)
+  - Unassigned P-high regression
+  - Culprit likely to be [#56837](https://github.com/rust-lang/rust/pull/56837)
+- "target_feature_11 allows bypassing safety checks through Fn* traits" [#72012](https://github.com/rust-lang/rust/issues/72012)
+- "Incorrect compilation / STATUS_ACCESS_VIOLATION when linking with lld with target-cpu set" [#72145](https://github.com/rust-lang/rust/issues/72145)
+  - Metabug: "Use lld by default on x64 msvc windows" [#71520](https://github.com/rust-lang/rust/issues/71520)
+- "[regression] empty shebang parsing" [#73250](https://github.com/rust-lang/rust/issues/73250)
+- "f32::powi on Windows returns different results between 1.44 and 1.45 beta" [#73420](https://github.com/rust-lang/rust/issues/73420)
+  - Nominated with intention of raising awareness of this LLVM 10 change and to discuss briefly what to do. Do we want to add some relnotes?.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-07-02.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-07-02.md
@@ -1,0 +1,196 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-07-02
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- We have a planning scheduled for tomorrow (friday 3rd), but [tomorrow is a US holiday and @**nikomatsakis** was asking if we are having this meeting or we should skip it](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/2020-07-03.20Planning.20meeting)
+- New MCPs (take a look, see if you like them!)
+    - "Change `ty::Const` to an integer tree representation" [compiler-team#323](https://github.com/rust-lang/compiler-team/issues/323)
+    - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+- Old MCPs (not seconded, take a look)
+    - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "--extern-location to specify where an --extern dependency is defined" [compiler-team#303](https://github.com/rust-lang/compiler-team/issues/303)
+    - "Move Rust provided objects, libraries and binaries meant for self-contained linkage to separate directory" [compiler-team#310](https://github.com/rust-lang/compiler-team/issues/310)
+    - "Add future-incompat entries to json diagnostic output" [compiler-team#315](https://github.com/rust-lang/compiler-team/issues/315)
+    - "MCP: Reorganize the rust-lang/rust repo directory structure" [compiler-team#316](https://github.com/rust-lang/compiler-team/issues/316)
+- Pending FCP requests (check your boxes!)
+    - "Stabilize control-flow-guard codegen option" [rust#73893](https://github.com/rust-lang/rust/pull/73893)
+- Things in FCP (make sure you're good with it)
+    - "illumos toolchain builds" [compiler-team#279](https://github.com/rust-lang/compiler-team/issues/279)
+    - "RISC-V Linux Tier 2 Host support" [compiler-team#312](https://github.com/rust-lang/compiler-team/issues/312)
+    - "Switch from libbacktrace to gimli" [compiler-team#313](https://github.com/rust-lang/compiler-team/issues/313)
+    - "`#![deny(unsafe_op_in_unsafe_fn)]` in libcore and libstd" [compiler-team#317](https://github.com/rust-lang/compiler-team/issues/317)
+    - "-Zmir-opt-level Reform" [compiler-team#319](https://github.com/rust-lang/compiler-team/issues/319)
+    - "Move CONTRIBUTING.md to rustc-dev-guide and instead point to Getting Started" [compiler-team#320](https://github.com/rust-lang/compiler-team/issues/320)
+    - "mv std libs to std/" [rust#73265](https://github.com/rust-lang/rust/pull/73265)
+- Accepted MCPs
+    - "Support const parameters in type dependent paths" [compiler-team#304](https://github.com/rust-lang/compiler-team/issues/304)
+
+### WG checkins
+
+@*WG-traits* checkin by @**Jack Huey**:
+>* We are finishing up 2020 sprint 3 (ends Jul. 7th)
+>* Set up weekly releases of Chalk
+>    * Needed for rustc integration and rust-analyzer publishing
+>* rustc work
+>    * Work by @lcnr on refactoring `Predicate`, including interning and introducing `ForAll`
+>    * Work by Matthew Jaspar pushing GATs
+>    * Chalk integration is getting updated as new Chalk features are integrated
+>        * Still quite a bit to be done, but progress is being made
+>* Chalk work
+>    * Two separate solvers - SLG and recursive
+>        * We eventually want to settle on one, but for now, work is being done on both
+>    * Some initial work on writing `.chalk` files for reproducing issues
+>    * Getting close to supporting all builtin types and traits
+>        * Recently added `Fn` family and closures
+>        * Support for `enum`s has a PR
+>        * `Generator`/`GeneratorWitness` work being done by @Aaron Hill
+>        * Need full support for auto traits of builtin types
+>        * `Unpin`/`CoerceUnsized`/`DispatchFromDyn` traits need to be implemented
+>        * Subtyping is being worked on with WIP PR
+>* Overall, the past 3 sprints have been super productive
+>    * Lots of interest and activity
+>* Taking a summer break from meetings & sprints, picking back up in September
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Change how compiler-builtins gets many CGUs" [rust#73136](https://github.com/rust-lang/rust/pull/73136)
+  - This one was discussed and approved on our last meeting but is lacking the `beta-accepted` label. 
+- "Reoder order in which MinGW libs are linked to fix recent breakage" [rust#73184](https://github.com/rust-lang/rust/pull/73184)
+  - Approved on our last meeting but lacks `beta-accepted` label.
+- "Perform obligation deduplication to avoid buggy `ExistentialMismatch`" [rust#73485](https://github.com/rust-lang/rust/pull/73485)
+  - Approved on our last meeting but PR wasn't merged at that time, now it is already merged so it can be labelled with `beta-accepted`.
+- "rustc_lexer: Simplify shebang parsing once more" [rust#73596](https://github.com/rust-lang/rust/pull/73596)
+  - Fixes [a beta regression about parsing an empty shebang (admittedly questionable code)](https://github.com/rust-lang/rust/issues/73250)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- "rustdoc: Fix doc aliases with crate filtering" [rust#73644](https://github.com/rust-lang/rust/pull/73644)
+  - Approved on our last meeting but lacks `beta-accepted` label.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Perform obligation deduplication to avoid buggy `ExistentialMismatch`" [rust#73485](https://github.com/rust-lang/rust/pull/73485)
+  - Also beta nominated
+  - Approved on our last meeting but PR wasn't merged at that time, now it is already merged so it can be labelled with `stable-accepted`.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Implement `--extern-location`" [rust#72603](https://github.com/rust-lang/rust/pull/72603)
+  - [@**nikomatsakis** thinks it's reasonable to land this even though we've not figured out the cargo integration story, but he would reluctant to stabilize, however, until we have a clearer picture of what's happening with cargo.](https://github.com/rust-lang/rust/pull/72603#issuecomment-649705763)
+  - Last minute edit: [MCP was just seconded](https://github.com/rust-lang/compiler-team/issues/303)
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on libs-impl this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [47 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [25 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 0 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 1 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 13 P-high, 44 P-medium, 4 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "cannot create local mono-item for DefId" [rust#73537](https://github.com/rust-lang/rust/issues/73537)
+  - Discussed last week
+  - [Labeled as `P-critical` to raise awareness](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/I-prioritize.20.2373537.20cannot.20create.20local.20mono-item.20for.20DefId)
+  - [This seems to be fixed seeing some of the latest comments](https://github.com/rust-lang/rust/issues/73537#issuecomment-649364509), still needs a test.
+  - Maybe we should lower the priority to `P-medium` or something that represents the priority of lacking a test in the compiler.
+- "Nightly ICEs trying to normalize during a cast" [rust#73747](https://github.com/rust-lang/rust/issues/73747)
+  - Unassigned
+  - nightly regression, ICE on previously accepted code
+  - still needs MCVE and bisection
+  - current repro code uses WinRT and thus is only reproducible on Windows
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- No unassigned P-high beta regressions this time.
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- No unassigned P-high nightly regressions this time.
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs). Latest revision: 0ca7f74dbd23a3e8ec491cd3438f490a3ac22741.
+Three regressions, two of them on rollups; two improvements, one on a rollup.
+
+Regressions:
+- [Rollup of 13 pull requests](https://github.com/rust-lang/rust/pull/73756#issuecomment-651422253)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=14e65d5e95da0f7e4f9127cf1598fa46f33972e8&end=9672b5e95c520774cc17bffc7031c80a1bcf4b4c&stat=instructions:u)):
+  Up to 1.7% losses on many benchmarks, affecting `incr-unchanged` runs the
+  most. Might be due to [#73102](https://github.com/rust-lang/rust/pull/73102)
+  or [#73597](https://github.com/rust-lang/rust/pull/73597).
+- [Rollup of 11 pull requests](https://github.com/rust-lang/rust/pull/73669#issuecomment-651421194)
+  ([instructions](https://github.com/rust-lang/rust/compare/ff5b446d2fdbd898bc97a751f2f72858de185cf1...0c04344d86f9598f20d9ec86fe87ea2a5d6ff8e6)):
+  Up to 2.1% losses on a few benchmarks, mostly on `incr-unchanged` runs.
+- [Always capture tokens for `macro_rules!` arguments](https://github.com/rust-lang/rust/pull/73293#issuecomment-651423672)
+  ([instructions](https://github.com/rust-lang/rust/compare/0c04344d86f9598f20d9ec86fe87ea2a5d6ff8e6...3c90ae8404b6b83bc3cba35840ddf7edd500cc86), [max-rss](https://perf.rust-lang.org/compare.html?start=0c04344d86f9598f20d9ec86fe87ea2a5d6ff8e6&end=3c90ae8404b6b83bc3cba35840ddf7edd500cc86&stat=max-rss)):
+  Up to 6.1% losses on the artificial `deep-vector` benchmark, and memory
+  increases on the same benchmark.
+
+Improvements:
+- [Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/73643#issuecomment-651427381)
+  ([instructions](https://github.com/rust-lang/rust/compare/3b1c08c68ccc2c222f84384c836b5e167e2bc241...1557fb031b272b4c5bfcc7de5df7eddc7b36a584)):
+  Up to 13.6% wins on `wg-grammar`, tiny wins on a couple of other benchmarks.
+- [Revert PR #72389 - "Explain move errors that occur due to method calls involving `self`"](https://github.com/rust-lang/rust/pull/73594)
+  ([instructions](https://github.com/rust-lang/rust/compare/6bb3dbfc6c6d8992d08431f320ba296a0c2f7498...cbf356a1a5677b1c073f09ba833d8247c7ed01aa)):
+  Up to 3.1% wins on a few benchmarks.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Some `NodeId`/`LocalDefId` don't have a corresponding `HirId`" [rust#71104](https://github.com/rust-lang/rust/issues/71104)
+  - Unassigned
+  - Blocks a rustdoc feature: intra-doc links.
+  - Has no clear path for a fix, thus would benefit from discussion in a T-compiler meeting.
+  - Issue raised when trying to remove `DUMMY_HIR_ID`
+  - Has a proposed fix by @_**Joshua Nelson**: #73566
+- "Inherit `#[stable(..)]` annotations in enum variants and fields from its item" [rust#71481](https://github.com/rust-lang/rust/pull/71481)
+  - Assigned to: @**Matthew Jasper**
+  - Is a PR to allow stability attributes flow down in enums to their variants and fields
+  - Nominated because it's controversial
+    - [@**Vadim Petrochenkov** believes is not a good idea](https://github.com/rust-lang/rust/pull/71481#issuecomment-625423500)
+    - [@**nagisa** believes it's dangerous and also limits our possibilities in the future](https://github.com/rust-lang/rust/pull/71481#discussion_r436266259)
+    - [@**nikomatsakis** expressed that we might accidentally stabilize struct fields without intending to](https://github.com/rust-lang/rust/pull/71481#discussion_r439594190)
+- "Rename TypeckTables to TypeckResults." [rust#72983](https://github.com/rust-lang/rust/pull/72983)
+  - This PR changes from `TypeckTables` to `TypeckResults` and it's already r+'d
+  - [@**nikomatsakis** thinks that the name is objectively better here](https://github.com/rust-lang/rust/pull/72983#issuecomment-652498948)
+  - Nominated to draw attention to it, people should be aware of the change 
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-07-09.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-07-09.md
@@ -1,0 +1,173 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-07-09
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- We will be releasing Rust 1.45 next thursday!
+- New MCPs (take a look, see if you like them!)
+    - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+    - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+    - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+    - "Move Rust provided objects, libraries and binaries meant for self-contained linkage to separate directory" [compiler-team#310](https://github.com/rust-lang/compiler-team/issues/310)
+    - "Add future-incompat entries to json diagnostic output" [compiler-team#315](https://github.com/rust-lang/compiler-team/issues/315)
+    - "MCP: Reorganize the rust-lang/rust repo directory structure" [compiler-team#316](https://github.com/rust-lang/compiler-team/issues/316)
+- Pending FCP requests (check your boxes!)
+    - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+    - "--extern-location to specify where an --extern dependency is defined" [compiler-team#303](https://github.com/rust-lang/compiler-team/issues/303)
+    - "Change `ty::Const` to an integer tree representation" [compiler-team#323](https://github.com/rust-lang/compiler-team/issues/323)
+    - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+    - "Improve defaults in x.py" [compiler-team#326](https://github.com/rust-lang/compiler-team/issues/326)
+    - "Rework rustc_serialize" [compiler-team#329](https://github.com/rust-lang/compiler-team/issues/329)
+    - "mv std libs to std/" [rust#73265](https://github.com/rust-lang/rust/pull/73265)
+    - "Stabilize control-flow-guard codegen option" [rust#73893](https://github.com/rust-lang/rust/pull/73893)
+- Accepted MCPs
+    - "illumos toolchain builds" [compiler-team#279](https://github.com/rust-lang/compiler-team/issues/279)
+    - "RISC-V Linux Tier 2 Host support" [compiler-team#312](https://github.com/rust-lang/compiler-team/issues/312)
+    - "Switch from libbacktrace to gimli" [compiler-team#313](https://github.com/rust-lang/compiler-team/issues/313)
+    - "`#![deny(unsafe_op_in_unsafe_fn)]` in libcore and libstd" [compiler-team#317](https://github.com/rust-lang/compiler-team/issues/317)
+    - "-Zmir-opt-level Reform" [compiler-team#319](https://github.com/rust-lang/compiler-team/issues/319)
+    - "Move CONTRIBUTING.md to rustc-dev-guide and instead point to Getting Started" [compiler-team#320](https://github.com/rust-lang/compiler-team/issues/320)
+
+### WG checkins
+
+@*WG-async-foundations* checkin by @**tmandry** and @**nikomatsakis**:
+> Checkin text
+
+@*WG-diagnostics* checkin by @**Esteban Küber**:
+> Checkin text
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- No beta nominations this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- "rustdoc: Rename invalid_codeblock_attribute lint to be plural" [rust#74131](https://github.com/rust-lang/rust/pull/74131)
+  - Renames a Lint name as [per lint naming conventions](https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md#lints)
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PR's S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on T-compiler this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on libs-impl this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [47 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [26 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 0 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 1 P-high, 7 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 13 P-high, 47 P-medium, 4 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3AP-critical+label%3AT-compiler)
+- "Nightly ICEs trying to normalize during a cast" [rust#73747](https://github.com/rust-lang/rust/issues/73747)
+  - Assigned to @**pnkfelix**
+  - nightly regression, ICEs on previously accepted code
+  - Has MCVE
+  - Regressed somewhere in [this rollup](https://github.com/rust-lang/rust/commit/25687caa2e4e35b31c29e28998710670e9d54ee9)
+  - Current repro code uses WinRT and thus is only reproducible on Windows
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- No unassigned P-high beta regressions this time.
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- No unassigned P-high nightly regressions this time.
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs).
+Latest revision: 0c03aee8b81185d65b5821518661c30ecdb42de5.
+One unimportant regression, on a rollup; six improvements, two on rollups.
+
+Regressions
+- [Rollup of 12 pull requests #74073](https://github.com/rust-lang/rust/pull/74073#issuecomment-654524169)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=2753fab7ce3647033146b07c8b6c9f4856a910b0&end=0c03aee8b81185d65b5821518661c30ecdb42de5&stat=instructions:u)):
+  Up to 1.9% losses, but only on the synthetic `wf-projection-stress-65510`
+  benchmark, which doesn't matter that much.
+
+Improvements
+- [Serialize all foreign `SourceFile`s into proc-macro crate metadata #73706](https://github.com/rust-lang/rust/pull/73706#issuecomment-653771986)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=16957bd4d3a5377263f76ed74c572aad8e4b7e59&end=d462551a8600e57d8b6f87e71ea56868bc5da6cf&stat=instructions:u)):
+  Up to 7.5% wins across numerous benchmarks, mostly the shorter-running ones.
+- [Handle inactive enum variants in `MaybeUninitializedPlaces` #73879](https://github.com/rust-lang/rust/pull/73879#issuecomment-651710137)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=0cd7ff7ddfb75a38dca81ad3e76b1e984129e939&end=2753fab7ce3647033146b07c8b6c9f4856a910b0&stat=instructions:u)):
+  Up to 7.1% wins across numerous benchmarks, mostly on opt builds. (Plus one
+  21% improvement, but that benchmark has high variability.)
+- [Rollup of 16 pull requests #73950](https://github.com/rust-lang/rust/pull/73950#issuecomment-654520286)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=9491f18c5de3ff1c4bf9c3fdacf52d9859e26f7c&end=b7856f695d65a8ebc846754f97d15814bcb1c244&stat=instructions:u)):
+  Up to 1.9% wins across numerous benchmarks.
+- [Avoid `unwrap_or_else` in `RawVec::allocate_in`. #73882](https://github.com/rust-lang/rust/pull/73882#issue-441778949)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=5f4abc16e1b2cb035eee6a5079ce45ce924c1f33&end=cd1a46d644791c79433db934ad4e6131c577efcc&stat=instructions:u)):
+  Up to 1.2% wins across a few benchmarks, mostly on debug builds. Maybe
+  [#73345](https://github.com/rust-lang/rust/pull/73345) or
+  [#73569](https://github.com/rust-lang/rust/pull/73569) is responsible?
+- [Remove `TypeckTables::empty(None)` and make hir_owner non-optional. #73751](https://github.com/rust-lang/rust/pull/73751#issuecomment-654521841)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=8a6d4342be6a6acbade8e7ef65e73d27ee8c9144&end=3503f565e1fb7296983757d2716346f48a4a262b&stat=instructions:u)):
+  Up to 3.8% wins, mostly on `unused-warnings`.
+- [Rollup of 17 pull requests #73924](https://github.com/rust-lang/rust/pull/73924#issuecomment-654518483)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=d462551a8600e57d8b6f87e71ea56868bc5da6cf&end=f781babf87dea29c44f93842b7ac9eb809549d29&stat=instructions:u)):
+  Up to 1.9% wins, mostly on `clap-rs`. Unclear which PR is responsible.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=label%3AI-nominated+label%3AT-compiler)
+- "Inherit `#[stable(..)]` annotations in enum variants and fields from its item" [rust#71481](https://github.com/rust-lang/rust/pull/71481)
+  - Assigned to: @**Matthew Jasper**
+  - Is a PR to allow stability attributes flow down in enums to their variants and fields
+  - Nominated because it's controversial
+    - [@**Vadim Petrochenkov** believes is not a good idea](https://github.com/rust-lang/rust/pull/71481#issuecomment-625423500)
+    - [@**nagisa** believes it's dangerous and also limits our possibilities in the future](https://github.com/rust-lang/rust/pull/71481#discussion_r436266259)
+    - [@**nikomatsakis** expressed that we might accidentally stabilize struct fields without intending to](https://github.com/rust-lang/rust/pull/71481#discussion_r439594190)
+- "A big regression in tokio-webpush-simple-opt" [rust#58368](https://github.com/rust-lang/rust/issues/58368)
+  - Tokio webpush bench regressed 88.5% [in this commit](https://github.com/rust-lang/rust/commit/ff19a53ef07566aa30860023f6eac6e75ffaf900).
+  - Nominated to raise awareness of such a big performance regression with no recent activity.
+- PR's "Avoid "blacklist"" [rust#74150](https://github.com/rust-lang/rust/pull/74150) and "Avoid "whitelist"" [rust#74127](https://github.com/rust-lang/rust/pull/74127)
+  - Felix nominated: these ended up being troll-magnets. Felix wants to establish that this kind of PR is in line with our values, for the reasons [posted by niko](https://github.com/rust-lang/rust/pull/74127#pullrequestreview-444766034).
+      - Felix asks: Would others agree with this statement, taken from ["The light and dark of language"](https://www.grammarphobia.com/blog/2009/12/light-and-dark-2.html)? :
+        > For what it’s worth, we don’t believe that metaphors identifying lightness as positive and darkness as negative are inherently racist. They certainly didn’t begin that way, though these negative connotations have certainly fed into and reinforced racism over the centuries. 
+  - (Also, as previously established, the Core Team has publicly noted support for BLM in the [1.44.0 blog post](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html))
+  - ~~Assuming they both land, pnkfelix proposes we lock them both again after they land, because even now they continue to invite trolling or troll-like behavior.~~
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-07-16.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-07-16.md
@@ -1,0 +1,189 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-07-16
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Rust 1.45 is being released today! :tada::tada::tada:
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Move Rust provided objects, libraries and binaries meant for self-contained linkage to separate directory" [compiler-team#310](https://github.com/rust-lang/compiler-team/issues/310)
+  - "Add future-incompat entries to json diagnostic output" [compiler-team#315](https://github.com/rust-lang/compiler-team/issues/315)
+  - "MCP: Reorganize the rust-lang/rust repo directory structure" [compiler-team#316](https://github.com/rust-lang/compiler-team/issues/316)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Change `ty::Const` to an integer tree representation" [compiler-team#323](https://github.com/rust-lang/compiler-team/issues/323)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Improve defaults in x.py" [compiler-team#326](https://github.com/rust-lang/compiler-team/issues/326)
+  - "Rework rustc_serialize" [compiler-team#329](https://github.com/rust-lang/compiler-team/issues/329)
+  - "Use `tracing` instead of `log`" [compiler-team#331](https://github.com/rust-lang/compiler-team/issues/331)
+  - "Stabilize control-flow-guard codegen option" [rust#73893](https://github.com/rust-lang/rust/pull/73893)
+- Accepted MCPs
+  - "--extern-location to specify where an --extern dependency is defined" [compiler-team#303](https://github.com/rust-lang/compiler-team/issues/303)
+- Finalized FCPs
+  - "Stabilize const_type_id feature" [rust#72488](https://github.com/rust-lang/rust/pull/72488)
+- Should we close #compiler channel on Discord?
+  - This was briefly discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/discord.20channel)
+
+### WG checkins
+
+@*WG-rustc-dev-guide* checkin by @**mark-i-m** and @**Santiago Pastorino**:
+> [68 merged PRs!](https://github.com/rust-lang/rustc-dev-guide/pulls?page=1&q=closed%3A%3E%3D2020-05-28) In fact, there was so much stuff, that we ran out of time to curate it... here is a prefix of the list of PRs (heavily biased towards earlier PRs); there are so many people that deserve credit:
+>- Aaron Hill
+>- Andy Russell
+>- Bastian Kauschke
+>- Drew Youngwerth
+>- Eric Huss
+>- Florian Gilcher
+>- Ivan Veselov
+>- Joshua Nelson
+>- mark-i-m
+>- Matt Kraai
+>- Nadrieril
+>- Niko Matsakis
+>- pierwill
+>- Ralf Jung
+>- Santiago Pastorino
+>- Takayuki Nakata
+>- ThePuzzlemaker
+>- Tomasz Miąsko
+>- Tom Eccles
+>- Yuki Okushi
+>
+>Accomplished:
+>
+>- Tons of new content:
+>   - [Getting Started Guide](https://github.com/rust-lang/rustc-dev-guide/pull/731) + many improvements
+>   - Type-system rustc-dev-guide#697
+>   - Diagnostics rustc-dev-guide#716
+>   - Building and testing `rustc` rustc-dev-guide#723, rustc-dev-guide#727, rustc-dev-guide#728, rustc-dev-guide#729, and many more
+>   - Writing tests rustc-dev-guide#724, rustc-dev-guide#725, rustc-dev-guide#749 
+>- Updates to various current content:
+>   - [Lints](https://github.com/rust-lang/rustc-dev-guide/pull/713)
+>   - [`TyKind::Error`](https://github.com/rust-lang/rustc-dev-guide/pull/715)
+>   - [Coding Conventions](https://github.com/rust-lang/rustc-dev-guide/pull/735)
+>   - Notification Groups rustc-dev-guide#739, rustc-dev-guide#740, and more 
+>- Some reorganization:
+>   - rustc-dev-guide#753, rustc-dev-guide#752, rustc-dev-guide#763, rustc-dev-guide#764, rustc-dev-guide#767, rustc-dev-guide#768, rustc-dev-guide#773
+
+@*WG-llvm* checkin by @**nagisa**:
+> * As mentioned above, there’s LLVM11 upgrade on the horizon. The usual caveats etc apply. Potential regressions, improvements in compiler code output etc.
+>* In similar spirit been seeing an increased flow of issue reports about sub-optimal code generation, thuogh that's a very subjective evaluation;
+>* There's an ongoing effort by a community member to enable building targeting apple silicon with "fat" libraries. There are some complication in enabling this:
+    * Upstream LLVM support for this is _dubious_ both now and possibly LLVM 11.
+    * What kind of tier are we hoping to have for this target at launch time? I’d say just let it go through the usual process, but I can see logic in idea of having T2/T1 support at launch time.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+
+ * lint: use `transparent_newtype_field` to avoid ICE [rust#74340](https://github.com/rust-lang/rust/pull/74340)
+   * fix for Nightly ICEs trying to normalize during a cast [rust#73747](https://github.com/rust-lang/rust/issues/73747)
+   * authored by @davidtwco and r+'ed by @pnkfelix
+   * (just barely missed the promotion from master to beta)
+   * pnkfelix would be fine with letting this simmer until next week.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on T-compiler this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on libs-impl this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [49 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [27 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 0 P-high, 3 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 14 P-high, 46 P-medium, 4 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No P-critical issues for T-compiler this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- No unassigned P-high beta regressions this time.
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- No unassigned P-high nightly regressions this time.
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs).
+Revision range: [0c03aee8b81185d65b5821518661c30ecdb42de5..9d09331e00b02f81c714b0c41ce3a38380dd36a2](https://perf.rust-lang.org/?start=0c03aee8b81185d65b5821518661c30ecdb42de5&end=9d09331e00b02f81c714b0c41ce3a38380dd36a2&absolute=false&stat=instructions%3Au).
+
+12 revisions checked. Zero regressions, one improvement.
+
+Regressions
+- None!
+
+Improvements
+- [Shrink ParamEnv to 16 bytes #73978](https://github.com/rust-lang/rust/pull/73978#issuecomment-657877594)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=0c03aee8b81185d65b5821518661c30ecdb42de5&end=8981dbbc36f1575b0a417b6849767bde29e7c6b4&stat=instructions:u)):
+  Up to 1.8% wins on a few benchmarks.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Polymorphization" [rust#69749](https://github.com/rust-lang/rust/pull/69749)
+  - This was nominated for discussion about what the next steps are.
+  - [See @wesleywiser's comment](https://github.com/rust-lang/rust/pull/69749#issuecomment-658871287) for a summary of the current state and questions.
+- "mv std libs to std/" [rust#73265](https://github.com/rust-lang/rust/pull/73265)
+  - This was nominated again for discussion about what the next steps are.
+  - "I propose to wait one week and nominate the issue one (hopefully) last time"
+  - [See @mark-i-m's comment](https://github.com/rust-lang/rust/pull/73265#issuecomment-657075856) for a summary of the current proposal.
+- "[WIP] Upgrade to LLVM 11" [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - [Nominated](https://github.com/rust-lang/rust/pull/73526#issuecomment-658943064) to double check whether we're okay with landing this prior to the final LLVM 11 release.
+  - [See @nikic's comment](https://github.com/rust-lang/rust/pull/73526#issuecomment-658943064) ...
+  - "The last perf run had large compile-time improvements for opt builds and some minor regressions for debug builds."
+  - [Perf shows some nice improvements](https://perf.rust-lang.org/compare.html?start=7e11379f3b4c376fbb9a6c4d44f3286ccc28d149&end=adff1be71c9e1b3abb95b761d9caa41e4e1b9096)
+- "Compiler doesn't terminate with --release" [rust#74384](https://github.com/rust-lang/rust/issues/74384)
+  - Compiler doesn't "terminate" when nesting 3 arrays.
+  - "It seems like this is an LLVM bug."
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-07-23.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-07-23.md
@@ -1,0 +1,227 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-07-23
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new MCPs at this time.
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "MCP: Reorganize the rust-lang/rust repo directory structure" [compiler-team#316](https://github.com/rust-lang/compiler-team/issues/316)
+- Pending FCP requests (check your boxes!)
+  - "Stabilizable subset of const generics" [compiler-team#332](https://github.com/rust-lang/compiler-team/issues/332)
+- Things in FCP (make sure you're good with it)
+  - "Move Rust provided objects, libraries and binaries meant for self-contained linkage to separate directory" [compiler-team#310](https://github.com/rust-lang/compiler-team/issues/310)
+  - "Add future-incompat entries to json diagnostic output" [compiler-team#315](https://github.com/rust-lang/compiler-team/issues/315)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+- Accepted MCPs
+  - "Change `ty::Const` to a "value tree" representation" [compiler-team#323](https://github.com/rust-lang/compiler-team/issues/323)
+  - "Improve defaults in x.py" [compiler-team#326](https://github.com/rust-lang/compiler-team/issues/326)
+  - "Rework rustc_serialize" [compiler-team#329](https://github.com/rust-lang/compiler-team/issues/329)
+  - "Use `tracing` instead of `log`" [compiler-team#331](https://github.com/rust-lang/compiler-team/issues/331)
+- Finalized FCPs
+  - No finalized FCPs this time.
+
+### WG checkins
+
+@*T-compiler/WG-meta* checkin by @**nikomatsakis**:
+> Checkin text
+
+@*WG-mir-opt* checkin by @**oli**:
+> * `-Zmir-opt-level`'s meaning gets refactored to stop including buggy opts (https://github.com/rust-lang/compiler-team/issues/319)
+> * harden const propagator against regressions and bugs (https://github.com/rust-lang/rust/pull/73693, https://github.com/rust-lang/rust/pull/73613)
+> * MIR overflow messages now contain the binop arguments that caused the overflow (https://github.com/rust-lang/rust/pull/73513)
+>   * only used in the const evaluator and const propagator, but we can make runtime asserts also do this (similar to how index out of bounds displays length and index)
+> * MIR printing can now print variant-less enums (https://github.com/rust-lang/rust/pull/73442)
+> * MIR is now checked to make sure its invariants are upheld (https://github.com/rust-lang/rust/pull/72796, https://github.com/rust-lang/rust/pull/72093)
+>
+> Not sure if we already had this last time, but even if, this is worth repeating: [we have a totally awesome NRVO pass!](https://github.com/rust-lang/rust/pull/72205)
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Don't panic if the lhs of a div by zero is not statically known" [rust#74221](https://github.com/rust-lang/rust/pull/74221)
+    - PR by @**oli**, approved by @**Wesley Wiser**
+    - Fixes [a P-high nightly regression](https://github.com/rust-lang/rust/issues/73993)
+- "improper_ctypes_definitions: allow `Box`" [rust#74448](https://github.com/rust-lang/rust/pull/74448)
+    - PR by @**davidtwco**, approved by @**Alex Crichton** 
+    - stops [linting against Box in extern "C" functions for the improper_ctypes_definitions lint](https://github.com/rust-lang/rust/pull/72700#issuecomment-659449386) - boxes are documented to be FFI-safe.
+- "Use `ReEmpty(U0)` as the implicit region bound in typeck" [rust#74509](https://github.com/rust-lang/rust/pull/74509)
+  - PR by @_**Matthew Jasper**, not merged yet
+  - Fixes [a `P-critical` stable regression](https://github.com/rust-lang/rust/issues/74429) that rejects previously accepted code
+  - Very small patch, one line changed
+  - This one is also stable nominated
+- "Fix an ICE on an invalid `binding @ ...` in a tuple struct pattern" [rust#74557](https://github.com/rust-lang/rust/pull/74557)
+  - PR by @**jakubadamw**, approved by @**nagisa**
+  - Fixes: [a stable to stable regression (ICE)](https://github.com/rust-lang/rust/issues/74539). Where a better displayed error was previously produced.
+  - This one is also stable nominated
+- "Correctly parse `{} && false` in tail expression" [rust#74650](https://github.com/rust-lang/rust/pull/74650)
+  - PR by @**Esteban Küber**, not merged yet
+  - Fixes [#74233](https://github.com/rust-lang/rust/issues/74233) a `P-high` regression and [#54186](https://github.com/rust-lang/rust/issues/54186)
+  - This one is also stable nominated
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Use `ReEmpty(U0)` as the implicit region bound in typeck" [rust#74509](https://github.com/rust-lang/rust/pull/74509)
+  - This was also beta nominated
+- "Fix an ICE on an invalid `binding @ ...` in a tuple struct pattern" [rust#74557](https://github.com/rust-lang/rust/pull/74557)
+  - This was also beta nominated
+- "Correctly parse `{} && false` in tail expression" [rust#74650](https://github.com/rust-lang/rust/pull/74650)
+  - This was also beta nominated
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on T-compiler this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on libs-impl this time
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [50 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [27 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 1 P-high, 3 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 15 P-high, 47 P-medium, 4 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Borrowck deduces empty lifetime" [rust#74429](https://github.com/rust-lang/rust/issues/74429)
+  - Unassigned
+  - There is [a single crate repro](https://github.com/rust-lang/rust/issues/74429#issuecomment-660400487) but an MCVE is still lacking
+  - Regressed in [#72362](https://github.com/rust-lang/rust/pull/72362) by @**Matthew Jasper**
+  - [It has an opened PR](https://github.com/rust-lang/rust/pull/74509), already approved but tests are failing
+- "LTO triggers apparent miscompilation on Windows 10 x64" [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - Unassigned
+  - [LLVM issue reproduced on LLVM master](https://github.com/rust-lang/rust/issues/74498#issuecomment-661950983)
+  - Regression from stable to stable, started failing when we updated to LLVM 9.0
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- No unassigned P-high beta regressions this time.
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Type mismatch in function arguments E0631, E0271 are falsely recognized as E0308 mismatched types" [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Unassigned
+  - Nightly to stable regression
+  - Regressed on [#73643](https://github.com/rust-lang/rust/pull/73643) which is a rollup, likely to be [#72493](https://github.com/rust-lang/rust/pull/72493) or maybe [these others](https://github.com/rust-lang/rust/issues/74400#issuecomment-661450558)
+
+## Performance logs
+
+[Triage done by njn](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+This week was a disaster, perf-wise. 28 revisions checked. 7 regressions, several of them ranging from large to huge, many in rollups. Some additional regressions may have occurred in rollups that were masked by other regressions/improvements. 3 improvements, one of which was a reversion of a regression. Thanks for Mark-Simulacrum and eddyb for follow-up measurements and adding new tooling to help investigate regressions in rollups. A follow-up thread on Zulip is [here](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/Follow-up.20to.20the.20bad.20perf.20triage.20of.202020-07-21).
+
+In better news, rustdoc performance is now being benchmarked, thanks to the
+efforts of [Joshua Nelson](https://github.com/rust-lang/rustc-perf/pull/675).
+
+Triage done by njn. Revision range: [9d09331e00b02f81c714b0c41ce3a38380dd36a2..71384101ea3b030b80f7def80a37f67e148518b0](https://perf.rust-lang.org/?start=9d09331e00b02f81c714b0c41ce3a38380dd36a2&end=71384101ea3b030b80f7def80a37f67e148518b0&absolute=false&stat=instructions%3Au).
+
+Regressions
+- [Rollup of 18 pull requests #74461](https://github.com/rust-lang/rust/pull/74461#issuecomment-660492867)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=39d5a61f2e4e237123837f5162cc275c2fd7e625&end=d3df8512d2c2afc6d2e7d8b5b951dd7f2ad77b02-v1&stat=instructions:u)):
+  Up to 73.0% losses on many benchmarks.
+  [#74416](https://github.com/rust-lang/rust/pull/74416#issuecomment-660545238)
+  is at fault; it was reverted in
+  [#74478](https://github.com/rust-lang/rust/pull/74478), see below.
+- [std: Switch from libbacktrace to gimli #73441](https://github.com/rust-lang/rust/pull/73441#issuecomment-660881380)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=7d31ffc1ac9e9ea356e896e63307168a64501b9d&end=1fa54ad9680cc82e7301f8ed4e9b7402dfd6ce0e&stat=instructions:u),
+   [max-rss](https://perf.rust-lang.org/compare.html?start=7d31ffc1ac9e9ea356e896e63307168a64501b9d&end=1fa54ad9680cc82e7301f8ed4e9b7402dfd6ce0e&stat=max-rss)):
+  Up to 44.8% instruction increases on many benchmarks, and 5-10% max-rss increases on many benchmarks. Being reverted in [#74613](https://github.com/rust-lang/rust/pull/74613).
+- [Support const args in type dependent paths (Take 2) #74113](https://github.com/rust-lang/rust/pull/74113#issuecomment-661470398)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=d9e8d6290745a65025a3e082aea72fbe372292c6&end=7e11379f3b4c376fbb9a6c4d44f3286ccc28d149&stat=instructions:u)):
+  Up to 1.5% losses on numerous benchmarks, which was expected.
+- [Reduce the amount of interning and `layout_of` calls in const eval. #74202](https://github.com/rust-lang/rust/pull/74202#issuecomment-661475728)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=4cd0ee9343da86d9770bf0a514a682d240e0dce8&end=125c58caebc67c32ec45ac6c0581b596fd532082&stat=instructions:u)):
+  Up to 2% losses on one benchmark.
+- [Rollup of 9 pull requests #74543](https://github.com/rust-lang/rust/pull/74543#issuecomment-661507295)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=2c21a6f3a8b1c75c444b87fde5116853383b3fbd&end=891e6fee572009ff2be4d4057fb33483610c36a7&stat=instructions:u)):
+  Up to 12% losses on rustdoc for many benchmarks.
+- [Rollup of 4 pull requests #74518](https://github.com/rust-lang/rust/pull/74518#issuecomment-661498214)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=48036804d2bc461b243c5d291b850e44bcca68ef&end=d7f94516345a36ddfcd68cbdf1df835d356795c3&stat=instructions:u)):
+  Up to 6.4% losses on rustdoc for two benchmarks.
+
+Improvements
+- [Rollup of 7 pull requests #74493](https://github.com/rust-lang/rust/pull/74493#issuecomment-661521298)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=1fa54ad9680cc82e7301f8ed4e9b7402dfd6ce0e&end=0701419e96d94e5493c7ebfcecb66511ab0aa778&stat=instructions:u)):
+  Up to 33.5% improvements, at least partly due to the backout of
+  [#74416](https://github.com/rust-lang/rust/pull/74416) in
+  [#74478](https://github.com/rust-lang/rust/pull/74478), but it's also
+  possible that another PR in that rollup [caused a regression that was masked
+  by the improvement from the backout](https://github.com/rust-lang/rust/pull/74493#issuecomment-661521298).
+- [Change `SymbolName::name` to a `&str`. #74214](https://github.com/rust-lang/rust/pull/74214#issuecomment-661459141)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=c714eae0e3b4ba263c193d54f6e46bb9a1feb2cc&end=d9e8d6290745a65025a3e082aea72fbe372292c6&stat=instructions:u)):
+  Up to 2.5% wins on numerous benchmarks.
+- [Don't run `everybody_loops` for rustdoc; instead ignore resolution errors #73566](https://github.com/rust-lang/rust/pull/73566#issuecomment-661484787)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=6ee1b62c811a6eb68d6db6dfb91f66a49956749b&end=5c9e5df3a097e094641f16dab501ab1c4da10e9f&stat=instructions:u)):
+  Wins of up to 62.6% and losses of up to 8.5%, all on rustdoc builds. Overall,
+  the improvements greatly outweigh the losses. (Landed in rollup
+  [#74408](https://github.com/rust-lang/rust/pull/74408).)
+
+### Notes
+
+[Rollup of 11 pull requests #74468](https://github.com/rust-lang/rust/pull/74468#issuecomment-661371815)
+ * ([instructions](https://perf.rust-lang.org/compare.html?start=d3df8512d2c2afc6d2e7d8b5b951dd7f2ad77b02-v1&end=7d31ffc1ac9e9ea356e896e63307168a64501b9d&stat=instructions:u))
+
+This rollup was originally judged as responsible for a 10% regression in
+instrutions:u. However, since then, it has been determined that the likely cause of this regression is actually perf's [move](https://github.com/rust-lang/rustc-perf/commit/048360c77a74244ba6e70d9b3f2bcd7779b8129f) to using `x.py dist`-shipped std's rather than building one locally. Investigation into *why* this move caused a regression is as yet not done, but is being tracked in [rustc-perf#724](https://github.com/rust-lang/rustc-perf/issues/724).
+
+Initially [#74069](https://github.com/rust-lang/rust/pull/74069) and/or [#72414](https://github.com/rust-lang/rust/pull/72414) were suspected as the cause of the regression, but further testing showed that to not be the case.
+
+ * The original rollup, #74468, landed with a [5-10% performance regression](https://perf.rust-lang.org/compare.html?start=d3df8512d2c2afc6d2e7d8b5b951dd7f2ad77b02-v1&end=7d31ffc1ac9e9ea356e896e63307168a64501b9d&stat=instructions:u)
+ * In #74611, we tested as-if a rollup of #74069 and #72414 landed. ([This](https://gist.github.com/Mark-Simulacrum/6893dff239d116947bca647f4f8128c7) is the diff between d3df85 and cfade73) That yielded [identical results to the rollup](https://perf.rust-lang.org/compare.html?start=d3df8512d2c2afc6d2e7d8b5b951dd7f2ad77b02-v1&end=cfade73820883adf654fe34fd6b0b03a99458a51).
+ * We reverted #74069 in #74611, this yielded [neutral performance results](https://perf.rust-lang.org/compare.html?start=e8b55a4ad230ebec762fdfc4f241ba98a98560af&end=fcac11993ca055bbdc7683a2f6ed7b88a838fb0f&stat=instructions:u).
+ * #74716 then tried a revert of #72414 but this also yielded [neutral performance results](https://perf.rust-lang.org/compare.html?start=900869371e13cead086f4f9809419daa6a63cfaf&end=193b2f77c9463ed7378c20bad843a9031489e215)
+
+We have since opened a PR to re-land #74069, as well: #74802.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Compiler doesn't terminate with --release" [rust#74384](https://github.com/rust-lang/rust/issues/74384)
+  - Compiler doesn't "terminate" when nesting 3 arrays.
+  - "It seems like this is an LLVM bug."
+  - Nominated to assign it
+  - On our last meeting we briefly mention it but wasn't picked up yet
+- "error: could not compile `gkrust` since Rust 1.43 on SPARC Solaris" [rust#74551](https://github.com/rust-lang/rust/issues/74551)
+  - Unassigned `I-unsound` stable to stable regression
+  - Nominated by @**ecstatic-morse**, [they think this is concerning and may affect tier 1 platforms](https://github.com/rust-lang/rust/issues/74551#issuecomment-662273391)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-07-30.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-07-30.md
@@ -1,0 +1,190 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-07-30
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow (Friday at 2pm UTC) we have our [Steering Meeting](https://forge.rust-lang.org/compiler/steering-meeting.html)
+- New MCPs (take a look, see if you like them!)
+  - "Move the compiler to a new `compiler/` directory" [compiler-team#336](https://github.com/rust-lang/compiler-team/issues/336)
+  - "Create a WebAssembly target notification group." [compiler-team#337](https://github.com/rust-lang/compiler-team/issues/337)
+  - "Form t-compiler/wg-parser-library" [compiler-team#338](https://github.com/rust-lang/compiler-team/issues/338)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Stabilizable subset of const generics" [compiler-team#332](https://github.com/rust-lang/compiler-team/issues/332)
+- Accepted MCPs
+  - "Move Rust provided objects, libraries and binaries meant for self-contained linkage to separate directory" [compiler-team#310](https://github.com/rust-lang/compiler-team/issues/310)
+  - "Add future-incompat entries to json diagnostic output" [compiler-team#315](https://github.com/rust-lang/compiler-team/issues/315)
+- Finalized FCPs
+  - "Stabilize core::future::{pending,ready}" [rust#74328](https://github.com/rust-lang/rust/pull/74328)
+
+### WG checkins
+
+@*WG-polonius* checkin by @**nikomatsakis** and @**lqd**:
+> We are planning a "sprint" Aug 3 - 5, which means that we'll be putting some energy into pushing polonius along. We've been changing to this "sprint-oriented" model because it's hard to keep a complex project like polonius moving in fits and starts, it requires some dedicated attention.
+> 
+> Last sprint we focused on getting a "complete write-up" of the polonius rules and in particular incorporating liveness and other things. I'm not sure what we'll focus on this sprint, probably similar themes, but I know that lqd has some ideas. --nikomatsakis
+
+WG-Polymorphization checkin by @**davidtwco**:
+> Since the last check-in from the polymorphisation working group (myself with lots of help from @_**eddyb** and @_**lcnr**), we’ve made a few steps forward and a few steps back:
+>
+> Polymorphisation (#69749) was merged and enabled by default. Another perf run was performed before merge, which found that the improvements from earlier perf runs had vanished - some investigation revealed that this was due to an update to the script-servo benchmark that patched the opportunity that polymorphisation was taking advantage of.
+>
+> We quickly discovered a regression that was missed by the test suite in #74614. Some investigation revealed the issue but we fixed the issue by disabling polymorphisation again in #74633. #74636 was filed to track fixing the underlying bug - there are some subtle implications of polymorphisation here that we hadn’t thought about and warrant some discussion. 
+>
+> #74717 has been submitted to fix that regression, but it’s still pending review and warrants some discussion before merge (particularly with respect to the intersection between polymorphisation and reflection). 
+> 
+> @_**lcnr** fixed another bug with polymorphisation that was discovered while investigating the regression with #74623. 
+>
+> @_**njn** reported that disabling polymorphisation didn’t regain the performance losses of enabling it - I intend to look into why this might be soon. 
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Add the aarch64-apple-darwin target" [rust#74541](https://github.com/rust-lang/rust/pull/74541)
+  - PR by @**Jake Goulding**, Assigned to @**varkor**
+- "rustc_target: Add a target spec option for disabling `--eh-frame-hdr`" [rust#74631](https://github.com/rust-lang/rust/pull/74631)
+  - PR by @**Vadim Petrochenkov**, Assigned to @**oli**
+- "Fix #[track_caller] shims for trait objects." [rust#74784](https://github.com/rust-lang/rust/pull/74784)
+  - PR by @**anp**, Assigned to @**eddyb**
+  - Fixes an `I-unsound` `P-critical` issue [rust#74764](https://github.com/rust-lang/rust/issues/74764).
+  - This is also stable nominated
+- "Fix incorrect clashing_extern_declarations warnings." [rust#73990](https://github.com/rust-lang/rust/pull/73990)
+    - PR by @**jumbatm**, Assigned to @**nagisa**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "The const propagator cannot trace references." [rust#73613](https://github.com/rust-lang/rust/pull/73613)
+  - Assigned to @**Wesley Wiser**, already merged
+  - Fixes an `I-unsound` `P-critical` issue [rust#73609](https://github.com/rust-lang/rust/issues/73609)
+- "Fix #[track_caller] shims for trait objects." [rust#74784](https://github.com/rust-lang/rust/pull/74784)
+  - PR by @**anp**, Assigned to @**eddyb**
+  - Fixes an `I-unsound` `P-critical` issue [rust#74764](https://github.com/rust-lang/rust/issues/74764).
+  - This is also beta nominated
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Inlined symbols" [rust#74554](https://github.com/rust-lang/rust/pull/74554)
+  - PR by @**njn**, assigned to @**Vadim Petrochenkov** 
+  - "Encode symbols that are 4 bytes or shorter directly in the u32"
+  - Waiting on [an evaluation of the performance vs complexity tradeoff](https://github.com/rust-lang/rust/pull/74554#issuecomment-664001716)
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on libs-impl this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [51 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [28 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 2 P-high, 3 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 15 P-high, 48 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "LTO triggers apparent miscompilation on Windows 10 x64" [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - Discussed last week
+  - Assigned to @**pnkfelix**
+  - I-unsound regression from stable to stable, started failing when we updated to LLVM 9.0
+  - [LLVM issue reproduced on LLVM master](https://github.com/rust-lang/rust/issues/74498#issuecomment-661950983)
+  - Rust started to trigger this misbehavior more frequent since the introduction of [rust#69659](https://github.com/rust-lang/rust/pull/69659) that happened in 1.45+.
+- "Unexpected trait resolution overflow error" [rust#74868](https://github.com/rust-lang/rust/issues/74868)
+  -  Unassigned
+  -  Needs MCVE and bisection
+  -  Possible culprits [rust#73357](https://github.com/rust-lang/rust/pull/73357) or [rust#73261](https://github.com/rust-lang/rust/pull/73261) maybe?
+- "Lifetime error when indexing with borrowed index in beta but not in stable" [rust#74933](https://github.com/rust-lang/rust/issues/74933)
+  - Unassigned
+  - Code that compiles on stable, fails on beta
+  - Regressed in [rust#73504](https://github.com/rust-lang/rust/pull/73504) which is a roll-up, likely [rust#72280](https://github.com/rust-lang/rust/pull/72280)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "libtest panics when running `should_panic` tests under QEMU armv7 " [rust#74820](https://github.com/rust-lang/rust/issues/74820)
+  - Cargo lib skeleton + should_panic test code fails on armv7
+  - It seems to be caused by [rust#72746](https://github.com/rust-lang/rust/pull/72746) by @**tmandry**
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Type mismatch in function arguments E0631, E0271 are falsely recognized as E0308 mismatched types" [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Discussed last week
+  - Regressed on [rust#73643](https://github.com/rust-lang/rust/pull/73643) which is a rollup, likely to be [rust#72493](https://github.com/rust-lang/rust/pull/72493)
+
+## Performance logs
+
+We need to first re-discuss [last week's performance report](https://hackmd.io/jK5Cm8QJSGG7ukq7lVilLg?view#Performance-logs) because during last meeting we didn't have time for that.
+
+This week's performance report ...
+
+Triage done by njn. Revision range: [71384101ea3b030b80f7def80a37f67e148518b0..efc02b03d18b0cbaa55b1e421d792f70a39230b2](https://perf.rust-lang.org/?start=71384101ea3b030b80f7def80a37f67e148518b0&end=efc02b03d18b0cbaa55b1e421d792f70a39230b2&absolute=false&stat=instructions%3Au)
+
+2 regressions, 1 improvement, none of them on rollups.
+
+Regressions
+- [Serialize span hygiene data #72121](https://github.com/rust-lang/rust/pull/72121#issuecomment-664685450)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=c70986264b4d534e35992fc64ecd9139700b5071&end=fa36f960687c41caf5b260ab7610ebd83a7860dd&stat=instructions:u)):
+  Up to 3.5% losses on numerous benchmarks. This was expected, and the author and reviewer deemed it reasonable for the improvement in error messages.
+- [Polymorphization #69749](https://github.com/rust-lang/rust/pull/69749#issuecomment-664688297)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=734233d29771869f824d8ddbaddabb90b3b68e03&end=b52522ade1f6979a35b24087dadcf5ba5c981cbe&stat=instructions:u)):
+  Up to 1.8% losses (ignoring the noisy `script-servo-2-opt` results), which was expected. (Hopefully extensions to this change will allow for compile time improvements in the future.) This feature was later disabled due to correctness issues, but the disabling was [performance neutral](https://github.com/rust-lang/rust/pull/74633#issuecomment-664691511), oddly enough.
+
+Improvements
+- [Revert libbacktrace -> gimli #74613](https://github.com/rust-lang/rust/pull/74613#issuecomment-664682974)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=2bbfa02b1b15974d5772b520aa027bf79f8c248e&end=371917ab218de72a625227ba6eed7e84e610a058&stat=instructions:u)):
+  Up to 25.5% wins across many benchmarks. A reversion of one of last week's regressions. This PR may re-land because it's a big functional improvement and the regressions are mostly on very short-running benchmarks. If it does it will be after consideration and with intention.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Compiler doesn't terminate with --release" [rust#74384](https://github.com/rust-lang/rust/issues/74384)
+  - Compiler doesn't "terminate" when nesting 3 arrays.
+  - "It seems like this is an LLVM bug."
+  - Nominated to assign it
+  - On our last meeting we briefly mention it but wasn't picked up yet
+- "error: could not compile `gkrust` since Rust 1.43 on SPARC Solaris" [rust#74551](https://github.com/rust-lang/rust/issues/74551)
+  - Unassigned `I-unsound` stable to stable regression
+  - Nominated by @**ecstatic-morse**, [they think this is concerning and may affect tier 1 platforms](https://github.com/rust-lang/rust/issues/74551#issuecomment-662273391)
+- "ICE with the `(foo @ ..,)` pattern" [rust#74702](https://github.com/rust-lang/rust/issues/74702)
+  - `I-ICE`, `I-nominated` for discussion, see [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/245100-t-compiler.2Fwg-prioritization.2Falerts/topic/I-prioritize.20.2374702.20ICE.20with.20the.20.60(foo.20.40.20.2E.2E.2C).60.20pattern) topic
+  - No assignee yet
+- "std: Switch from libbacktrace to gimli (take 2)" [#74682](https://github.com/rust-lang/rust/pull/74682)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-08-06.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-08-06.md
@@ -1,0 +1,215 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-08-06
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- `tracing` has been added to rustc, @oli is playing with features, comment if you have opinions: https://github.com/rust-lang/rust/pull/75143
+- New MCPs (take a look, see if you like them!)
+  - "refactor types to fit the chalk-ty generic plan" [compiler-team#341](https://github.com/rust-lang/compiler-team/issues/341)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Move the compiler to a new `compiler/` directory" [compiler-team#336](https://github.com/rust-lang/compiler-team/issues/336)
+  - "Form t-compiler/wg-parser-library" [compiler-team#338](https://github.com/rust-lang/compiler-team/issues/338)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Stabilizable subset of const generics" [compiler-team#332](https://github.com/rust-lang/compiler-team/issues/332)
+  - "Create a WebAssembly target notification group." [compiler-team#337](https://github.com/rust-lang/compiler-team/issues/337)
+  - "Set ninja=true by default" [compiler-team#339](https://github.com/rust-lang/compiler-team/issues/339)
+  - "Implement const equality and const wf" [compiler-team#340](https://github.com/rust-lang/compiler-team/issues/340)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs
+  - No finalized FCPs this time.
+
+### WG checkins
+
+@*WG-prioritization*  checkin by @**spastorino**:
+>- We have now a [repo for the working group](https://github.com/rust-lang/compiler-team-prioritization/) and we are mainly handling our todo list as issues there.
+>- Our procedure automation cli is "complete" and outputs the agenda but we still need to integrate it with the Zulip bot.
+>- We've [documented our procedure](https://forge.rust-lang.org/compiler/prioritization/procedure.html) with a lot of details on Rust Forge.
+>- We have added Pre-FCP and FCP information to the announcements.
+>- There's a list of things we need to tweak [in our issue tracker](https://github.com/rust-lang/compiler-team-prioritization/issues?q=is%3Aopen+is%3Aissue), help is appreciated :)
+
+@*WG-rfc-2229* checkin by @**Aman Arora** and @**nikomatsakis**:
+> Work is currently on a temporary hiatus because of exam period.
+> 
+> We have been working on various refactorings to allow captures
+> to capture not just individual variables but arbitrary places.
+> 
+> Some of the refactorings we are working on:
+> 
+> * Making it so that we don't assume that we always know how many
+>   captured variables there are for a particular closure, since
+>   that will now need to be inferred by upvar analysis.
+> * Extending the [**HIR** definition of a 
+>   place](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/hir/place/struct.Place.html)
+>   to have more information. (rust-lang/project-rfc-2229#10)
+> * Created a data structure that captures the full places that a closure uses
+>   and then uses that to create the existing capture data structures of
+>   individual variables, thus testing out the new visitor and place information. (rust-lang/project-rfc-2229#7)
+> * Experimenting with the algorithm to capture minimal places (rust-lang/project-rfc-2229#9)
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "typeck: check for infer before type impls trait" [rust#73965](https://github.com/rust-lang/rust/pull/73965)
+  - PR by @**davidtwco**, assigned to @**Esteban Küber** 
+  - Fixes [rust#73886](https://github.com/rust-lang/rust/issues/73886) a `P-medium` nightly regression
+  - [Nominated](https://github.com/rust-lang/rust/issues/74734#issuecomment-667711436) to also fix [rust#74734](https://github.com/rust-lang/rust/issues/74734)
+- "forbid `#[track_caller]` on main" [rust#75130](https://github.com/rust-lang/rust/pull/75130)
+  - PR by @**lcnr**, assigned to @**ecstatic-morse**
+  - Fixes [rust#75125](https://github.com/rust-lang/rust/issues/75125) a `P-high` `I-unsound`  issue
+- "Forbid non-derefable types explicitly in unsizing casts" [rust#75136](https://github.com/rust-lang/rust/pull/75136)
+  - PR by @**Yuki Okushi**, assigned to @**oli**
+  - Fixes [rust#75118](https://github.com/rust-lang/rust/issues/75118) a beta regression
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Rename "cyclone" to "apple-a7" per changes in upstream LLVM" [rust#73086](https://github.com/rust-lang/rust/pull/73086)
+  - "cyclone" is now a legacy and flood with warnings + probably creates incorrectly optimized artifacts.
+  - Nominated by @**simulacrum**, [reason here](https://github.com/rust-lang/rust/pull/73086#issuecomment-666762193)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PR's S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "[android] Add support for android's file descriptor ownership tagging to libstd." [rust#74860](https://github.com/rust-lang/rust/pull/74860)
+  - @**nikomatsakis** is inclined to land the PR but thinks it needs an FCP given it's a user-facing change.
+  - This is also of interest of `T-libs` but it lies somewhere on the boundary of "implementation detail" and "public facing API change", so maybe everyone wants weigh in.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on libs-impl this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [51 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [28 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 2 P-high, 3 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 14 P-high, 50 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3AP-critical+label%3AT-compiler)
+- "LTO triggers apparent miscompilation on Windows 10 x64" [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - Discussed last week
+  - Assigned to @**pnkfelix**
+  - I-unsound regression from stable to stable, started failing when we updated to LLVM 9.0
+  - [LLVM issue reproduced on LLVM master](https://github.com/rust-lang/rust/issues/74498#issuecomment-661950983)
+  - Rust started to trigger this misbehavior more frequent since the introduction of [rust#69659](https://github.com/rust-lang/rust/pull/69659) that happened in 1.45+.
+  - @**pnkfelix** [filled a bug with LLVM upstream](https://bugs.llvm.org/show_bug.cgi?id=46943)
+  - [According to @**pnkfelix**](https://github.com/rust-lang/rust/issues/74498#issuecomment-667452406) the remaining question is if we should, for the short term, change that `range.rs` code to not used an `unchecked_add`, in order to (hopefully) bypass the misoptimization here or patch LLVM.
+  - @**pnkfelix** [also discusses](https://github.com/rust-lang/rust/issues/74498#issuecomment-668598776) if this generates an overflow or not.
+- "Unexpected trait resolution overflow error" [rust#74868](https://github.com/rust-lang/rust/issues/74868)
+  - Assigned to @**pnkfelix**
+  - Needs MCVE and bisection
+  - Possible culprits [rust#73357](https://github.com/rust-lang/rust/pull/73357) or [rust#73261](https://github.com/rust-lang/rust/pull/73261) maybe?
+  - According to @**Matthew Jasper** this is probably due to [rust#73452](https://github.com/rust-lang/rust/pull/73452), [rust#73905](https://github.com/rust-lang/rust/pull/73905) fixes that issue but is not suitable for a backport. @**Matthew Jasper** is going to provide a PR suitable for a backport.
+- "Lifetime error when indexing with borrowed index in beta but not in stable" [rust#74933](https://github.com/rust-lang/rust/issues/74933)
+  - Assigned to @**Gary Guo**
+  - Code that compiles on stable, fails on beta
+  - Regressed in [rust#73504](https://github.com/rust-lang/rust/pull/73504) which is a roll-up, likely [rust#72280](https://github.com/rust-lang/rust/pull/72280)
+  - PR by @**Gary Guo** and assigned to @**nikomatsakis** is up in [rust#74960](https://github.com/rust-lang/rust/pull/74960)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "libtest panics when running `should_panic` tests under QEMU armv7 " [rust#74820](https://github.com/rust-lang/rust/issues/74820)
+  - Cargo lib skeleton + should_panic test code fails on armv7
+  - It seems to be caused by [rust#72746](https://github.com/rust-lang/rust/pull/72746) by @**tmandry**
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Type mismatch in function arguments E0631, E0271 are falsely recognized as E0308 mismatched types" [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Discussed last week
+  - Regressed on [rust#73643](https://github.com/rust-lang/rust/pull/73643) which is a rollup, likely to be [rust#72493](https://github.com/rust-lang/rust/pull/72493)
+
+## Performance logs
+
+Triage done by [simulacrum](https://github.com/Mark-Simulacrum).
+Revision range: [efc02b03d18b0cbaa55b1e421d792f70a39230b2..19cefa68640843956eedd86227ddc1d35dbc6754](https://perf.rust-lang.org/?start=efc02b03d18b0cbaa55b1e421d792f70a39230b2&end=19cefa68640843956eedd86227ddc1d35dbc6754&absolute=false&stat=instructions%3Au)
+
+8 regressions, 2 improvements, 1 of them on rollups.
+1 outstanding nag from last week.
+
+Regressions
+* [convert higher ranked `Predicate`s to `PredicateKind::ForAll` #73503](https://github.com/rust-lang/rust/pull/73503)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=efc02b03d18b0cbaa55b1e421d792f70a39230b2&end=76e83339bb619aba206e5590b1e4b813a154b199&stat=instructions%3Au))
+  Up to 2.5% losses on stress tests, 1-2% on some other real-world crates. This was [expected](https://github.com/rust-lang/rust/pull/73503#issuecomment-661053865).
+* [mv std libs to library/ #73265](https://github.com/rust-lang/rust/pull/73265#issuecomment-668254522)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=9be8ffcb0206fc1558069a7b4766090df7877659&end=ac48e62db85e6db4bbe026490381ab205f4a614d&stat=instructions%3Au))
+  Up to 3% losses on tiny crates, and stress tests show 1-3% regressions.
+* [Update cargo #74923](https://github.com/rust-lang/rust/pull/74923#issuecomment-668261346)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=efc02b03d18b0cbaa55b1e421d792f70a39230b2&end=76e83339bb619aba206e5590b1e4b813a154b199&stat=instructions%3Au))
+  This was up to a 28% loss on some incremental benchmarks, as a result of regressions in proc macro performance (expansion is slower).
+* [Replace all uses of `log::log_enabled` with `Debug` printers #74876](https://github.com/rust-lang/rust/pull/74876#issuecomment-668262178)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=6e50a225fd67576e43bab1d4dfa3c97f310786a8&end=1799d31847294d6e3816c17679247a5c206e809a&stat=instructions%3Au))
+  A 1.5% regression on the ctfe stress test.
+* [std: Switch from libbacktrace to gimli (take 2) #74682](https://github.com/rust-lang/rust/pull/74682#issuecomment-668264270)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=cfc572cae2d1fc381cce476b5c787fd7221af98c&end=c058a8b8dc5dea0ed9b33e14da9e317e2749fcd7&stat=instructions%3Au))
+  An expected loss of up to 20% on smaller benchmarks. This was also a [max-rss](https://perf.rust-lang.org/compare.html?start=cfc572cae2d1fc381cce476b5c787fd7221af98c&end=c058a8b8dc5dea0ed9b33e14da9e317e2749fcd7&stat=max-rss)
+  regression, though how big is difficult to determine as this statistics is noisy. See discussion on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/gimli.20regressions).
+  Optimistically, there is a follow-up PR, "metadata: track the simplified Self type for every trait impl #75008", which may [eliminate](https://github.com/rust-lang/rust/pull/75008#issuecomment-667577993) a good portion of these losses.
+* [Normalize all opaque types when converting ParamEnv to Reveal::All #65989](https://github.com/rust-lang/rust/pull/65989#issuecomment-668267468)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=62f9aa94c0d0312544589bed78679d85646d4e62&end=6e87bacd37539b7e7cd75152dffd225047fa983a&stat=instructions%3Au))
+  A slight performance regression, of up to 4%. Expected.
+* [Move 'probably equal' methods to librustc_parse #75004](https://github.com/rust-lang/rust/pull/75004#issuecomment-668271907)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=8141873e6d50a0a0829fd756b0a16a92b27cfe22&end=46cf80dc1a75ad27f67e79f73fec371a16762494&stat=instructions%3Au))
+  A 1% regression on some smaller crates, rustdoc-only.
+* [Rollup of 10 pull requests #75060](https://perf.rust-lang.org/compare.html?start=e8876ae2c11f341565059b900eeae1254a9accf1&end=a99ae95c722d4dc8d1eef09aaa4e72d50d496e75&stat=instructions%3Au)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=e8876ae2c11f341565059b900eeae1254a9accf1&end=a99ae95c722d4dc8d1eef09aaa4e72d50d496e75&stat=instructions%3Au))
+  Up to 1% regression; unclear cause -- possibly `BTreeMap` changes.
+
+Improvements
+* [Cache non-exhaustive separately from attributes #74887](https://github.com/rust-lang/rust/pull/74887#issuecomment-668258043)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=517385b31b0add8487ff3cc27e216cf3f867ab44&end=10c375700ce170fc57cb617754dc6d0631d3d573&stat=instructions%3Au))
+  Up to 2% wins on tiny crates. This arose as an attempt to mitigate some of the effects of [re-landing gimli](https://github.com/rust-lang/rust/pull/74682).
+* [Move from `log` to `tracing` #74726](https://github.com/rust-lang/rust/pull/74726#issuecomment-668269871)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=de10abf50c514ca648eb3bdcbc912d46b7eb32a6&end=05762e3d6f5facafdd47efdf4203021fadf61bb1&stat=instructions%3Au))
+  Up to 1.5% wins, scattered across the smaller benchmarks. Expected.
+
+Nags:
+ * [Disable polymorphisation #74633](https://github.com/rust-lang/rust/pull/74633#issuecomment-668243225)
+   From last week, this was a performance neutral PR even though the landing of polymorphisation was a regression. Investigation on why needs to be conducted.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- async-std docs no longer build on recent nightlies [rust#75100](https://github.com/rust-lang/rust/issues/75100)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.
+

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-08-13.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-08-13.md
@@ -1,0 +1,179 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-08-13
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Next thursday 20th is RustConf
+- New MCPs (take a look, see if you like them!)
+  - "Stabilise `link-self-contained` option" [compiler-team#343](https://github.com/rust-lang/compiler-team/issues/343)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Stabilizable subset of const generics" [compiler-team#332](https://github.com/rust-lang/compiler-team/issues/332)
+  - "Move the compiler to a new `compiler/` directory" [compiler-team#336](https://github.com/rust-lang/compiler-team/issues/336)
+  - "Form t-compiler/wg-parser-library" [compiler-team#338](https://github.com/rust-lang/compiler-team/issues/338)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "refactor types to fit the chalk-ty generic plan" [compiler-team#341](https://github.com/rust-lang/compiler-team/issues/341)
+- Accepted MCPs
+  - "Create a WebAssembly target notification group." [compiler-team#337](https://github.com/rust-lang/compiler-team/issues/337)
+  - "Set ninja=true by default" [compiler-team#339](https://github.com/rust-lang/compiler-team/issues/339)
+  - "Implement const equality and const wf" [compiler-team#340](https://github.com/rust-lang/compiler-team/issues/340)
+- Finalized FCPs
+  - No new finished FCP this time.
+
+### WG checkins
+
+@*WG-rls2.0* checkin by @**matklad**:
+* RFC2912 (move from rls to rust-analyzer)
+  * soft-blocked on merging VS Code extensions: https://github.com/rust-lang/vscode-rust/issues/812.
+  * rust-analyzer is available via rustup, but update procedure for rust-lang/rust is not smooth: rust-analyzer often fails to build for weird targets.
+
+* Library-ification
+  * Started the effort to extract the parser (there's an MCP to form a parser library-ification wg, to improve communication)
+  * No big progress yet, mostly looking around at existing code
+  * Un-Grammar for concrete syntax trees: https://github.com/rust-analyzer/ungrammar/blob/master/rust.ungram
+    * Could we use it to generate rustc's AST? Seems unlikely :(
+  * Some glances at name resolution -- it seems like it should be possible to extract a small core of "set of 'module' scopes with names + fixed point iteration",
+     but this is low priority for now.
+
+* Org
+  *  Microsoft will sponsor rust-analyzer a bit via GitHub Sponsors: https://twitter.com/jeffwilcox/status/1293678932433055745
+
+* Misc
+  * Perf Dashboard https://rust-analyzer.github.io/metrics/
+  * Automatic reload on Cargo.toml changes
+
+@*WG-self-profile* checkin by @**wesleywiser**:
+
+- @**nagisa** contributed some [improved documentation](https://github.com/rust-lang/measureme/pull/118), [bug fixes and other enhancements](https://github.com/rust-lang/measureme/pull/119).
+- @**Mark-Simulacrum** updated perf.rlo to include flamegraphs, Chrome-profiler data and the raw self-profile output on new runs. (See [the new links on the details page](https://perf.rust-lang.org/detailed-query.html?commit=3fbed1739c384faabf00cd8a62abedbf506e949b&base_commit=4a689da944977496fb758cc2d700984cc6a10b7f&benchmark=style-servo-debug&run_name=full))
+- @**michaelwoerister** has [a PR](https://github.com/rust-lang/rust/pull/75452) up to shrink self-profile string data from detailed rustc invocations by 8-9%.
+- @**eddyb** has been working on using hardware counters (`rdpmc` instruction) to capture instruction counts instead of user-space timings. This is still work in progress but you can follow along in [this Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance).
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Fix regionck failure when converting Index to IndexMut" [rust#74960](https://github.com/rust-lang/rust/pull/74960)
+  - Fixes [a `P-critical` beta regression](https://github.com/rust-lang/rust/issues/74933) that regressed in [rust#73504](https://github.com/rust-lang/rust/pull/73504) which is a roll-up, likely [rust#72280](https://github.com/rust-lang/rust/pull/72280) 
+  - PR by @**Gary Guo** and assigned to @**nikomatsakis**
+- "Fix ICE #75307 in `format`" [rust#75319](https://github.com/rust-lang/rust/pull/75319)
+  - Fixes [a `P-medium` issue](https://github.com/rust-lang/rust/issues/75307)
+  - PR by @**Esteban Küber** and assigned to @**eddyb**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations this time.
+
+:back: / :shrug: / :hand:
+
+## PR's S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on T-compiler this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on libs-impl this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [52 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [30 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 2 P-high, 3 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 15 P-high, 50 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3AP-critical+label%3AT-compiler)
+- "LTO triggers apparent miscompilation on Windows 10 x64" [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - Discussed last week
+  - Assigned to @**pnkfelix**
+  - I-unsound stable regression, started failing when we updated to LLVM 9.0
+  - [LLVM issue reproduced on LLVM master](https://github.com/rust-lang/rust/issues/74498#issuecomment-661950983)
+  - Rust started to trigger this misbehavior more frequent since the introduction of [rust#69659](https://github.com/rust-lang/rust/pull/69659) that happened in 1.45+.
+  - @**pnkfelix** [filled a bug with LLVM upstream](https://bugs.llvm.org/show_bug.cgi?id=46943)
+  - [According to @**pnkfelix**](https://github.com/rust-lang/rust/issues/74498#issuecomment-667452406) the remaining question is if we should, for the short term, change that `range.rs` code to not used an `unchecked_add`, in order to (hopefully) bypass the misoptimization here or patch LLVM.
+  - @**pnkfelix** [also discusses](https://github.com/rust-lang/rust/issues/74498#issuecomment-668598776) if this generates an overflow or not.
+- "Unexpected trait resolution overflow error" [rust#74868](https://github.com/rust-lang/rust/issues/74868)
+  - Assigned to @**pnkfelix** and @**Matthew Jasper**
+  - Needs MCVE and bisection
+  - Possible culprits [rust#73357](https://github.com/rust-lang/rust/pull/73357) or [rust#73261](https://github.com/rust-lang/rust/pull/73261) maybe?
+  - According to @**Matthew Jasper** this is probably due to [rust#73452](https://github.com/rust-lang/rust/pull/73452), [rust#73905](https://github.com/rust-lang/rust/pull/73905) fixes that issue but is not suitable for a backport. @**Matthew Jasper** is going to provide a PR suitable for a backport.
+- "Panic when compiling gluon on 1.46" [rust#75313](https://github.com/rust-lang/rust/issues/75313)
+  - It is unassigned
+  - It's a beta regression, regressed in [rust#72796](https://github.com/rust-lang/rust/issues/72796)
+  - @**RalfJ** [provided a PR](https://github.com/rust-lang/rust/pull/75419)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No P-critical issues for libs-impl this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No P-critical issues for T-rustdoc this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "libtest panics when running `should_panic` tests under QEMU armv7 " [rust#74820](https://github.com/rust-lang/rust/issues/74820)
+  - Cargo lib skeleton + should_panic test code fails on armv7
+  - It seems to be caused by [rust#72746](https://github.com/rust-lang/rust/pull/72746) by @**tmandry**
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Type mismatch in function arguments E0631, E0271 are falsely recognized as E0308 mismatched types" [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Discussed last week
+  - Regressed on [rust#73643](https://github.com/rust-lang/rust/pull/73643) which is a rollup, likely to be [rust#72493](https://github.com/rust-lang/rust/pull/72493)
+
+## Performance logs
+
+Triage done by [simulacrum](https://github.com/Mark-Simulacrum).
+Revision range: [19cefa68640843956eedd86227ddc1d35dbc6754..8b84156c6ee2b4e707dc32f5a516e3143ab924d3](https://perf.rust-lang.org/?start=19cefa68640843956eedd86227ddc1d35dbc6754&end=8b84156c6ee2b4e707dc32f5a516e3143ab924d3&absolute=false&stat=instructions%3Au)
+
+1 regression, 1 improvement, 1 of them on rollups.
+0 outstanding nags from last week.
+
+Regressions
+* [Rollup of 5 pull requests #75174](https://github.com/rust-lang/rust/pull/75174)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=32d14eba47ee8bb0b5edb04bcf652517f81c4cf5&end=119d2a1a98fe87d4ae6cabf12134a0ef2fb95851))
+  Slight loss, up to 1%. Unclear if spurious. Likely caused by [Replace `Memoryblock` with `NonNull<[u8]>` #75152](https://github.com/rust-lang/rust/pull/75152).
+
+Improvements
+* [Remove two fields from `SubstFolder` #75133](https://github.com/rust-lang/rust/pull/75133)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=c9b80bb3ff194d488fdd95da2ef23bd466f921cb&end=d08eb98698cbce56e599324fb83d55eef2cac408))
+  Up to 2% wins on wf-projection stress test.
+
+New nags to follow up on
+* [#75174](https://github.com/rust-lang/rust/pull/75152#issuecomment-672452770)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for T-compiler this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for libs-impl this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-08-20.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-08-20.md
@@ -1,0 +1,211 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-08-20
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Next Thursday 27th we will be releasing Rust 1.46!
+- [Virtual RustConf](https://rustconf.com/) is starting in 2hs 
+- New MCPs (take a look, see if you like them!)
+  - "Uplift `temporary-cstring-as-ptr` lint from `clippy` into rustc" [compiler-team#346](https://github.com/rust-lang/compiler-team/issues/346)
+  - "Uplift `drop-bounds` lint from clippy into rustc" [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Move the compiler to a new `compiler/` directory" [compiler-team#336](https://github.com/rust-lang/compiler-team/issues/336)
+  - "Form t-compiler/wg-parser-library" [compiler-team#338](https://github.com/rust-lang/compiler-team/issues/338)
+  - "Stabilise `link-self-contained` option" [compiler-team#343](https://github.com/rust-lang/compiler-team/issues/343)
+  - "Moving `#[cfg(test)]` modules into a separate files to save recompiling the `std` crate" [compiler-team#344](https://github.com/rust-lang/compiler-team/issues/344)
+  - "Add a lint for attempting to mutate a `const` item" [compiler-team#345](https://github.com/rust-lang/compiler-team/issues/345)
+- Accepted MCPs
+  - "refactor types to fit the chalk-ty generic plan" [compiler-team#341](https://github.com/rust-lang/compiler-team/issues/341)
+- Finalized FCPs (disposition merge)
+  - "Upgrade the FreeBSD toolchain to version 11.4" [rust#75204](https://github.com/rust-lang/rust/pull/75204)
+  - "Stabilizable subset of const generics" [compiler-team#332](https://github.com/rust-lang/compiler-team/issues/332)
+- "allow escaping bound vars when normalizing `ty::Opaque`" [rust#75443](https://github.com/rust-lang/rust/pull/75443) has been unilaterally beta-accepted (by @**pnkfelix**)
+
+
+### WG checkins
+
+@*WG-traits* checkin by @**nikomatsakis** and @**Jack Huey**:
+> WG-traits has been on vacation/break
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+
+- "Don't immediately error for cycles during normalization" [rust#75494](https://github.com/rust-lang/rust/pull/75494)
+  - PR by @**Matthew Jasper**, assigned to @**nikomatsakis**
+  - Not yet merged to master
+  - Fixes a `P-critical` beta regression [rust#74868](https://github.com/rust-lang/rust/issues/74868)
+  - [Code that should compile](https://github.com/weiznich/wundergraph/tree/ffbb883eea169d1750659e038d7051a84b21f6e7/wundergraph_example) now ICEs
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [51 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [30 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 2 P-high, 4 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 15 P-high, 50 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=label%3AP-critical+label%3AT-compiler)
+- "LTO triggers apparent miscompilation on Windows 10 x64" [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - Discussed last week
+  - Assigned to @**pnkfelix**
+  - I-unsound stable regression, started failing when we updated to LLVM 9.0
+  - [LLVM issue reproduced on LLVM master](https://github.com/rust-lang/rust/issues/74498#issuecomment-661950983)
+  - Rust started to trigger this misbehavior more frequent since the introduction of [rust#69659](https://github.com/rust-lang/rust/pull/69659) that happened in 1.45+.
+  - @**pnkfelix** [filled a bug with LLVM upstream](https://bugs.llvm.org/show_bug.cgi?id=46943)
+  - [According to @**pnkfelix**](https://github.com/rust-lang/rust/issues/74498#issuecomment-667452406) the remaining question is if we should, for the short term, change that `range.rs` code to not used an `unchecked_add`, in order to (hopefully) bypass the misoptimization here or patch LLVM.
+  - @**pnkfelix** [also discusses](https://github.com/rust-lang/rust/issues/74498#issuecomment-668598776) if this generates an overflow or not.
+- "Unexpected trait resolution overflow error" [rust#74868](https://github.com/rust-lang/rust/issues/74868)
+  - Assigned to @**pnkfelix** and @**Matthew Jasper**
+  - Needs MCVE and bisection
+  - Regressed on [rust#73452](https://github.com/rust-lang/rust/pull/73452)
+  - PR pending for review by @**Matthew Jasper** [rust#75494](https://github.com/rust-lang/rust/pull/75494)
+- "Panic when compiling gluon on 1.46" [rust#75313](https://github.com/rust-lang/rust/issues/75313)
+  - Assigned to @**lcnr** 
+  - It's a beta regression, regressed in [rust#72796](https://github.com/rust-lang/rust/issues/72796)
+  - Fixed by [rust#75443](https://github.com/rust-lang/rust/pull/75443), issue still open waiting for backport
+      - (was unilaterally accepted for beta backport; see earlier announcement)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "libtest panics when running `should_panic` tests under QEMU armv7 " [rust#74820](https://github.com/rust-lang/rust/issues/74820)
+  - Discussed last week
+  - Cargo lib skeleton + should_panic test code fails on QEMU armv7
+  - It seems to be caused by [rust#72746](https://github.com/rust-lang/rust/pull/72746) by @**tmandry**
+  - Seems to be specific to QEMU, [see comment](https://github.com/rust-lang/rust/issues/74820#issuecomment-673977399)
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Type mismatch in function arguments E0631, E0271 are falsely recognized as E0308 mismatched types" [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Discussed last week
+  - Regressed on [rust#73643](https://github.com/rust-lang/rust/pull/73643) which is a rollup, likely to be [rust#72493](https://github.com/rust-lang/rust/pull/72493)
+
+## Performance logs
+
+This week was quite noisy, with many small regressions and improvements.
+Overall, instruction counts have increased somewhat, while max RSS remains the
+same. There were several updates to core data structures (`HashMap`,
+`IndexMap`), which contributed to some of the noise. 
+
+Triage done by @ecstaticmorse.
+Revision range: [8b84156c6ee2b4e707dc32f5a516e3143ab924d3..67e7b9b8cf776222825dbbd4cb1e39b7765ef27c](https://perf.rust-lang.org/?start=8b84156c6ee2b4e707dc32f5a516e3143ab924d3&end=67e7b9b8cf776222825dbbd4cb1e39b7765ef27c&absolute=false&stat=instructions%3Au)
+
+4 Regressions, 3 Improvements, 4 Mixed, 0 of them in rollups.
+
+#### 4 Regressions
+
+[#73851](https://github.com/rust-lang/rust/pull/73851) Remove most specialization use in serialization
+* [Very small regressions across the board](https://perf.rust-lang.org/compare.html?start=95879ad96104afa584e7aec7806cec1d0bd84116&end=668a34e0f438d4a950b9440239656d6755ad963c&stat=instructions:u)
+
+[#75048](https://github.com/rust-lang/rust/pull/75048) Prevent `__rust_begin_short_backtrace` frames from being tail-call optimised away
+* [Regressions in several benchmarks](https://perf.rust-lang.org/compare.html?start=c2d1b0d9800d922b0451921d2ce17e6ae665d5b4&end=f3a9de9b08659e20ce7c282ed77bc43ddd149107&stat=instructions:u)
+* Mostly for crates with very little codegen
+
+[#75306](https://github.com/rust-lang/rust/pull/75134) Hash parent ExpnData
+* [Very small regressions across the board](https://perf.rust-lang.org/compare.html?start=8bc801b05019cd3e0ef19e6c4c028d55baa645d2&end=543f03d24118d3af784aa98c507c00e30c796a0e&stat=instructions:u)
+* Necessary for correctness
+
+[#73656](https://github.com/rust-lang/rust/pull/73656) move Deaggregate pass to post\_borrowck\_cleanup 
+* [Very small regressions across the board](https://perf.rust-lang.org/compare.html?start=4b9ac5161781ca6a376daab3d3b2f2623d8f3789&end=cbe7c5ce705896d4e22bf6096590bc1f17993b78&stat=instructions:u)
+
+#### 3 Improvements
+
+[#74512](https://github.com/rust-lang/rust/pull/74512) Put panic code path from `copy_from_slice` into cold function
+* [Small improvements across the board, albeit mostly for incremental builds](https://perf.rust-lang.org/compare.html?start=576d27c5a6c80cd39ef57d7398831d8e177573cc&end=847ba835ce411d47364a93ddf0b4a5c0f27928a9&stat=instructions:u)
+
+[#74877](https://github.com/rust-lang/rust/pull/74877) Implement the `min_const_generics` feature gate
+* [A small improvement on `wf-projection-stress`](https://perf.rust-lang.org/compare.html?start=f3a9de9b08659e20ce7c282ed77bc43ddd149107&end=f9c2177ddc605f9c75ca1a3e6ddb33835b8a178d&stat=instructions:u)
+
+[#75121](https://github.com/rust-lang/rust/pull/75121)  Avoid `unwrap_or_else` in str indexing
+* [A small improvement on `encoding-opt`](https://perf.rust-lang.org/compare.html?start=63e34422bbaf4ae4ed5ae7309183185aa2aa13a4&end=98922795f68e86b0bca5aea8cfc66499d58eba1a&stat=instructions:u)
+
+#### 4 Mixed
+
+[#70052](https://github.com/rust-lang/rust/pull/70052)  Update hashbrown to 0.8.1
+* [Mixed results across the board](https://perf.rust-lang.org/compare.html?start=d4c940f0821754a98491b2d23fbb5323c14a2bf5&end=8b26609481c956a666f9189738f1ba611078e1ab&stat=instructions:u)
+
+[#75278](https://github.com/rust-lang/rust/pull/75278)  Upgrade indexmap and use it more
+* [Very small regressions for most builds, notably docs](https://perf.rust-lang.org/compare.html?start=39e593ab14c53fda63c3f2756716c5ad3cbb6465&end=18f3be7704a4ec7976fcd1272c728974243d29bd&stat=instructions:u)
+* Offset by larger wins on a few benchmarks: `encoding`, `keccak`, `inflate`.
+* Author cites improved CPU cycle counts.
+
+[#75306](https://github.com/rust-lang/rust/pull/75306) Update hashbrown to 0.8.2 
+* [Mixed results across the board](https://perf.rust-lang.org/compare.html?start=dcf107728c4e545b9fee6b0e6a929837429275cf&end=aced185592b6f99a21190965a7fecfcd72d954dc&stat=instructions:u)
+* Mostly improvements, but `incr-patched: println` has taken a rather large hit.
+
+[#75382](https://github.com/rust-lang/rust/pull/75382) First iteration of simplify match branches
+* [Very small improvements across the board](https://perf.rust-lang.org/compare.html?start=b6396b75e782954acb085447fb836c4e0ff5281d&end=5e3f1b148db5bfa27fee52464ae1f5d34c49d77b&stat=instructions:u)
+* However, a few moderate regressions on synthetic benchmarks
+
+Nags requiring follow up
+
+- [#73656](https://github.com/rust-lang/rust/pull/73656)
+- [#73851](https://github.com/rust-lang/rust/pull/73851)
+- [#75048](https://github.com/rust-lang/rust/pull/75048)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Disable zlib in LLVM on Haiku" [rust#75655](https://github.com/rust-lang/rust/pull/75655)
+  - Assigned to @**simulacrum**
+  - LLVM_ENABLE_ZLIB flag enabled in LLVM builds causes undefined symbols
+  - @**simulacrum** this is just too many platforms which are broken when enabling zlib.
+  - @**simulacrum** is leaning towards disabling zlib entirely until we can provide a workaround.
+  - Nominated to discuss a possible solution to this problem.
+  - Haiku is Tier 3 but issue shows up also on NetBSD and aarch64-apple-darwin
+  - There are some proposed solutions [here](https://github.com/rust-lang/rust/pull/75655#issuecomment-675424522) and [here](https://github.com/rust-lang/rust/pull/75655#issuecomment-675475933) and [the one proposed by @**mati865** is reported to work](https://github.com/rust-lang/rust/pull/75655#issuecomment-677090444)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-08-27.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-08-27.md
@@ -1,0 +1,210 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-08-27
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Rust 1.46 is being released today! :tada: :tada: :tada:
+- Crater run for 1.46 [rust#75142](https://github.com/rust-lang/rust/issues/75142) came back clear. In particular we wanted to check if [rust#75494](https://github.com/rust-lang/rust/issues/75494) was ok.
+- Tomorrow (friday 28th) we have [our planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html)
+- New MCPs (take a look, see if you like them!)
+  - "Add StatementKind::Call to MIR" [compiler-team#348](https://github.com/rust-lang/compiler-team/issues/348)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Uplift `temporary-cstring-as-ptr` lint from `clippy` into rustc" [compiler-team#346](https://github.com/rust-lang/compiler-team/issues/346)
+  - "Uplift `drop-bounds` lint from clippy into rustc" [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Auto-generate lint documentation" [compiler-team#349](https://github.com/rust-lang/compiler-team/issues/349)
+  - "Don't build tools by default with `x.py build`" [compiler-team#351](https://github.com/rust-lang/compiler-team/issues/351)
+- Accepted MCPs
+  - "Move the compiler to a new `compiler/` directory" [compiler-team#336](https://github.com/rust-lang/compiler-team/issues/336)
+  - "Form t-compiler/wg-parser-library" [compiler-team#338](https://github.com/rust-lang/compiler-team/issues/338)
+  - "Stabilise `link-self-contained` option" [compiler-team#343](https://github.com/rust-lang/compiler-team/issues/343)
+  - "Moving `#[cfg(test)]` modules into a separate files to save recompiling the `std` crate" [compiler-team#344](https://github.com/rust-lang/compiler-team/issues/344)
+  - "Add a lint for attempting to mutate a `const` item" [compiler-team#345](https://github.com/rust-lang/compiler-team/issues/345)
+- Finalized FCPs (disposition merge)
+  - "stabilize ptr_offset_from" [rust#74238](https://github.com/rust-lang/rust/pull/74238)
+  - "Stabilize Range[Inclusive]::is_empty" [rust#75132](https://github.com/rust-lang/rust/pull/75132)
+
+### WG checkins
+
+@*WG-diagnostics* checkin by @**Esteban Küber** 
+>- More gracefully handle patterns used in an incorrect manner (all combinations of struct variant/enum variant/unit variant that do not correspond to their declaration) with structured suggestions and pointing at definitions
+>- From fasterthanli.me (amos)'s last two articles we've gotten 3 diagnostics improvements
+cleaning up parser errors (regression from a refactor some time back, reduced amount of parse errors inside struct definitions significantly)
+    - structured suggestions for methods missing `self` receiver
+    - more structured suggestions for boxed trait objects instead of impl Trait on non-coerceable tail expressions
+>- Fix parser regression: `{block} &&true` is a valid tail expression in an `fn foo() -> &&bool`. This was introduced a couple of releases back, will be fixed in 1.47.
+>- We detect `===/!==` and `for foo of bar` (JS syntax) and suggest correct syntax
+>- Various clean ups, rewordings, fixing of ICEs and silencing of redundant errors
+>- Further various cleanups of `::` -> `:` typos (continue to hate the type ascription syntax, but I'll cope)
+>- Removal of type path string comparisons from diagnostics code and instead use "diagnostic_item"s.
+>- Further work on lifetime errors caused by implicit`'static` lifetimes with targeted diagnostics
+>- Tweak errors on arguments caused by Sized requirements and suggest to borrow
+>- Detect `foo.collect::Vec<_>();` and suggest `foo.collect::<Vec<_>>();`
+>- Provide suggestions for some moved value errors
+>
+>Changes requiring to be signed off (or closed)
+>
+>- [rust#74130](https://github.com/rust-lang/rust/pull/74130)
+>- [rust#71481](https://github.com/rust-lang/rust/pull/71481)
+>
+>Feeling fancy and wanting to highlight still unmerged change that I'm proud of:
+>
+>- [rust#75931](https://github.com/rust-lang/rust/pull/75931) Suggest `if let x = y` when encountering `if x = y`
+>
+>Kind of major change announcement:
+>
+>- [rust#75138](https://github.com/rust-lang/rust/pull/75138) moves a lot of the error handling logic "out of the happy path"
+  by using structs to describe the error situation and having a scheme for rendering said structs.
+
+@*WG-async-foundations* checkin by @**nikomatsakis** and @**tmandry**
+> Work on the compiler has, I believe, been slow lately. There has been progress towards an RFC for the `Stream` trait and experiments for a lint around values that should be live over yields. -- nikomatsakis, who may be a bit behindCheckin text
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Account for async functions when suggesting new named lifetime" [rust#75867](https://github.com/rust-lang/rust/pull/75867)
+  - Opened by @**Esteban Küber**, reviewed by @**pickfire**
+  - Fixes [rust#75850](https://github.com/rust-lang/rust/issues/75850)
+  - Nominating for beta backport simply because it is already in stable, but there's no harm on letting this ride the train.
+  - Assigned P-low
+- "Fix another clashing_extern_declarations false positive." [rust#75885](https://github.com/rust-lang/rust/pull/75885)
+  - Opened by @**jumbatm**, reviewed by @**nagisa** and @**lcnr** 
+  - Fixes [rust#75739](https://github.com/rust-lang/rust/issues/75739)
+  - [Backport reasons](https://github.com/rust-lang/rust/pull/75885#issuecomment-679270849)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [50 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [30 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 16 P-high, 54 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "libtest panics when running `should_panic` tests under QEMU armv7 " [rust#74820](https://github.com/rust-lang/rust/issues/74820)
+  - Discussed last week
+  - Cargo lib skeleton + should_panic test code fails on QEMU armv7
+  - It seems to be caused by [rust#72746](https://github.com/rust-lang/rust/pull/72746) by @**tmandry**
+  - Seems to be specific to QEMU, [see comment](https://github.com/rust-lang/rust/issues/74820#issuecomment-673977399)
+- "diagnostics: "one type is more general" for two identical types?" [rust#75791](https://github.com/rust-lang/rust/issues/75791)
+  - Very confusing error message
+  - @**matthiaskrgr** suggested that it may have regressed on [rust#73643](https://github.com/rust-lang/rust/pull/73643) which is a rollup.
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Type mismatch in function arguments E0631, E0271 are falsely recognized as E0308 mismatched types" [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Discussed last week
+  - Regressed on [rust#73643](https://github.com/rust-lang/rust/pull/73643) which is a rollup, likely to be [rust#72493](https://github.com/rust-lang/rust/pull/72493)
+
+## Performance logs
+
+This week saw an upgrade to LLVM 11, which resulted in large speedups to
+optimized builds. This offsets the slowdown we observed as part of the [upgrade
+to LLVM 10][llvm-10-results]. Many thanks to rust-lang and LLVM contributor
+[@nikic](https://github.com/nikic) for their work to measure [LLVM
+performance][llvm-fast]. That upgrade did cause slight regressions to check and
+debug builds, but on the whole it is a significant win for compile times.
+
+Triage done by @ecstaticmorse.
+Revision range: [67e7b9b8cf776222825dbbd4cb1e39b7765ef27c..03017003c77d782cf7ed841a05d7c628a9b93f25][range]
+
+[llvm-10-results]: https://perf.rust-lang.org/compare.html?start=0aa6751c19d3ba80df5b0b02c00bf44e13c97e80&end=82911b3bba76e73afe2881b732fe6b0edb35d5d3&stat=instructions:u
+[llvm-fast]: https://nikic.github.io/2020/05/10/Make-LLVM-fast-again.html
+[range]: https://perf.rust-lang.org/?start=67e7b9b8cf776222825dbbd4cb1e39b7765ef27c&end=03017003c77d782cf7ed841a05d7c628a9b93f25&absolute=false&stat=instructions%3Au
+
+1 Regression, 4 Improvements, 0 of them in rollups.
+
+#### Regressions
+
+[#75555](https://github.com/rust-lang/rust/pull/75555) Cargo update (almost) all the things! 
+- [A very small regression](https://perf.rust-lang.org/compare.html?start=30f0a07684f6c1f5df62d69e9519d82e13d6bf2d&end=1656582822a80139d725e56f00c564f4f58f2883&stat=instructions:u)
+
+#### Improvements
+
+[#75145](https://github.com/rust-lang/rust/pull/75145) Reference lang items during AST lowering 
+- [An improvement of ~3% on `await-call-tree`](https://perf.rust-lang.org/compare.html?start=33c96b4d9782cf6364e47cb2c904e66b06c22bb4&end=792c645ca7d11a8d254df307d019c5bf01445c37&stat=instructions:u)
+- Coupled with small improvements across the board 
+
+[#75590](https://github.com/rust-lang/rust/pull/75590) Add a packed/tagged pointer abstraction and utilize it for ParamEnv 
+- [A small improvement on `keccak`/`inflate`](https://perf.rust-lang.org/compare.html?start=9900178cba95369cd5822c8ce579edcc89ffeb76&end=32c654a9795b0d88541e56ba9da4150e34f1d5f9&stat=instructions:u)
+
+[#73526](https://github.com/rust-lang/rust/pull/73526) Upgrade to LLVM 11 (rc2) 
+- [An improvement on optimized builds](https://perf.rust-lang.org/compare.html?start=e482c86b9de32c6392cb83aa97d72e22425163f9&end=7ce71c362be9a89e7897ac066aba6e3e6f747800&stat=instructions:u)
+- Tempered by a small regression on debug and check builds.
+
+[#75813](https://github.com/rust-lang/rust/pull/75813) Lazy decoding of DefPathTable from crate metadata (non-incremental case) 
+- [A major improvement on small crates, especially on check builds](https://perf.rust-lang.org/compare.html?start=7ce71c362be9a89e7897ac066aba6e3e6f747800&end=d5abc8d3b2e14c8793182b427520497a90b6de83&stat=instructions:u)
+
+#### Nags requiring follow up
+
+None
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Unsizing coercion does not normalize associated types in structs." [rust#75899](https://github.com/rust-lang/rust/issues/75899)
+  - Opened and nominated by @**eddyb** 
+- "Add aarch64-pc-windows-msvc to CI" [rust#75914](https://github.com/rust-lang/rust/pull/75914)
+  - PR by @**arlosi**, reviewed by @**Ryan Levick**
+  - This one seems more a T-infra nomination
+  - @**Pietro Albini** may have wanted to notify the compiler team about this
+  - The infrastructure team approved allocating a dedicated builder for this!
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-09-03.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-09-03.md
@@ -1,0 +1,188 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-09-03
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow (Friday 4th at <time:2020-09-04T14:00:00+00:00>) we are going to [discuss results of 2020 Contributor Survey](https://github.com/rust-lang/compiler-team/issues/318)
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Uplift `temporary-cstring-as-ptr` lint from `clippy` into rustc" [compiler-team#346](https://github.com/rust-lang/compiler-team/issues/346)
+  - "Uplift `drop-bounds` lint from clippy into rustc" [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347)
+  - "Add StatementKind::Call to MIR" [compiler-team#348](https://github.com/rust-lang/compiler-team/issues/348)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Don't build tools by default with `x.py build`" [compiler-team#351](https://github.com/rust-lang/compiler-team/issues/351)
+- Accepted MCPs
+  - "Auto-generate lint documentation" [compiler-team#349](https://github.com/rust-lang/compiler-team/issues/349)
+- Finalized FCPs (disposition merge)
+  - "Tracking issue for hint::spin_loop (renamed sync::atomic::spin_loop_hint)" [rust#55002](https://github.com/rust-lang/rust/issues/55002)
+  - "Stabilize deque_make_contiguous" [rust#74559](https://github.com/rust-lang/rust/pull/74559)
+
+### WG checkins
+
+@*WG-rustc-dev-guide* checkin by @**Santiago Pastorino**:
+>- Rewrite/update compiler source code chapter [#765](https://github.com/rust-lang/rustc-dev-guide/pull/765)
+>- Document serialization in rustc [#785](https://github.com/rust-lang/rustc-dev-guide/pull/785)
+>- Expand on the documentation for polymorphization. [#803](https://github.com/rust-lang/rustc-dev-guide/pull/803)
+>- Add basic steps for a new target [#805](https://github.com/rust-lang/rustc-dev-guide/pull/805)
+>- Fix misguided suggestions in config.toml [#840](https://github.com/rust-lang/rustc-dev-guide/pull/840)
+>- Adds documentation to cover spanview output [#844](https://github.com/rust-lang/rustc-dev-guide/pull/844)
+>- @**mark-i-am**, formerly one of the working group leads, [has stepped down](https://internals.rust-lang.org/t/until-we-meet-again/12985) on their Rust involvement. @**mark-i-am** was a great co-lead with me and an awesome person to hang with. The work they've done is invaluable and it will be hugely missed.
+>
+>#### Changes in progress
+>
+>- Explain stages (take N) [#843](https://github.com/rust-lang/rustc-dev-guide/pull/843). This is an attempt by @jynelson to explain stages better for new contributors. However, after some discussion on the PR, it's not clear that the new explanation is better than the existing '`--stage N` runs `stageN/rustc`'. Opinions welcome!
+>- Name `rustbuild` instead of saying 'the bootstrap binary' [#808](https://github.com/rust-lang/rustc-dev-guide/pull/808). This needs a consensus that it's actually useful terminology.
+>- Fix dep-graph-caller-callee test location [#845](https://github.com/rust-lang/rustc-dev-guide/pull/845)
+>- Update error codes to match the current implementation [#841](https://github.com/rust-lang/rustc-dev-guide/pull/841)
+
+@*WG-llvm* checkin by @**nagisa** 
+> no updates from me, but its more like I didn’t spend too much time looking for things rather than there not being any activity.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Fix loading pretty-printers in rust-lldb script" [rust#76015](https://github.com/rust-lang/rust/pull/76015)
+  - Opened by @ortem and reviewed by @**Eric Huss** and @**simulacrum**  
+  - Fixes a [stable regression](https://github.com/rust-lang/rust/issues/76006)
+- "[beta] Clippy backport for stabilization of range_is_empty feature" [rust#76051](https://github.com/rust-lang/rust/pull/76051)
+  - Opened by @flip1995 and assigned to @**simulacrum**
+  - This is not merged on master
+  - Nominated because @**scottmcm** asked about it in [rust-clippy#5956](https://github.com/rust-lang/rust-clippy/issues/5956) but they have [no strong opinion on this](https://github.com/rust-lang/rust/pull/76051#issuecomment-685461529)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [52 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [32 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 1 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 18 P-high, 56 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "incorrect code generation for i686 release build for 1.47 beta and nightly" [rust#76042](https://github.com/rust-lang/rust/issues/76042)
+  - Unassigned
+  - `I-unsound` issue and beta regression
+  - It seems to be [a bug in LLVM](https://bugs.llvm.org/show_bug.cgi?id=47278), triggered by compiler flag `-Copt-level=0`
+- "Regression in proc macro panics being reported as compiler bugs" [rust#76270](https://github.com/rust-lang/rust/issues/76270)
+  - Fresh issue, prioritized 1 minute before the meeting
+  - Assigned to @**Aaron Hill** who seems that will provide a PR soon
+  - Nightly regression [rust#75082](https://github.com/rust-lang/rust/pull/75082)
+  - Looks like it breaks `syn` and `quote`
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "diagnostics: "one type is more general" for two identical types?" [rust#75791](https://github.com/rust-lang/rust/issues/75791)
+  - Discussed last week
+  - Opened by @**matthiaskrgr**, unassigned
+  - Confusing suggestion by the diagnostics
+  - Niko [comments](https://github.com/rust-lang/rust/issues/75791#issuecomment-681997605) likely the culprit to be PR [rust#72493](https://github.com/rust-lang/rust/pull/72493), points to this [Zulip discussion](https://zulip-archive.rust-lang.org/238009tcompilermeetings/49871weeklymeeting2020082754818.html#208226050)
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Type mismatch in function arguments E0631, E0271 are falsely recognized as E0308 mismatched types" [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Discussed last week
+  - Very confusing error message
+  - [Comment suggesting a likely culprit](https://github.com/rust-lang/rust/issues/74400#issuecomment-661860117)
+  - [@**nikomatsakis** suggests to improve the error reporting for the new point where the error occurs](https://github.com/rust-lang/rust/issues/74400#issuecomment-664526040)
+
+## Performance logs
+
+A quiet week for the most part with the exception of two PRs. The first,
+[#76027](https://github.com/rust-lang/rust/pull/76027), was a rather large regression that was soon fixed by [#76030](https://github.com/rust-lang/rust/pull/76030). The net result seems to be a small improvement overall on optimized and debug builds.
+
+Triage done by @**ecstatic-morse**.
+Revision range: [03017003c77d782cf7ed841a05d7c628a9b93f25..d927e5a655809b6b20501889e093c085d6ffe6f7][range]
+
+[range]: https://perf.rust-lang.org/?start=03017003c77d782cf7ed841a05d7c628a9b93f25&end=d927e5a655809b6b20501889e093c085d6ffe6f7&absolute=false&stat=instructions%3Au
+
+1 Regression, 2 Improvements, 0 of them in rollups.
+
+#### Regressions
+
+[#76027](https://github.com/rust-lang/rust/pull/76027) ty: remove obsolete pretty printer
+- [A major regression on some `incr-patched` benchmarks](https://perf.rust-lang.org/compare.html?start=e98f0632bbec24b196dbd6fc820537f6f3724807&end=8ed5cb56b5e5cc216eb6820a44dd4f7ef65107b0&stat=instructions:u)
+- Very small regressions on full builds of other benchmarks along with a major one on `await-call-tree`
+- Seems to have been solved by #76030 (see below).
+
+#### Improvements
+
+[#75754](https://github.com/rust-lang/rust/pull/75754) Switch to Snappy compression for metadata
+- [A small improvement across the board](https://perf.rust-lang.org/compare.html?start=fe8ab8a530fc2369e2748421a319444383363340&end=7fc048f0712ba515ca11fac204921b9ad8a0c5a3&stat=instructions:u)
+
+[#76030](https://github.com/rust-lang/rust/pull/76030) cg\_llvm: `fewer_names` in `uncached_llvm_type`
+- [A major improvement on some `incr-patched` benchmarks](https://perf.rust-lang.org/compare.html?start=897ef3a0ec001b89fffe7125c20d6a6bb12fee6c&end=1d22f75c9f75cad2e408a145861904898ac982dd&stat=instructions:u)
+- Small improvements on full builds of other benchmarks along with a major one on `await-call-tree`
+
+#### Nags requiring follow up
+
+None
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Unsizing coercion does not normalize associated types in structs." [rust#75899](https://github.com/rust-lang/rust/issues/75899)
+  - Opened and nominated by @**eddyb**
+  - [Nomination reason](https://github.com/rust-lang/rust/issues/75899#issue-685378672)
+  - @**eddyb** was unsure if nominating this for `T-lang` first or `T-compiler` but decided to try with `T-compiler` first
+- "Widen TypeId from 64 bits to 128." [rust#75923](https://github.com/rust-lang/rust/pull/75923)
+  - Opened by @**eddyb**
+  - @**simulacrum** [nominated it to talk about @**eddyb**'s concern wrt to typeid stabilization; it might be a T-lang question too](https://github.com/rust-lang/rust/pull/75923#issuecomment-684051064).
+- "Large performance drop in compiled binary in stable rust 1.45.2 vs 1.44.0 on x86_64 linux" [rust#76247](https://github.com/rust-lang/rust/issues/76247)
+  - Nominated by @*WG-prioritization* to raise awareness of a runtime performance regression that seems to have started when we upgraded to LLVM 10 and LLVM 11rc2 doesn't fix.
+  - Unsure if it's a known LLVM issue but [it doesn't seem to be part of the issues that block the LLVM 11 release](https://bugs.llvm.org/show_bug.cgi?id=46725)
+  - [It seems like LLVM is struggling with the conversion between boolean vectors and integer vectors.](https://github.com/rust-lang/rust/issues/76247#issuecomment-686451846)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-09-10.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-09-10.md
@@ -1,0 +1,195 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-09-10
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Please fill out the [MCP retrospective survey](https://docs.google.com/forms/d/e/1FAIpQLSc-7SN8HCkJBwgQverz9NfBAo2Ik_dwk6DyJtsQjVjnWxK5Pw/viewform); we'll use the results to guide the upcoming design meeting  Friday Sep 18.
+- Contributors may want to check out [improving bootstrap times for contributor fun and profit Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/improving.20bootstrap.20times.20for.20contributor.20fun.20and.20profit)
+- New MCPs (take a look, see if you like them!)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Uplift `temporary-cstring-as-ptr` lint from `clippy` into rustc" [compiler-team#346](https://github.com/rust-lang/compiler-team/issues/346)
+  - "Uplift `drop-bounds` lint from clippy into rustc" [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347)
+  - "Add StatementKind::Intrinsic to MIR" [compiler-team#348](https://github.com/rust-lang/compiler-team/issues/348)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+- Pending FCP requests (check your boxes!)
+  - "Promote aarch64-pc-windows-msvc to Tier 2 Development Platform" [rust#75914](https://github.com/rust-lang/rust/pull/75914)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - "Don't build tools by default with `x.py build`" [compiler-team#351](https://github.com/rust-lang/compiler-team/issues/351)
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Update stdarch" [rust#73166](https://github.com/rust-lang/rust/pull/73166)
+
+### WG checkins
+
+@*WG-mir-opt* checkin by @**oli**:
+>* `x != false` -> `x` optimization: (https://github.com/rust-lang/rust/pull/76067)
+>* `x = y == CONST; switch(x)` -> `switch(y)` optimization: (https://github.com/rust-lang/rust/pull/75370)
+>* various clean ups of mir printing making it less noisy: https://github.com/rust-lang/rust/pull/75697 https://github.com/rust-lang/rust/pull/75670 https://github.com/rust-lang/rust/pull/75566
+>* deaggregate `Rvalue::Aggregate` before running optimizations: https://github.com/rust-lang/rust/pull/73656
+>* mir validation checks that we don't reintroduce aggregates after deaggregation: https://github.com/rust-lang/rust/pull/75562
+>* optimize away `_x = true`, `_x = false` basic blocks if `_x` can be computed without branches https://github.com/rust-lang/rust/pull/75382
+>* OOM bugfix in const prop optimization: https://github.com/rust-lang/rust/pull/74821
+>* make simplify match arms opt more powerful: https://github.com/rust-lang/rust/pull/74748
+>* peephole optimize identity ops on BitAnd, BitOr and Mul: https://github.com/rust-lang/rust/pull/74491
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Account for version number in NtIdent hack" [rust#76331](https://github.com/rust-lang/rust/pull/76331)
+  - Opened by @**Aaron Hill** and approved by @**Vadim Petrochenkov**
+  - @**Aaron Hill** suggests a beta-backport, since this PR just fixes what PR [rust#73084](https://github.com/rust-lang/rust/pull/73084) was supposed to do in the first place.
+- "Fix HashMap visualizers in Visual Studio (Code)" [rust#76389](https://github.com/rust-lang/rust/pull/76389)
+  - Opened by [MaulingMonkey](https://github.com/MaulingMonkey) and approved by @**Vadim Petrochenkov**
+  - @**Vadim Petrochenkov** suggests beta-backport to fix an issue introduced in [rust#70052](https://github.com/rust-lang/rust/pull/70052) (update hashbrown crate to 0.8.1)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Don't run tidy exec check on WSL2" [rust#74753](https://github.com/rust-lang/rust/pull/74753)
+  - @**nikomatsakis** approved the changes
+  - @**mati865** is not convinced this is the right solution
+  - Windows WG was just pinged
+- "build aarch64-musl host compiler in CI" [rust#75751](https://github.com/rust-lang/rust/pull/75751)
+  - Assigned to @**Pietro Albini**
+  - @**Pietro Albini** suggests `T-compiler` to review since this PR bumps AArch64 MUSL from **Cross-compilation Tier 2** to **Development Platform Tier 2**
+  - This issue is `I-nominated` for `T-compiler` discussion
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [52 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [31 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 2 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 5 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 20 P-high, 57 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "incorrect code generation for i686 release build for 1.47 beta and nightly" [rust#76042](https://github.com/rust-lang/rust/issues/76042)
+  - Assigned to @**pnkfelix**
+  - `I-unsound` issue and beta regression
+  - It seems to be [a bug in LLVM](https://bugs.llvm.org/show_bug.cgi?id=47278), introduced in the LLVM 11 upgrade and triggered by compiler flag `-Copt-level=0`
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - Unassigned
+  - Also nominated for discussion
+  - Is not a regression, this never worked so it was also discussed if this was `P-critical` or `P-high`
+  - [It's an LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47444)
+  - @**Aaron Hill** is working on an LLVM patch
+- "regression: get_unchecked resolves to unstable feature use" [rust#76479](https://github.com/rust-lang/rust/issues/76479)
+  - Unassigned
+  - Opened by @**simulacrum** after hitting the issue on a crater run
+  - @**simulacrum** suggested that is expected breakage (before the MCVE was built)
+  - Beta regression that started in PR [rust#73565](https://github.com/rust-lang/rust/pull/73565) cc @**Matthew Jasper** @**nagisa**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- No unassigned `P-high` beta regressions this time.
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+A few small compile-time regressions this week. The first was [#70793](https://github.com/rust-lang/rust/pull/70793), which added some specializations to the standard library in order to increase runtime performance. The second was [#73996](https://github.com/rust-lang/rust/pull/73996), which adds an option to the diagnostics code to print only the names of types and traits when they are unique instead of the whole path. The third was [#75200](https://github.com/rust-lang/rust/pull/75200), which refactored part of `BTreeMap` to avoid aliasing mutable references.
+
+Triage done by @**ecstatic-morse** 
+Revision range: [d927e5a655809b6b20501889e093c085d6ffe6f7..35fc8359868e65a0970094f648ba87fce634e8c7](https://perf.rust-lang.org/?start=d927e5a655809b6b20501889e093c085d6ffe6f7&end=35fc8359868e65a0970094f648ba87fce634e8c7&absolute=false&stat=instructions%3Au)
+
+3 Regressions, 0 Improvements, 0 of them in rollups.
+
+#### Regressions
+
+[#75200](https://github.com/rust-lang/rust/pull/75200)
+- A small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=c59199efca5856cdf810919fbf9b5bce32dc4523&end=70c5f6efc445963bbfa5dd53f81c245741eac8cb&stat=instructions:u)
+
+[#73996](https://github.com/rust-lang/rust/pull/73996)
+- A small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=0d0f6b113047b2cf9afbde990cee30fd5b866469&end=af3c6e733a40e671550e0f0f5aeecaa13772ba56&stat=instructions:u)
+
+[#70793](https://github.com/rust-lang/rust/pull/70793)
+- A small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=62dad457bc73804891c6ac9a31f90de19cbb59a3&end=0d0f6b113047b2cf9afbde990cee30fd5b866469&stat=instructions:u) for `check`, `debug` and `opt` benchmarks.
+- However, an improvement in `doc` benchmarks, likely due to better optimized standard library.
+
+#### Improvements
+
+- None
+
+#### Nags requiring follow up
+
+- [#75200](https://github.com/rust-lang/rust/pull/75200)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- [T-compiler RFC backlog](https://github.com/rust-lang/rfcs/pulls?q=is%3Apr+is%3Aopen+label%3AT-compiler+sort%3Aupdated-asc)
+  - 13 total RFCs tagged with T-compiler
+  - 6 have not had any activity since last year
+  - @**wesleywiser** suggests "Perhaps we should try to triage these during the weekly compiler team meetings?"
+- "build aarch64-musl host compiler in CI" [rust#75751](https://github.com/rust-lang/rust/pull/75751)
+  - Assigned to @**Pietro Albini**
+  - @**Pietro Albini** suggests `T-compiler` to review since this PR bumps AArch64 MUSL from **Cross-compilation Tier 2** to **Development Platform Tier 2**
+- "diagnostics: "one type is more general" for two identical types?" [rust#75791](https://github.com/rust-lang/rust/issues/75791)
+  - Opened by @**matthiaskrgr** and assigned to @**Esteban Küber** 
+  - Confusing diagnostics suggestion
+  - `P-high` stable regression, duplicate of [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Nominated to ensure we circle back around to it this week if progress isn't made
+- "Widen TypeId from 64 bits to 128." [rust#75923](https://github.com/rust-lang/rust/pull/75923)
+  - Opened by @**eddyb**
+  - @**simulacrum** [nominated it to talk about @**eddyb**'s concern wrt to typeid stabilization; it might be a T-lang question too](https://github.com/rust-lang/rust/pull/75923#issuecomment-684051064).
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - Unassigned
+  - Also nominated for discussion
+  - Is not a regression, this never worked so it was also discussed if this was `P-critical` or `P-high`
+  - [It's an LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47444)
+  - @**Aaron Hill** is working on an LLVM patch
+- "Macro hygiene change breaks Firefox builds." [rust#76480](https://github.com/rust-lang/rust/issues/76480)
+  - Breaking change
+  - Nominated for discussion about how can we do better here
+  - cc @**Esteban Küber** @**Aaron Hill**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-09-17.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-09-17.md
@@ -1,0 +1,241 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-09-17
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- [There was a meeting followup from last weekly meeting where a bunch of T-compiler RFC backlog things were discussed.](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.20followup.5D.202020-09-11.20.2354818)
+- Tomorrow we will have the [MCP retrospective](https://github.com/rust-lang/compiler-team/issues/314) at <time:2020-09-18T14:00:00+00:00>
+- wg-incr-comp will have its third meeting next Tuesday at 8am EDT.
+    - Ping wesleywiser or pnkfelix if you're interested in helping out.
+- New MCPs (take a look, see if you like them!)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "`ty.kind()` -> `ty.data()`" [compiler-team#359](https://github.com/rust-lang/compiler-team/issues/359)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Uplift `temporary-cstring-as-ptr` lint from `clippy` into rustc" [compiler-team#346](https://github.com/rust-lang/compiler-team/issues/346)
+  - "Uplift `drop-bounds` lint from clippy into rustc" [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347)
+  - "Add StatementKind::Intrinsic to MIR" [compiler-team#348](https://github.com/rust-lang/compiler-team/issues/348)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+- Pending FCP requests (check your boxes!)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "Promote aarch64-pc-windows-msvc to Tier 2 Development Platform" [rust#75914](https://github.com/rust-lang/rust/pull/75914)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Implement `Index` and `IndexMut` for arrays" [rust#74989](https://github.com/rust-lang/rust/pull/74989)
+  - [T-lang] "Use implicit (not explicit) rules for promotability by default in `const fn`" [rust#75502](https://github.com/rust-lang/rust/pull/75502)
+  - [T-libs] "Make some Ordering methods const" [rust#76198](https://github.com/rust-lang/rust/pull/76198)
+  - [T-libs] "Stabilize some Option methods as const" [rust#76135](https://github.com/rust-lang/rust/pull/76135)
+  - [T-libs] "Stabilize some Result methods as const" [rust#76136](https://github.com/rust-lang/rust/pull/76136)
+  - [T-libs] "Add `[T; N]: TryFrom<Vec<T>>` (insta-stable)" [rust#76310](https://github.com/rust-lang/rust/pull/76310)
+
+### WG checkins
+
+Polymorphization working group checkin by @**davidtwco** @**eddyb** @**lcnr** 
+> I think the initial goal ought to be getting polymorphization enabled by default:
+>
+>- #75185 was opened to perform a crater run on polymorphization enabled-by-default. This was rebased after some other PRs broke polymorphization and we didn't notice, and we've yet to rebase and re-queue it.
+>
+>We've currently got the following open PRs:
+>
+>- #75675 (assigned to @**eddyb**) was opened to adjust the new symbol mangling scheme to encode impl parameters - this is an alternative fix for #75326 (which was originally resolved by #75518 and then #75595 - which changed polymorphization's analysis to mark more parameters are used). It's works but one of the tests required normalization that didn't differ based on bitness, which was unexpected and we've yet to decide how to proceed.
+>
+>- #75737 (blocked, but approved by @**eddyb**)  was opened to remove the predicate logic in polymorphization's analysis. This logic was added during the original polymorphization PR (and then extended in #75518 and #75595) and isn't necessary after #75675 (which is why it is blocked). Other changes to polymorphization must have affected the necessity of this logic, since I'm confident that the new symbol mangling scheme wasn't the original impetus for it, but I'm not sure which changes those would have been.
+>
+>- #75414 (assigned to @**eddyb**) changes polymorphization's analysis to take an `InstanceDef`, which enables the MIR of shims to be polymorphized. I'm not sure if it is exactly what we want.
+>
+>- #75346 (assigned to @**nikomatsakis**) changes how `FnPtrShim`s are constructed so that they don't require substitution during codegen - this will help avoid double substitution from polymorphization changes.
+>
+>We've also got the following issues open:
+>
+>- #75327 would remove `ParamEnv::reveal_all()` from codegen, a necessary next step so that we can construct `ParamEnv`s that constrain generic parameters by their size (eventually) - this is the first step towards polymorphization by size/alignment.
+>
+>- #75336 suggests re-applying some changes from #75255 that we reverted (in #75337) because it caused regressions (the crux of this issue is fixing those regressions). #75255 modified the closure upvar tuple so that if it contained closures, those would be polymorphized - this was necessary to avoid issues that were revealed when the new symbol mangling scheme was used ([#t-compiler/wg-polymorphization>symbol mangling v0 ✕ polymorphisation](https://rust-lang.zulipchat.com/#narrow/stream/216091-t-compiler.2Fwg-polymorphization/topic/symbol.20mangling.20v0.20.E2.9C.95.20polymorphisation) discussed this issue initially). After chatting with eddy, I'm not sure that approach #75255 implemented is desirable - we've experimented with changing how the polymorphization analysis treats closures, and with attempts to reveal other issues that this could be a symptom of - we haven't had any luck with that though. Anyway, the changes that #75336 suggests polymorphizing closures anywhere in a `Instance`'s substs, not just in the upvar tuple because that would reduce duplication of more functions (see the example in the issue).
+>
+>- #69925 is fixed by #75346 above.
+>
+>- #75325 is probably the biggest unknown facing polymorphization right now and relates to how we handle the `type_id` and `type_name` intrinsics - which would make polymorphization observable. The issue contains some examples which were failing at one point with polymorphization enabled (I'm not sure if that's still the case). This issue requires a lot of investigation.
+>
+>I think that's everything. I think that landing the current PRs and addressing #75325 are the most important tasks right now, we can crater after that and hopefully try enabling polymorphization by default.
+
+@*WG-polonius* checkin by @**nikomatsakis** and @**lqd** 
+> The polonius WG (Niko, Albin, and Rémy) had a sprint at the beginning of August, where:
+>- we continued the work on move errors: both in rustc to prepare the data needed to do the analysis and actually emit the errors computed by polonius, and in polonius itself, to fix potential false positives, and current efficiency issues in this part of the computation. Some new rules have been written but not yet fully implemented or tested, so this is something we'll continue to look at in the next sprint.
+>- we were able to prototype our different lifetime analysis, and evaluate it: there was an open question whether it'd be better to track subset relations or equality relations, and we were able to find some subtle flaws in our current thoughts about tracking equality. There's some interesting theoretical core that could be useful in the future, but also has foundational issues, so we decided to keep tracking subset relations for now and not change our existing lifetime analysis rules.
+>- we continued the work on universal region errors / illegal subset errors: we settled a tiny open question on whether we should compute these errors using subset relations or by looking for unexpected loans in universal regions. We decided to switch to using subset relations because it works everywhere: the polonius analysis is currently split into different parts for validation and efficiency reasons. Our existing subset errors computation had only been added to the main rules used for validation, and it used the "looking at unexpected loans" approach. We did the work necessary to update this, and also to compute the errors in the other parts dedicated to efficiency.
+>- we were able to work on a fix for the current OOMs we see in a couple rustc UI tests (during fact generation): we have prototyped a fix in rustc and polonius. It is, however, quite invasive and requires subtle duplication of rules. So we also started looking at a different fix which could avoid that, and is something we'll continue to look at in the next sprint.
+>- we did our periodic reevaluation of rustc UI tests using the polonius compare mode: find which tests might have changed .stderr files, add the ones missing for the tests added recently, etc; since the compare mode is not run on CI yet, we do this manually every few months to keep up to date with diagnostics changes and the likes. This time, a new test OOMs for move errors and will be fixed as part of this work mentioned earlier.
+>- finally, we also looked at supporting profiling polonius' internals from rustc's -Zself-profile, and also when using the tracy profiler.
+
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- No beta nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- "Ignore rustc_private items from std docs" [rust#76571](https://github.com/rust-lang/rust/pull/76571)
+  - Opened by @**lzutao** and assigned to @**Joshua Nelson**
+  - Potentially fixes the following issues [rust#74672](https://github.com/rust-lang/rust/issues/74672), [rust#75588](https://github.com/rust-lang/rust/issues/75588) and [rust#76529](https://github.com/rust-lang/rust/issues/76529)
+  - @**GuillaumeGomez** is in favor of the backport
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Don't run tidy exec check on WSL2" [rust#74753](https://github.com/rust-lang/rust/pull/74753)
+  - This was discussed last week
+  - @**nikomatsakis** approved the changes
+  - @**mati865** is not convinced this is the right solution
+  - Windows WG was just pinged
+- "Uplift drop-bounds lint from clippy" [rust#75699](https://github.com/rust-lang/rust/pull/75699)
+  - This is the implementation of [MCP #347](https://github.com/rust-lang/compiler-team/issues/347) to move the lint warning from clippy into the compiler, which needs a second
+  - Reviewed by @**lzutao** @**Vadim Petrochenkov** and @**Aaron Hill** 
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [54 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [33 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [3 P-critical, 0 P-high, 4 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 5 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 20 P-high, 58 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "incorrect code generation for i686 release build for 1.47 beta and nightly" [rust#76042](https://github.com/rust-lang/rust/issues/76042)
+  - This was discussed last week
+  - Assigned to @**pnkfelix**
+  - `I-unsound` issue and beta regression
+  - It seems to be [a bug in LLVM](https://bugs.llvm.org/show_bug.cgi?id=47278), introduced in the LLVM 11 upgrade and triggered by compiler flag `-Copt-level=0`
+  - The [LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47278) was fixed and included in the 11.x branch of LLVM
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - This was discussed last week
+  - Assigned to @**Aaron Hill**
+  - Also nominated for discussion
+  - Is not a regression, this never worked so it was also discussed if this was `P-critical` or `P-high`
+  - [It's an LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47444)
+  - @**Aaron Hill** is [left a patch up for review upstream and can be cherry picked if needed](https://github.com/rust-lang/rust/issues/76387#issuecomment-690610859)
+- "regression: get_unchecked resolves to unstable feature use" [rust#76479](https://github.com/rust-lang/rust/issues/76479)
+  - This was discussed last week
+  - Unassigned
+  - Opened by @**simulacrum** after hitting the issue on a crater run
+  - @**simulacrum** suggested that is expected breakage (before the MCVE was built)
+  - Beta regression that started on PR [rust#73565](https://github.com/rust-lang/rust/pull/73565) cc @**Matthew Jasper** @**nagisa**
+- "starting from nightly-2020-08-18 rustls can't connect to some websites" [rust#76803](https://github.com/rust-lang/rust/issues/76803)
+  - Unassigned
+  - Opened by @**Paolo Barbolini**
+  - Beta regression that started on PR [rust#74748](https://github.com/rust-lang/rust/pull/74748) cc @**Simon Vandel Sillesen** @**oli** 
+  - [Mir optimization bug](https://github.com/rust-lang/rust/issues/76803#issuecomment-693999586)
+  - [Has a PR to disable the optimization](https://github.com/rust-lang/rust/pull/76837) by @**wesleywiser**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- "btree_map::OccupiedEntry: Send regression" [rust#76686](https://github.com/rust-lang/rust/issues/76686)
+  - Assigned to @**simulacrum**
+  - Nightly regression
+  - Regressed on [rust#74437](https://github.com/rust-lang/rust/pull/74437)
+  - [Has a PR](https://github.com/rust-lang/rust/pull/76722) opened by @**Stein Somers**
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- No unassigned `P-high` beta regressions this time.
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Linker error with wasm target with spaces in install path" [rust#76466](https://github.com/rust-lang/rust/issues/76466)
+  - Unassigned
+  - Reported by @**Jordan Miner** 
+  - Nightly regression
+  - [Probably an LLVM 11 regression](https://github.com/rust-lang/rust/issues/76466#issuecomment-688686973)
+  - Reporter ran into the issues on a **Win10 64bit** and suggests a possible range of [culprit commits](https://github.com/rust-lang/rust/issues/76466#issuecomment-688686973) 
+  - @**Mason Stallmo** could not reproduce on both Windows or Linux 64bit, therefore suggests a possible [Windows 32bit only regression](https://github.com/rust-lang/rust/issues/76466#issuecomment-693805846)
+
+## Performance logs
+
+Triage done by @**simulacrum** .
+Revision range: [35fc8359868e65a0970094f648ba87fce634e8c7..a53f449516f23486d2dfd4e5685d4e869e8591d9](https://perf.rust-lang.org/index.html?start=35fc8359868e65a0970094f648ba87fce634e8c7&end=a53f449516f23486d2dfd4e5685d4e869e8591d9&absolute=false&stat=instructions%3Au)
+
+0 Regressions, 2 Improvements, 0 of them in rollups.
+
+#### Regressions
+
+No regressions noted.
+
+#### Improvements
+
+[BTreeMap mutable iterators should not take any reference to visited nodes during iteration #73971](https://github.com/rust-lang/rust/pull/73971)
+- A ~1.4% improvement on token-stream-stress check in [instruction counts](https://perf.rust-lang.org/compare.html?start=b4bdc07ff5a70175dbcdff7331c557245ddb012f&end=d92155bf6ae0b7d79fc83cbeeb0cc0c765353471)
+
+[make `ConstEvaluatable` more strict #74595](https://github.com/rust-lang/rust/pull/74595)
+- Improvement of up to 2% in [instruction counts](https://perf.rust-lang.org/compare.html?start=d92155bf6ae0b7d79fc83cbeeb0cc0c765353471&end=e2be5f568d1f60365b825530f5b5cb722460591b)
+
+#### Nags requiring follow up
+
+None
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- [RFC #2959](https://github.com/rust-lang/rfcs/pull/2959) almost ready for approval
+  - @**Pietro Albini** [suggests](https://github.com/rust-lang/rfcs/pull/2959#issuecomment-693293223) only one unresolved question (about stack probes) doesn't need to block the bump to FCP and can be later added to the RFC process policy
+- "Re-enable debug and LLVM assertions" [rust#75199](https://github.com/rust-lang/rust/pull/75199)
+    - Opened by @**simulacrum** and assigned to @**Pietro Albini**
+    - Helps with [rust#59637](https://github.com/rust-lang/rust/issues/59637) but doesn't close it, macOS still has asserts off
+    - "We hit a similar looking bug in [rust#75380](https://github.com/rust-lang/rust/pull/75380)
+- "diagnostics: "one type is more general" for two identical types?" [rust#75791](https://github.com/rust-lang/rust/issues/75791)
+  - Opened by @**matthiaskrgr** and assigned to @**Esteban Küber** 
+  - Confusing diagnostics suggestion
+  - `P-high` stable regression, duplicate of [rust#74400](https://github.com/rust-lang/rust/issues/74400)
+  - Nominated to ensure we circle back around to it this week if progress isn't made
+- "Widen TypeId from 64 bits to 128." [rust#75923](https://github.com/rust-lang/rust/pull/75923)
+  - Opened by @**eddyb**
+  - @**simulacrum** [nominated it to talk about @**eddyb**'s concern wrt to typeid stabilization; it might be a T-lang question too](https://github.com/rust-lang/rust/pull/75923#issuecomment-684051064).
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - Unassigned
+  - Also nominated for discussion
+  - Is not a regression, this never worked so it was also discussed if this was `P-critical` or `P-high`
+  - [It's an LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47444)
+  - @**Aaron Hill** is working [on an LLVM patch](https://github.com/rust-lang/rust/issues/76387#issuecomment-690610859)
+- "Macro hygiene change breaks Firefox builds." [rust#76480](https://github.com/rust-lang/rust/issues/76480)
+  - Breaking change
+  - Nominated for discussion about how can we do better here
+  - cc @**Esteban Küber** @**Aaron Hill**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-09-24.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-09-24.md
@@ -1,0 +1,267 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-09-24
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow we have our [planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html) at <time:2020-09-25T14:00:00+00:00>
+- New MCPs (take a look, see if you like them!)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "`ty.kind()` -> `ty.data()`" [compiler-team#359](https://github.com/rust-lang/compiler-team/issues/359)
+- Pending FCP requests (check your boxes!)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "Promote aarch64-pc-windows-msvc to Tier 2 Development Platform" [rust#75914](https://github.com/rust-lang/rust/pull/75914)
+- Things in FCP (make sure you're good with it)
+  - "Uplift `temporary-cstring-as-ptr` lint from `clippy` into rustc" [compiler-team#346](https://github.com/rust-lang/compiler-team/issues/346)
+  - "Uplift `drop-bounds` lint from clippy into rustc" [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347)
+  - "Add StatementKind::Intrinsic to MIR" [compiler-team#348](https://github.com/rust-lang/compiler-team/issues/348)
+  - "Make TyKind Copy and change ty.kind() to return TyKind instead of &TyKind" [compiler-team#363](https://github.com/rust-lang/compiler-team/issues/363)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-rustdoc] "Stabilize intra-doc links" [rust#74430](https://github.com/rust-lang/rust/pull/74430)
+
+### WG checkins
+
+@*WG-prioritization* checkin by @**Santiago Pastorino**:
+>- We published last week a [Call for new contributors](https://blog.rust-lang.org/2020/09/14/wg-prio-call-for-contributors.html). The answer was above our expectations, to this day we have received 13 new applications and we are therefore encouraging new volunteers showing up to also join the [Cleanup crew group](https://rustc-dev-guide.rust-lang.org/notification-groups/cleanup-crew.html).
+>- Most of our procedures and work have settled now and not many huge things are happening other than our day to day work.
+
+@*WG-rfc-2229* checkin by @**Aman Arora** and @**nikomatsakis**:
+> - Most of the infrastructure to capture Places is in now
+> - Work resumed after the break, all existing branches revived.
+> - Progress on updating how closures are printed (for non-verbose just removing upvar types)
+> - New capture analysis verified to not break existing functionality (all tests up to stage1 tests pass).
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Issue 72408 nested closures exponential" [rust#72412](https://github.com/rust-lang/rust/pull/72412)
+  - Fixes [rust#72408](https://github.com/rust-lang/rust/issues/72408) an exponential compilation time increase
+- "[mir-opt] Disable the `ConsideredEqual` logic in SimplifyBranchSame opt" [rust#76837](https://github.com/rust-lang/rust/pull/76837)
+  - Fixes [rust#76803](https://github.com/rust-lang/rust/issues/76803) a `P-critical` unsound beta regression
+  - The PR just disables the logic
+- "Rebase LLVM onto 11.0.0-rc3" [rust#77063](https://github.com/rust-lang/rust/pull/77063)
+  - Needed to fix some LLVM 11 regressions, like [rust#76042](https://github.com/rust-lang/rust/issues/76042)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Uplift drop-bounds lint from clippy" [rust#75699](https://github.com/rust-lang/rust/pull/75699)
+  - This is waiting on MCP [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347), which was seconded 7 days ago.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [55 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [33 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [3 P-critical, 1 P-high, 4 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 5 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 20 P-high, 59 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "incorrect code generation for i686 release build for 1.47 beta and nightly" [rust#76042](https://github.com/rust-lang/rust/issues/76042)
+  - This was discussed last week
+  - Assigned to @**pnkfelix**
+  - `I-unsound` issue and beta regression
+  - The [LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47278) was fixed and included in the 11.x branch of LLVM
+  - [Rebasing on top of LLVM 11.0.0-rc3 will fix the issue](https://github.com/rust-lang/rust/pull/77063#issuecomment-696895601)
+  - Issue is fixed with [rust#77063](https://github.com/rust-lang/rust/pull/77063) backport
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - This was discussed last week
+  - Assigned to @**Aaron Hill**
+  - Also nominated for discussion
+  - Is not a regression, this never worked so it was also discussed if this was `P-critical` or `P-high`
+  - [It's an LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47444)
+  - @**Aaron Hill** is [left a patch up for review upstream and can be cherry picked if needed](https://github.com/rust-lang/rust/issues/76387#issuecomment-690610859)
+- "regression: get_unchecked resolves to unstable feature use" [rust#76479](https://github.com/rust-lang/rust/issues/76479)
+  - This was discussed last week
+  - Assigned to @**pnkfelix**
+  - Opened by @**simulacrum** after hitting the issue on a crater run
+  - @**simulacrum** suggested that is expected breakage (before the MCVE was built)
+  - Beta regression that started on PR [rust#73565](https://github.com/rust-lang/rust/pull/73565) cc @**Matthew Jasper** @**nagisa**
+- "starting from nightly-2020-08-18 rustls can't connect to some websites" [rust#76803](https://github.com/rust-lang/rust/issues/76803)
+  - Unassigned
+  - Opened by @**Paolo Barbolini**
+  - Beta regression that started on PR [rust#74748](https://github.com/rust-lang/rust/pull/74748) cc @**Simon Vandel Sillesen** @**oli** 
+  - [Mir optimization bug](https://github.com/rust-lang/rust/issues/76803#issuecomment-693999586)
+  - [Fix by @**wesleywiser** is in master already](https://github.com/rust-lang/rust/pull/76837) but it's still pending beta backport.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### Unassigned P-high regressions
+
+[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - It's also nominated
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - Assigned `P-high` and requested an MCVE, we probably need to get more context about this issue
+
+[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+- "Linker error with wasm target with spaces in install path" [rust#76466](https://github.com/rust-lang/rust/issues/76466)
+  - Unassigned
+  - Reported by @**Jordan Miner** 
+  - Nightly regression
+  - [Probably an LLVM 11 regression](https://github.com/rust-lang/rust/issues/76466#issuecomment-688686973)
+  - Reporter ran into the issues on a **Win10 64bit** and suggests a possible range of [culprit commits](https://github.com/rust-lang/rust/issues/76466#issuecomment-688686973) 
+  - @**Mason Stallmo** could not reproduce on both Windows or Linux 64bit, therefore suggests a possible [Windows 32bit only regression](https://github.com/rust-lang/rust/issues/76466#issuecomment-693805846)
+  - @**retep007** [suggests that it may be an lld issue](https://github.com/rust-lang/rust/issues/76466#issuecomment-697130900)
+
+## Performance logs
+
+This was the first week of semi-automated perf triage, and thank goodness:
+There was a lot going on. Most regressions are either quite small or already
+have a fix published.
+
+[#72412](https://github.com/rust-lang/rust/issues/72412) is probably the most
+interesting case. It fixes a pathological problem involving nested closures by
+adding cycle detection to what seems to be a relatively hot part of the code.
+As a result, most users will see a slight [compile-time
+regression](https://perf.rust-lang.org/compare.html?start=2c69266c0697b0c0b34abea62cba1a1d3c59c90c&end=fdc3405c20122fd0f077f5a77addabc873f20e4c&stat=task-clock)
+for their crates.
+
+Triage done by **@ecstaticmorse**.
+Revision range: [dbb73f8f79ab176a897d5a95e696adb71b957cbe..b01326ab033e41986d4a5c8b96ce4f40f3b38e30](https://perf.rust-lang.org/?start=dbb73f8f79ab176a897d5a95e696adb71b957cbe&end=b01326ab033e41986d4a5c8b96ce4f40f3b38e30&absolute=false&stat=instructions%3Au)
+
+2 Regressions, 5 Improvements, 4 Mixed,
+1 of them in rollups
+
+### Regressions
+
+[#76575](https://github.com/rust-lang/rust/issues/76575) compare generic constants using `AbstractConst`s
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=fdc3405c20122fd0f077f5a77addabc873f20e4c&end=9f8ac718f44e280edb1a7b3266f2c26106ec11a0&stat=instructions:u)
+ (up to 2.4% on `full` builds of `inflate-check`)
+
+[#74040](https://github.com/rust-lang/rust/issues/74040) fix unification of const variables
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=956e06c6c85e918524b67503c4d65c7baf539585&end=e0bf356f9e5f6a8cca1eb656e900ffba79340fa1&stat=instructions:u)
+  (up to 3.3% on `incr-full` builds of `coercions-debug`)
+
+### Improvements
+
+[#76656](https://github.com/rust-lang/rust/issues/76656) Don't query stability data when `staged_api` is off
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=f9a322a6fdd1e12fbe30441feaa4402e23efe303&end=1eb00abf35b9bb59825edf81d05c2fa2f17cefca&stat=instructions:u)
+  (up to -1.5% on `incr-unchanged` builds of `many-assoc-items-check`)
+
+[#76311](https://github.com/rust-lang/rust/issues/76311) Split `core::slice` to smaller mods
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=90b1f5ae59291dd69d72fad41a22277df19dc953&end=4c1966f97e192d6282be935baa163fb58f9b8b27&stat=instructions:u)
+  (up to -1.9% on `full` builds of `html5ever-opt`)
+- Very odd, since this just split up a file.
+
+[#76880](https://github.com/rust-lang/rust/issues/76880) Update cc crate to 1.0.60 to understand aarch64-apple-darwin with clang
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=8e9d5db8392c44a2e94008168fa3506ecddaa357&end=b3aae050cd7e0c9a9eb6085bd49b02f67dc1396f&stat=instructions:u)
+(up to -1.0% on `incr-patched: Compiler new` builds of `regex-opt`)
+
+[#76975](https://github.com/rust-lang/rust/issues/76975) Rollup of 15 pull requests
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b873fa6d42cf305131d2583d03b84686e5e40f2e&end=81e02708f1f4760244756548981277d5199baa9a&stat=instructions:u)
+on exactly `encoding-check` (-2.0% on `incr-full` builds)
+
+[#76680](https://github.com/rust-lang/rust/issues/76680) Make `ensure_sufficient_stack()` non-generic, using cargo-llvm-lines
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=4eff9b0b29a8898c839d46f3c66526710afed68a&end=b01326ab033e41986d4a5c8b96ce4f40f3b38e30&stat=instructions:u)
+(up to -3.2% on `incr-full` builds of `coercions-debug`)
+
+### Mixed
+
+[#76244](https://github.com/rust-lang/rust/issues/76244) Removing the `def_id` field from hot `ParamEnv` to make it smaller
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a055c5a1bd95e029e9b31891db63b6dc8258b472&end=7402a394471a6738a40fea7d4f1891666e5a80c5&stat=instructions:u)
+  (up to 3.3% on `full` builds of `unicode_normalization-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=a055c5a1bd95e029e9b31891db63b6dc8258b472&end=7402a394471a6738a40fea7d4f1891666e5a80c5&stat=instructions:u)
+  (up to -1.8% on `full` builds of `ctfe-stress-4-check`)
+- A fix has been published as [#76913](https://github.com/rust-lang/rust/pull/76913).
+
+[#72412](https://github.com/rust-lang/rust/issues/72412) Issue 72408 nested closures exponential
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=2c69266c0697b0c0b34abea62cba1a1d3c59c90c&end=fdc3405c20122fd0f077f5a77addabc873f20e4c&stat=instructions:u)
+  (up to -99.9% on `incr-unchanged` builds of `deeply-nested-closures-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=2c69266c0697b0c0b34abea62cba1a1d3c59c90c&end=fdc3405c20122fd0f077f5a77addabc873f20e4c&stat=instructions:u)
+  (up to 1.5% on `full` builds of `coercions-check`)
+- Fixes a pathological case, but slows down normal builds slightly.
+- Might be worth investigating to see if we can do better, although the author seems to have done a pretty thorough job.
+
+[#74949](https://github.com/rust-lang/rust/issues/74949) Validate constants during `const_eval_raw`
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=10b3595ba6a4c658c9dea105488fc562c815e434&end=5e449b9adff463455743291b0c1f76feec092992&stat=instructions:u)
+  (up to 515.8% on `incr-unchanged` builds of `ctfe-stress-4-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=10b3595ba6a4c658c9dea105488fc562c815e434&end=5e449b9adff463455743291b0c1f76feec092992&stat=instructions:u)
+  (up to -2.7% on `incr-patched: add static arr item` builds of `coercions-check`)
+- A fix has been published as [#77006](https://github.com/rust-lang/rust/pull/77006).
+
+[#75119](https://github.com/rust-lang/rust/issues/75119)  New MIR optimization pass to reduce branches on match of tuples of enums
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=81e02708f1f4760244756548981277d5199baa9a&end=2e0edc0f28c5647141bedba02e7a222d3a5dc9c3&stat=instructions:u)
+  (up to -1.6% on `full` builds of `style-servo-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=81e02708f1f4760244756548981277d5199baa9a&end=2e0edc0f28c5647141bedba02e7a222d3a5dc9c3&stat=instructions:u)
+  (up to 1.3% on `full` builds of `wf-projection-stress-65510-check`)
+- Seems to have been a regression overall. If there's no improvment in the generated code, we should disable this.
+
+### Nags requiring follow up
+
+- [#75119](https://github.com/rust-lang/rust/issues/75119)
+- [#76575](https://github.com/rust-lang/rust/issues/76575)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Widen TypeId from 64 bits to 128." [rust#75923](https://github.com/rust-lang/rust/pull/75923)
+  - Opened by @**eddyb**
+  - @**simulacrum** [nominated it to talk about @**eddyb**'s concern wrt to typeid stabilization; it might be a T-lang question too](https://github.com/rust-lang/rust/pull/75923#issuecomment-684051064).
+  - @**eddyb** @**RalfJ** and `KodrAus` [have agreed on reverting `TypeId` stabilization](https://github.com/rust-lang/rust/pull/75923#issuecomment-696696433) before it hits stable, [until we get a chance to settle this entirely](https://github.com/rust-lang/rust/pull/75923#issuecomment-696604147).
+- "Set up CI for aarch64-apple-darwin" [rust#75991](https://github.com/rust-lang/rust/pull/75991)
+  - Nominated by @**Pietro Albini** for compiler approval
+  - This PR is promoting the aarch64-apple-darwin target from Tier 3 to a Tier 2 development platform
+- "Macro hygiene change breaks Firefox builds." [rust#76480](https://github.com/rust-lang/rust/issues/76480)
+  - Breaking change
+  - Nominated for discussion about how can we do better here
+  - cc @**Esteban Küber** @**Aaron Hill**
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - It's also an unassigned beta regression
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - Assigned `P-high` and requested an MCVE, we probably need to get more context about this issue
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-10-01.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-10-01.md
@@ -1,0 +1,224 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-10-01
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Rust 1.47 is going to be released next Thursday, October 8th.
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Infer hidden types without replacing with an inference variable" [compiler-team#325](https://github.com/rust-lang/compiler-team/issues/325)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "`ty.kind()` -> `ty.data()`" [compiler-team#359](https://github.com/rust-lang/compiler-team/issues/359)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+- Pending FCP requests (check your boxes!)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "Promote aarch64-pc-windows-msvc to Tier 2 Development Platform" [rust#75914](https://github.com/rust-lang/rust/pull/75914)
+  - "Set up CI for aarch64-apple-darwin" [rust#75991](https://github.com/rust-lang/rust/pull/75991)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - "Uplift `temporary-cstring-as-ptr` lint from `clippy` into rustc" [compiler-team#346](https://github.com/rust-lang/compiler-team/issues/346)
+  - "Uplift `drop-bounds` lint from clippy into rustc" [compiler-team#347](https://github.com/rust-lang/compiler-team/issues/347)
+  - "Add StatementKind::Intrinsic to MIR" [compiler-team#348](https://github.com/rust-lang/compiler-team/issues/348)
+  - "Make TyKind Copy and change ty.kind() to return TyKind instead of &TyKind" [compiler-team#363](https://github.com/rust-lang/compiler-team/issues/363)
+- Finalized FCPs (disposition merge)
+  - [T-lang] "might_permit_raw_init: also check aggregate fields" [rust#71274](https://github.com/rust-lang/rust/pull/71274)
+  - [T-lang] "target-feature 1.1: should closures inherit target-feature annotations?" [rust#73631](https://github.com/rust-lang/rust/issues/73631)
+  - [T-libs] "Add PartialEq impls for Vec <-> slice" [rust#74194](https://github.com/rust-lang/rust/pull/74194)
+  - [T-lang] "Explicitly document the size guarantees that Option makes." [rust#75454](https://github.com/rust-lang/rust/pull/75454)
+  - [T-release] "Write manifest for MAJOR.MINOR channel to enable rustup convenience" [rust#76107](https://github.com/rust-lang/rust/pull/76107)
+  - [T-lang] "Stabilize move_ref_pattern" [rust#76119](https://github.com/rust-lang/rust/pull/76119)
+  - [T-lang] "Permit uninhabited enums to cast into ints" [rust#76199](https://github.com/rust-lang/rust/pull/76199)
+
+### WG checkins
+
+@*WG-rls2.0* checkin by @**matklad**:
+> Checkin text
+
+@*WG-self-profile* checkin by @**Wesley Wiser**:
+> We've had quite a lot of activity recently!
+> - We released `measureme` 0.8 today :tada:
+>   - Release highlights:
+>     - We have a new storage format contributed by @**mw** that records all of our data in one file instead of three
+>     - @**wesleywiser** made some UI tweaks to the `summarize` tool so it's a bit nicer to use. The main one is that we no longer show columns for data that isn't applicable like parallel query blocking time if the compiler wasn't built with parallel support. 
+>     - @**simulacrum** made it possible to run the analysis tools from perf.rlo without writing profile data to disk.
+    >     - Several contributors (@**workingjubilee**, @**Aaron1011**, @**wesleywiser**) updated and removed unneeded dependencies :medal: 
+> - @**mw** has been working on additional improvements so that we can record query keys when building `rustc_middle`. Currently, `rustc_middle` is so large, it exhausts the address space we use for recording string data. [rust-lang/measureme#137](https://github.com/rust-lang/measureme/pull/137) will resolve that and allow us to profile even extremely large crates with query keys enabled. This is a breaking change so `0.9.0` (or perhaps `9.0`) is likely going to ship soon.
+> - @**eddyb** continues to work on adding support for reading hardware performance counters like `perf` does instead of using `std::time::Instant` for much more precise timings. 
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Rename Iterator::get_unchecked" [rust#77201](https://github.com/rust-lang/rust/pull/77201)
+  - Closes `P-critical` [rust#76479](https://github.com/rust-lang/rust/issues/76479)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [54 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [33 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 1 P-high, 5 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 3 P-high, 4 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 20 P-high, 59 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - This was discussed last week
+  - Assigned to @**Aaron Hill**
+  - Is not a regression, this never worked so it was also discussed if this was `P-critical` or `P-high`
+  - [It's an LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=47444)
+  - @**Aaron Hill** [left a patch up for review upstream and can be cherry picked if needed](https://github.com/rust-lang/rust/issues/76387#issuecomment-690610859)
+  - [A possibly "nicer" solution was posted on LLVM issue](https://reviews.llvm.org/D87474#2302407)
+- "regression: get_unchecked resolves to unstable feature use" [rust#76479](https://github.com/rust-lang/rust/issues/76479)
+  - This was discussed last week
+  - Assigned to @**matthewjasper**
+  - Opened by @**simulacrum** after hitting the issue on a crater run
+  - @**simulacrum** suggested that is expected breakage (before the MCVE was built)
+  - Beta regression that started on PR [rust#73565](https://github.com/rust-lang/rust/pull/73565) cc @**Matthew Jasper** @**nagisa**
+  - This is waiting for [rust#77201](https://github.com/rust-lang/rust/pull/77201) backport
+- "Segfaults/corruption when reading an enum in release mode" [rust#77359](https://github.com/rust-lang/rust/issues/77359)
+  - Assigned to @**Wesley Wiser**
+  - [There's an MCVE](https://github.com/rust-lang/rust/issues/77359#issuecomment-701433566)
+  - [SimplifyArmIdentity moves an assignment to a local before StorageLive](https://github.com/rust-lang/rust/issues/77359#issuecomment-701423281)
+  - [@**Wesley Wiser** offered to disable the optimization so this doesn't hit beta](https://github.com/rust-lang/rust/issues/77359#issuecomment-701433566)
+- "coreos-installer test segfaults on s390x-unknown-linux-gnu" [rust#77382](https://github.com/rust-lang/rust/issues/77382)
+    - Opened by @**cuviper**
+    - @**ecstatic-morse** points to this issue as duplicate of [rust#74551](https://github.com/rust-lang/rust/issues/74551)
+    - Seems like a mir-opt misoptimization
+    - Crossreferenced in Bugzilla issue [#1883457](https://bugzilla.redhat.com/show_bug.cgi?id=1883457)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - Assigned `P-high` and requested an MCVE, we probably need to get more context about this issue
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- "Linker error with wasm target with spaces in install path" [rust#76466](https://github.com/rust-lang/rust/issues/76466)
+  - Unassigned
+  - Reported by @**Jordan Miner** 
+  - Nightly regression
+  - [Probably an LLVM 11 regression](https://github.com/rust-lang/rust/issues/76466#issuecomment-688686973)
+  - Reporter ran into the issues on a **Win10 64bit** and suggests a possible range of [culprit commits](https://github.com/rust-lang/rust/issues/76466#issuecomment-688686973) 
+  - @**Mason Stallmo** could not reproduce on both Windows or Linux 64bit, therefore suggests a possible [Windows 32bit only regression](https://github.com/rust-lang/rust/issues/76466#issuecomment-693805846)
+  - @**retep007** [suggests that it may be an lld issue](https://github.com/rust-lang/rust/issues/76466#issuecomment-697130900)
+  - @**eddyb** points to [this commit](https://github.com/llvm/llvm-project/commit/928e9e172305752583a75a8174ab5a87b4e09d80) as possible culprit
+
+## Performance logs
+
+Most significant changes this week came in response to regressions discussed in
+last week's triage report. Curious readers may be interested in
+[#77058](https://github.com/rust-lang/rust/issues/77058), in which the removal
+of a single field from a struct caused a 25% decrease in wall-times for one
+seemingly unrelated benchmark, or
+[#76986](https://github.com/rust-lang/rust/issues/76986), an ABI change that
+should be a pretty clear win but seems to have mixed results.
+
+Triage done by **@ecstaticmorse**.
+Revision range: [b01326ab033e41986d4a5c8b96ce4f40f3b38e30..6369a98ebdee8ce01510f5d4307ddb771c8cb0e5](https://perf.rust-lang.org/?start=b01326ab033e41986d4a5c8b96ce4f40f3b38e30&end=6369a98ebdee8ce01510f5d4307ddb771c8cb0e5&absolute=false&stat=instructions%3Au)
+
+0 Regressions, 1 Improvements, 3 Mixed
+
+0 of them in rollups
+
+### Improvements
+
+[#77041](https://github.com/rust-lang/rust/issues/77041) perf: move cold path of `process_obligations` into a separate function
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=fadf0257235ddb8a464befc02e50b35652174689&end=521d8d8a2236a239e3327336844ed5948857ea31&stat=instructions:u) (up to -4.8% on `full` builds of `inflate-check`)
+- Fixes a regression introduced in [#76575](https://github.com/rust-lang/rust/issues/76575).
+
+### Mixed
+
+[#77006](https://github.com/rust-lang/rust/issues/77006)  Cache `eval_to_allocation_raw` on disk
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=893fadd11a52aa26fc19c67ee1b79f03d6a1bed3&end=87d262acb50200d767baa7115f30c650a13672ee&stat=instructions:u) (up to -83.9% on `incr-unchanged` builds of `ctfe-stress-4-check`)
+- Large regression in [task clock](https://perf.rust-lang.org/compare.html?start=893fadd11a52aa26fc19c67ee1b79f03d6a1bed3&end=87d262acb50200d767baa7115f30c650a13672ee&stat=task-clock) (up to 14.5% on `incr-full` builds of `ctfe-stress-4-check`),
+- Fixes a regression introduced in [#74949](https://github.com/rust-lang/rust/issues/74949).
+- `incr-full` builds of `ctfe-stress-4` also have significantly increased [`max-rss`](https://perf.rust-lang.org/?start=b01326ab033e41986d4a5c8b96ce4f40f3b38e30&end=6369a98ebdee8ce01510f5d4307ddb771c8cb0e5&absolute=false&stat=instructions%3Au).
+- Real-world benchmarks seem to have mostly improved, however.
+
+[#76913](https://github.com/rust-lang/rust/issues/76913)  Fixing the performance regression of #76244
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=f47df31ae5d7d9795399dca3a0003c1856900361&end=45198456be60a6906d24abdc3c67a31b9206188e&stat=instructions:u) (up to -3.1% on `full` builds of `unicode_normalization-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f47df31ae5d7d9795399dca3a0003c1856900361&end=45198456be60a6906d24abdc3c67a31b9206188e&stat=instructions:u) (up to 2.7% on `incr-unchanged` builds of `ctfe-stress-4-check`)
+- A temporary revert of [#76244](https://github.com/rust-lang/rust/issues/76244) to fix a rather large wall time regression in `unicode-normalization`.
+- Gains will reappear as part of [#77257](https://github.com/rust-lang/rust/issues/77257) with the losses mitigated.
+
+[#76986](https://github.com/rust-lang/rust/issues/76986) Return values up to 128 bits in registers
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=1ec980d225fff2346a1a631a7ffc88b37e9e18af&end=62fe055aba3ddac5e5d113920cf5fd80522104e2&stat=instructions:u) (up to 2.3% on `full` builds of `deeply-nested-debug`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=1ec980d225fff2346a1a631a7ffc88b37e9e18af&end=62fe055aba3ddac5e5d113920cf5fd80522104e2&stat=instructions:u) (up to -1.9% on `full` builds of `piston-image-opt`)
+- Seems to be a slight regression overall, even looking at [`task-clock`](https://perf.rust-lang.org/compare.html?start=1ec980d225fff2346a1a631a7ffc88b37e9e18af&end=62fe055aba3ddac5e5d113920cf5fd80522104e2&stat=task-clock) measurements.
+
+### Nags requiring follow up
+
+- [#76986](https://github.com/rust-lang/rust/issues/76986)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Widen TypeId from 64 bits to 128." [rust#75923](https://github.com/rust-lang/rust/pull/75923)
+  - Opened by @**eddyb**
+  - @**simulacrum** [nominated it to talk about @**eddyb**'s concern wrt to typeid stabilization; it might be a T-lang question too](https://github.com/rust-lang/rust/pull/75923#issuecomment-684051064).
+  - @**eddyb** @**RalfJ** and `KodrAus` [have agreed on reverting `TypeId` stabilization](https://github.com/rust-lang/rust/pull/75923#issuecomment-696696433) before it hits stable, [until we get a chance to settle this entirely](https://github.com/rust-lang/rust/pull/75923#issuecomment-696604147).
+  - [Changes to `TypeId` could easily break Firefox](https://github.com/rust-lang/rust/pull/75923#issuecomment-699096904)
+- "Set up CI for aarch64-apple-darwin" [rust#75991](https://github.com/rust-lang/rust/pull/75991)
+  - Nominated by @**Pietro Albini** for compiler approval
+  - This PR is promoting the aarch64-apple-darwin target from Tier 3 to a Tier 2 development platform
+- "Macro hygiene change breaks Firefox builds." [rust#76480](https://github.com/rust-lang/rust/issues/76480)
+  - Breaking change
+  - Nominated for discussion about how can we do better here
+  - cc @**Esteban Küber** @**Aaron Hill**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-10-08.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-10-08.md
@@ -1,0 +1,215 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-10-08
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Today we are releasing Rust 1.47! :tada::tada::tada:
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+- Pending FCP requests (check your boxes!)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+- Things in FCP (make sure you're good with it)
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+  - "`ty.kind()` -> `ty.data()`" [compiler-team#359](https://github.com/rust-lang/compiler-team/issues/359)
+  - "Internal lint: Ban `pub` re-exports in compiler/" [compiler-team#368](https://github.com/rust-lang/compiler-team/issues/368)
+  - "Promote aarch64-pc-windows-msvc to Tier 2 Development Platform" [rust#75914](https://github.com/rust-lang/rust/pull/75914)
+  - "Set up CI for aarch64-apple-darwin" [rust#75991](https://github.com/rust-lang/rust/pull/75991)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Relax promises about condition variable." [rust#76932](https://github.com/rust-lang/rust/pull/76932)
+  - [T-libs] "Make RawFd implement the RawFd traits" [rust#76969](https://github.com/rust-lang/rust/pull/76969)
+  - [T-libs] "Remove std::io::lazy::Lazy in favour of SyncOnceCell" [rust#77154](https://github.com/rust-lang/rust/pull/77154)
+
+### WG checkins
+
+@*WG-traits* checkin by @**jackh726**:
+> We started sprint 4 of the year on Sept. 15.
+> rustc PRs:
+> * Separate projection bounds and predicates (#73905)
+> * Refactor `ty.kind` -> `ty.kind()`` (#75077)
+> * Several Chalk updates
+>   * Includes fix for fundamental types that unblocks #77187
+>
+> Chalk PRs:
+> * Add foreign types and generators (#601 and #593)
+> * Add `Unpin` and `CoerceUnsized` (#603 and #607)
+> * Extend auto trait impls for some builtin types (#612)
+> * Add `'static` (#617)
+>
+> Some changes on the horizon:
+> * `TyKind` -> `TyData`
+> * Refactoring `Binder` to track late-bound variables
+> * Adding variance and subtyping to Chalk
+> * Adding canonicalization of placeholders to Chalk
+>
+> Also, about half of rustc tests pass in `compare-mode=chalk`; we're working on triaging these and making more pass.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Move `EarlyOtherwiseBranch` to mir-opt-level 2" [rust#77582](https://github.com/rust-lang/rust/pull/77582)
+  - Opened by @**ecstatic-morse** and assigned to @**Wesley Wiser**
+  - References [PR #75119](https://github.com/rust-lang/rust/pull/75119)
+- "Update RLS and Rustfmt" [rust#77590](https://github.com/rust-lang/rust/pull/77590)
+  - Nominated because the rustfmt bump includes support for some syntax that is newly introduced in 1.48.0. When adding syntax we should aim for the rustfmt which ships with the same version of rustc to not fail on the new syntax.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [5 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [50 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [32 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [3 P-critical, 1 P-high, 4 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 20 P-high, 60 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - This one was already discussed
+  - Assigned to @**Aaron Hill**
+  - [A different LLVM patch has been accepted](https://reviews.llvm.org/D88529) and will be included in LLVM 12
+  - The accepted patch is pretty small and self-contained, so we could cherry-pick it if we wanted to
+- "coreos-installer test segfaults on s390x-unknown-linux-gnu" [rust#77382](https://github.com/rust-lang/rust/issues/77382)
+  - This was discussed last week
+  - Opened by @**cuviper**
+  - @**ecstatic-morse** points to this issue as duplicate of [rust#74551](https://github.com/rust-lang/rust/issues/74551)
+  - Crossreferenced in Bugzilla issue [#1883457](https://bugzilla.redhat.com/show_bug.cgi?id=1883457)
+  - @**cuviper** opened an issue on [LLVM](https://bugs.llvm.org/show_bug.cgi?id=47736)
+  - There's an [LLVM patch already](https://reviews.llvm.org/D89034)
+- "Type inference regression and ICE in nightly 2020-10-06" [rust#77638](https://github.com/rust-lang/rust/issues/77638)
+  - Assigned to @**Matthew Jasper**
+  - Nightly regression
+  - Bisected to [rust#73905](https://github.com/rust-lang/rust/pull/73905). The issue below regressed in the same PR
+- "[ICE] Encountered errors resolving bounds after type-checking" [rust#77653](https://github.com/rust-lang/rust/issues/77653)
+  - Assigned to @**Matthew Jasper**
+  - Nightly regression
+  - Opened by @**lzutao** to highlight comment from issue above :point_up: [rust#77638](https://github.com/rust-lang/rust/issues/77638#issuecomment-704892157)
+- "ICE: Projection bound ... was applicable to ... but now is not" [rust#77656](https://github.com/rust-lang/rust/issues/77656)
+  - Opened by @**Tavian Barnes** 
+  - Nightly regression that impacts code in a crate
+  - Bisected to commit [08e2d46](https://github.com/rust-lang/rust/commit/08e2d4616613716362b4b49980ff303f2b9ae654), merged in [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - A [possible work-around was added](https://github.com/rust-lang/rust/pull/77642) by @**Pietro Albini** but it doesn't seem to be confirmation if works or not.
+  - [@**cuviper** believes that the work-around is not the whole story about this issue](https://github.com/rust-lang/rust/issues/76980#issuecomment-705244990)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+A quiet week. One rather large regression on a synthetic benchmark and a few
+small improvements.
+
+[#77023](https://github.com/rust-lang/rust/issues/77023) is an interesting
+case. It encoded an invariant about slice lengths as an `assume` intrinsic
+inside `len` function. It seems to have caused a small compile-time slowdown,
+but there was no improvement in `check` build performance (a proxy for generated
+code quality). In fact, the LLVM documentation [specifically advises
+against](https://llvm.org/docs/LangRef.html#llvm-assume-intrinsic) overuse of
+the `assume` intrinsic in cases where the invariant is unlikely to be of much
+help to the optimizer. That seems to be the case here.
+
+Triage done by **@ecstaticmorse**.
+Revision range: [6369a98ebdee8ce01510f5d4307ddb771c8cb0e5..ea7e131435a960d154e9a5d6a9297039574ffd7d](https://perf.rust-lang.org/?start=6369a98ebdee8ce01510f5d4307ddb771c8cb0e5&end=ea7e131435a960d154e9a5d6a9297039574ffd7d&absolute=false&stat=instructions%3Au)
+
+1 Regressions, 2 Improvements, 1 Mixed
+
+1 of them in rollups
+
+### Regressions
+
+[#77381](https://github.com/rust-lang/rust/issues/77381) Rollup of 12 pull requests
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9bb55dc8642d811d66a7599812009cc063577e00&end=b218b952f800c1160b8b5e764ca651b02d678565&stat=instructions:u) (up to 18.3% on `incr-full` builds of `deeply-nested-debug`)
+- I suspect [#76909](https://github.com/rust-lang/rust/pull/76909).
+
+### Improvements
+
+[#77257](https://github.com/rust-lang/rust/issues/77257) Optimize `IntRange::from_pat`, then shrink `ParamEnv`
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=fc2daaae610b5515438b551a2f3706196a997f35&end=48cab6744786cdc5cb5428d2b64efc967ae90496&stat=instructions:u) (up to -2.1% on `full` builds of `ctfe-stress-4-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=fc2daaae610b5515438b551a2f3706196a997f35&end=48cab6744786cdc5cb5428d2b64efc967ae90496&stat=instructions:u) (up to 1.3% on `full` builds of `unicode_normalization-check`)
+
+[#77466](https://github.com/rust-lang/rust/issues/77466) Re-land PR #71840 (Rework MIR drop tree lowering) #77466
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=beb5ae474d2835962ebdf7416bd1c9ad864fe101&end=ced813fec0fb9e883906f18b76d618baf9f5bc08&stat=instructions:u) (up to 2.3% on `full` builds of `regex-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=beb5ae474d2835962ebdf7416bd1c9ad864fe101&end=ced813fec0fb9e883906f18b76d618baf9f5bc08&stat=instructions:u) (up to -2.2% on `incr-unchanged` builds of `webrender-wrench-opt`)
+
+### Mixed
+
+[#77023](https://github.com/rust-lang/rust/issues/77023) Hint the maximum length permitted by invariant of slices
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=4ccf5f731bb71db3470002d6baf5ab4792b821d9&end=beb5ae474d2835962ebdf7416bd1c9ad864fe101&stat=instructions:u) (up to 2.5% on `incr-patched: sparse set` builds of `regex-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=4ccf5f731bb71db3470002d6baf5ab4792b821d9&end=beb5ae474d2835962ebdf7416bd1c9ad864fe101&stat=instructions:u) (up to -1.2% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+
+### Nags requiring follow up
+
+- [#77381](https://github.com/rust-lang/rust/issues/77381)
+- [#77023](https://github.com/rust-lang/rust/issues/77023)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`use dep1::foo as dep1` is considered ambiguous on nightly but not beta" [rust#77586](https://github.com/rust-lang/rust/issues/77586)
+  - @**Vadim Petrochenkov** explains that the reason of this regression is [rust#77421](https://github.com/rust-lang/rust/pull/77421) that addresses [rust#74556](https://github.com/rust-lang/rust/issues/74556) which is not [a bug fix, but rather an implementation of a slightly more conservative language rule giving us some more freedom in the future](https://github.com/rust-lang/rust/issues/77586#issuecomment-703812974).
+  - Reporter mentions that [fixing to code to make it compile](https://github.com/rust-lang/rust/issues/77586#issuecomment-703817449) is not a big deal 
+  - We're slighty inclined to either close it or maybe run craterbot over it
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- "regression 1.46 -> 1.47 big-endian backtrace-related UI tests failing" [rust#77410](https://github.com/rust-lang/rust/issues/77410)
+  - Looks like there's a regression on Tier 2 platforms: `s390x | powerpc | ppc64 | sparc64` but OK on 1.46: `s390x | ppc64`
+  - Could be related to PR [rust#74682](https://github.com/rust-lang/rust/pull/74682) and [rust#77424](https://github.com/rust-lang/rust/issues/77424)

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-10-15.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-10-15.md
@@ -1,0 +1,228 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-10-15
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+- Pending FCP requests (check your boxes!)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+- Things in FCP (make sure you're good with it)
+  - "`ty.kind()` -> `ty.data()`" [compiler-team#359](https://github.com/rust-lang/compiler-team/issues/359)
+  - "inherit stable annotations in enum variants and field items" [compiler-team#370](https://github.com/rust-lang/compiler-team/issues/370)
+- Accepted MCPs
+  - "Integration of the Cranelift backend with rustc" [compiler-team#270](https://github.com/rust-lang/compiler-team/issues/270)
+- Finalized FCPs (disposition merge)
+  - "Promote aarch64-pc-windows-msvc to Tier 2 Development Platform" [rust#75914](https://github.com/rust-lang/rust/pull/75914)
+  - "Set up CI for aarch64-apple-darwin" [rust#75991](https://github.com/rust-lang/rust/pull/75991)
+  - [T-libs] "Tracking issue for slice_partition_at_index" [rust#55300](https://github.com/rust-lang/rust/issues/55300) (closed via merge of PR #77639 Oct 13)
+  - [T-libs] "Fix Debug implementations of some of the HashMap and BTreeMap iterator types" [rust#75377](https://github.com/rust-lang/rust/pull/75377) (PR merged Oct 2)
+  - [T-libs] "Stabilize slice_ptr_range." [rust#77111](https://github.com/rust-lang/rust/pull/77111) (PR merged Oct 2)
+
+### WG checkins
+
+@*WG-async-foundations* checkin by @**tmandry**:
+> Most activity has been in RFCs and improving the async book lately. We've fixed some implementation issues lately and have a [large backlog](https://github.com/orgs/rust-lang/projects/2) of others.
+>
+> There haven't been a ton of people picking up new issues to work on, but I'd still say the main bottlenecks have been reviews and mentoring. I'm shifting priorities to focus more time on this and would love to grow more reviewers from the people who are contributing. One (minor) challenge here is it's unclear if we want to grant r+ to individual wg members, but I think we do.
+
+@*WG-diagnostics* checkin by @**estebank**:
+> As usual, there has been a flurry of unstructured activity, lots of small and medium sized improvements. The following are a loose cathegorization of some of the salient work since the last update, but I'm sure I'm missing some (mainly PRs I'm fogetting about that didn't close an existing A-diagnostics ticket)
+> * **short path in error messages for unique identifiers** 🎉
+> * various improvements to structured suggestions for invalid patterns and invalid enum uses
+> * various small fixes to I-perf, parser and span accuracy regressions
+> * various borrowck wording and span tweaks
+> * more turbofish misparse recovery and suggestions
+> * gracefully handle range `const` used as pattern [rust#76222](https://github.com/rust-lang/rust/pull/76222)
+> * structured suggestion when finding trait where a type was expected in where clause and trait object type [rust#77087](https://github.com/rust-lang/rust/pull/77087)
+> * silence various redundant trait selection errors
+> * detect turbofish without surrounding angle brackets and recover parser state gracefully
+> * smarter numeric conversion suggestion [rust#73145](https://github.com/rust-lang/rust/issues/73145)
+> * suggest constraining type parameter with appropriate trait bound when encountering binop involving them
+> * auditted hidden/short code suggestions
+> * tweak "missing lifetime" structured suggestions to be more accurate and account for `for<'lt>`
+> 
+> Upcoming change needing eyes:
+> * Provide appropriate types in turbofish suggestions [rust#76043](https://github.com/rust-lang/rust/pull/76043)
+
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "rustc_parse: More precise spans for `tuple.0.0`" [rust#77774](https://github.com/rust-lang/rust/pull/77774)
+  - Fixes a severe rustfmt issue [rustfmt#4355](https://github.com/rust-lang/rustfmt/issues/4355)
+  - cc @**Vadim Petrochenkov** @**Esteban Küber** 
+- "Update crossbeam-channel to avoid UB" [rust#77819](https://github.com/rust-lang/rust/pull/77819)
+  - Porting of a [security patch in crossbeam-channel](https://github.com/RustSec/advisory-db/pull/425) already in 1.47 stable
+  - cc @**mati865** @**Joshua Nelson** @**simulacrum** @**lcnr**
+- "Do not ICE with TraitPredicates containing [type error]" [rust#77930](https://github.com/rust-lang/rust/pull/77930)
+  - Fixes a `P-medium` ICE [rustc#77919](https://github.com/rust-lang/rust/issues/77919) on resolving bounds after type-checking error
+  - cc @**Esteban Küber** @**Jack Huey**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Do not ICE with TraitPredicates containing [type error]" [rust#77930](https://github.com/rust-lang/rust/pull/77930)
+  - Fixes a `P-medium` ICE [rustc#77919](https://github.com/rust-lang/rust/issues/77919) on resolving bounds after type-checking error
+  - Nominating for stable backport because this is handling a stable-to-stable regression, but it was introduced back in 1.36 so it doesn't warrant a dot release only for this one fix.
+  - cc @**Esteban Küber** @**Jack Huey**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Tracking issue for renaming crates inside compiler directory" [rust#76425](https://github.com/rust-lang/rust/issues/76425)
+  - References this [MCP](https://github.com/rust-lang/compiler-team/issues/336)
+  - The goal is to have all crates under `./compiler` have a consistent name
+  - cc @**DPC** @**Joshua Nelson** @**Eric Huss** @**mark-i-m** @**Vadim Petrochenkov**
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [48 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [30 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [2 P-critical, 2 P-high, 4 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 19 P-high, 63 P-medium, 6 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - This one was already discussed
+  - [A different LLVM patch has been accepted](https://reviews.llvm.org/D88529) and will be included in LLVM 12
+  - The accepted patch is pretty small and self-contained, so we could cherry-pick it if we wanted to
+  - cc @**Aaron Hill**
+- "coreos-installer test segfaults on s390x-unknown-linux-gnu" [rust#77382](https://github.com/rust-lang/rust/issues/77382)
+  - This one was already discussed
+  - @**ecstatic-morse** points to this issue as duplicate of [rust#74551](https://github.com/rust-lang/rust/issues/74551)
+  - @**cuviper** opened an issue on [LLVM](https://bugs.llvm.org/show_bug.cgi?id=47736) and the issue was already fixed
+  - [Backport is waiting for LLVM 11 final rebase](https://github.com/rust-lang/rust/issues/77382#issuecomment-708618338)
+- "[ICE] Encountered errors resolving bounds after type-checking" [rust#77653](https://github.com/rust-lang/rust/issues/77653)
+  - This one was already discussed
+  - Nightly regression
+  - Opened by @**lzutao** to highlight comment from issue above :point_up: [rust#77638](https://github.com/rust-lang/rust/issues/77638#issuecomment-704892157)
+  - Bisected to commit [08e2d46](https://github.com/rust-lang/rust/commit/08e2d4616613716362b4b49980ff303f2b9ae654)
+  - [PR by @**Matthew Jasper** that fixes the issue is up](https://github.com/rust-lang/rust/pull/77720) 
+- "ICE: Projection bound ... was applicable to ... but now is not" [rust#77656](https://github.com/rust-lang/rust/issues/77656)
+  - This one was already discussed
+  - Nightly regression that impacts code in a crate
+  - Bisected to commit [08e2d46](https://github.com/rust-lang/rust/commit/08e2d4616613716362b4b49980ff303f2b9ae654), merged in [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+  - [PR by @**Matthew Jasper** that fixes the issue is up](https://github.com/rust-lang/rust/pull/77720) 
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "ICE: Expected module, found DefId" [rust#75982](https://github.com/rust-lang/rust/issues/75982)
+  - Unassigned
+  - Reported by @**Daniel Henry-Mantilla|232018**
+  - Issue priority raised to `P-high`: issue reporter [mentions there was a test shadowing the ICE](https://github.com/rust-lang/rust/issues/75982#issuecomment-706100003) behind a compiler error. ICE persists after removing this test. 
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - A [possible workaround was added](https://github.com/rust-lang/rust/pull/77642) by @**Pietro Albini** but it doesn't seem to be confirmation if works or not.
+  - @**cuviper** believes the real issue stems in PR [rustc#74163](https://github.com/rust-lang/rust/pull/74163)
+  - There's a long technical analysis in the [last comment](https://github.com/rust-lang/rust/issues/76980#issuecomment-705800997)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- "New "warning incompatible with previous forbid in same scope" error" [rust#77713](https://github.com/rust-lang/rust/issues/77713)
+  - Opened by @**Nemo157** 
+  - Error seems two conflicting/overlapping `unused_extern_crates` linting options cause a crash
+  - issue reporter mentions issue [rustc#77713](https://github.com/rust-lang/rust/issues/70819) and following PR [rustc#77534](https://github.com/rust-lang/rust/pull/77534) as origin of the intended behaviour
+  - @**nikomatsakis** reported about the [discussion on this issues](https://github.com/rust-lang/rust/issues/77713#issuecomment-707326546) and suggests to be ok with giving precedence to the `forbid` directive, provided a context of how the linting precedence used to work, works today and in different context (e.g. from the CLI)
+
+## Performance logs
+
+Overall, fairly busy week, but without major regressions that need to be
+addressed.
+
+Triage done by **@simulacrum**.
+Revision range: [ea7e131435a960d154e9a5d6a9297039574ffd7d..06a079c43efb062e335e6e6c9dabd3c750619980](https://perf.rust-lang.org/?start=ea7e131435a960d154e9a5d6a9297039574ffd7d&end=06a079c43efb062e335e6e6c9dabd3c750619980&absolute=false&stat=instructions%3Au)
+
+0 Regressions, 3 Improvements, 3 Mixed
+1 mixed improvement in a rollup
+
+### Regressions
+
+### Improvements
+
+[#73905](https://github.com/rust-lang/rust/issues/73905)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5849a7eca90582ee59b67eb09548a2aa424d7f52&end=08e2d4616613716362b4b49980ff303f2b9ae654&stat=instructions:u) (up to -90.5% on `full` builds of `wf-projection-stress-65510-check`)
+
+[#77597](https://github.com/rust-lang/rust/issues/77597)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=91a79fb29ac78d057d04dbe86be13d5dcc64309a&end=e055f87cdfcac1f4da6c518a547dee459de0aa26&stat=instructions:u) (up to -3.5% on `full` builds of `match-stress-enum-debug`)
+
+[#77793](https://github.com/rust-lang/rust/issues/77793)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=bc74dd711fd154555dea3b110dfed39c4dc37bc6&end=8cc82ee340ed96099680ec1165cf5e192d658d0f&stat=instructions:u) (up to -2.3% on `full` builds of `piston-image-debug`)
+
+### Mixed
+
+[#77594](https://github.com/rust-lang/rust/issues/77594)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5ded394553296d56bb66e925d7001ab3271979ce&end=5849a7eca90582ee59b67eb09548a2aa424d7f52&stat=instructions:u) (up to 46.0% on `full` builds of `deeply-nested-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5ded394553296d56bb66e925d7001ab3271979ce&end=5849a7eca90582ee59b67eb09548a2aa424d7f52&stat=instructions:u) (up to -1.6% on `incr-unchanged` builds of `deeply-nested-opt`)
+
+[#77630](https://github.com/rust-lang/rust/issues/77630)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=98edd1fbf8a68977a2a7c1312eb1ebff80515a92&end=59dafb876e125c49fca93820c5ef22da3fcb8644&stat=instructions:u) (up to -5.2% on `full` builds of `match-stress-enum-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=98edd1fbf8a68977a2a7c1312eb1ebff80515a92&end=59dafb876e125c49fca93820c5ef22da3fcb8644&stat=instructions:u) (up to 1.6% on `full` builds of `style-servo-opt`)
+
+[#77771](https://github.com/rust-lang/rust/issues/77771)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=cae8bc1f2324e31c98cb32b8ed37032fc9cef405&end=87b71ed68b69361ab0d45653a972ad4cf7a65cba&stat=instructions:u) (up to -2.5% on `incr-patched: Job` builds of `regex-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=cae8bc1f2324e31c98cb32b8ed37032fc9cef405&end=87b71ed68b69361ab0d45653a972ad4cf7a65cba&stat=instructions:u) (up to 1.3% on `full` builds of `match-stress-enum-check`)
+
+### Nags requiring follow up
+
+- #77594
+- [#77630](https://github.com/rust-lang/rust/pull/77630#issuecomment-707713702)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+-  Confusing type error due to strange inferred type for a closure argument [rustc#41078](https://github.com/rust-lang/rust/issues/41078)
+    -  Longstsanding issue since 2017, has generated many duplicates since then
+    -  Seems to impact more from an usability/ergonomics point of view since there are workarounds, example [this comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-298180037) and this [Stack Overflow](https://stackoverflow.com/questions/58773989) answer
+    -  [First comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-293646723) by @**nikomatsakis** 
+    -  More [recent comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-358385901) from @**nikomatsakis**
+    -  [Another explaination](https://github.com/rust-lang/rust/issues/41078#issuecomment-552064766) from @**eddyb** 
+    -  nightly from June shows a [slightly different error](https://github.com/rust-lang/rust/issues/41078#issuecomment-649465827)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-10-22.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-10-22.md
@@ -1,0 +1,337 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-10-22
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Rust Compiler + Dev Tools Jobs
+    - Microsoft has a [Senior Software Engineer role](https://careers.microsoft.com/us/en/job/917051/Senior-Software-Engineer): "We are looking for engineers to work on Rust compilers and tools to support the usage of the Rust programming language."
+    - Facebook is also hiring compiler and library engineers (US only), according to [Nadav Rotem tweet](https://twitter.com/nadavrot/status/1319003839018614784?s=20); (if anyone finds an actual job listing, feel free to share it)
+- Tomorrow Friday 23rd at <time:2020-10-23T14:00:00+00:00> we have a [Compiler Team Planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html)
+- New MCPs (take a look, see if you like them!)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+- Old MCPs (not seconded, take a look)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+- Pending FCP requests (check your boxes!)
+  - "inherit stable annotations in enum variants and field items" [compiler-team#370](https://github.com/rust-lang/compiler-team/issues/370)
+- Things in FCP (make sure you're good with it)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "`ty.kind()` -> `ty.data()`" [compiler-team#359](https://github.com/rust-lang/compiler-team/issues/359)
+  - "Change type folding to take self by value" [compiler-team#371](https://github.com/rust-lang/compiler-team/issues/371)
+  - "TypeVisitor: use ops::ControlFlow instead of bool" [compiler-team#374](https://github.com/rust-lang/compiler-team/issues/374)
+  - "Allow making `RUSTC_BOOTSTRAP` conditional on the crate name" [rust#77802](https://github.com/rust-lang/rust/pull/77802)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-lang] "resolve: Do not put nonexistent crate `meta` into prelude" [rust#75802](https://github.com/rust-lang/rust/pull/75802)
+  - [T-lang] "stabilize union with 'ManuallyDrop' fields and 'impl Drop for Union'" [rust#77547](https://github.com/rust-lang/rust/pull/77547)
+
+### WG checkins
+
+@*WG-rustc-dev-guide* checkin by @**Santiago Pastorino** and @**Joshua Nelson**:
+>- [75 merged PRs!](https://github.com/rust-lang/rustc-dev-guide/pulls?q=is%3Apr+sort%3Aupdated-desc+updated%3A%3E2020-09-03+)
+>- Joshua Nelson is now a co-lead of the rustc-dev-guide working group! [team#449](https://github.com/rust-lang/team/pull/449)
+>
+>### Authors
+
+>**@1c3t3a**, **@arora-aman**, **@bugadani**, **@caass**, **@camelid**, **@ecstatic-morse**, **@follower**, **@guswynn**, **@JakobDegen**, **@JOE1994**, **@JohnTitor**, **@Julian-Wollersberger**, **@jyn514**, **@LeSeulArtichaut**, **@macdonaldo**, **@mark-i-m**, **@matklad**, **@mautamu**, **@mightyiam**, **@Monadic-Cat**, **@Nadrieril**, **@pickfire**, **@r-52**, **@richkadel**, **@spastorino**, **@Stupremee**
+>
+>### Major Changes
+>
+>Some minor changes are omitted for brevity.
+>
+>#### Contributor-facing changes
+>
+>- New content
+>    - Explain stages in terms of the compiler currently running (take N+1) [#857](https://github.com/rust-lang/rustc-dev-guide/pull/857)
+>    - Explain pattern exhaustiveness checking [#923](https://github.com/rust-lang/rustc-dev-guide/pull/923)
+>    - Added description of word Scrutinee to the glossary [#921](https://github.com/rust-lang/rustc-dev-guide/pull/921)
+>    - Add a paragraph about reviewers and review latency in Getting Started chapter [#907](https://github.com/rust-lang/rustc-dev-guide/pull/907)
+>    - Document the usage of cargo-llvm-lines and -Ztimings. [#905](https://github.com/rust-lang/rustc-dev-guide/pull/905)
+>    - Add docs for `x.py setup` [#899](https://github.com/rust-lang/rustc-dev-guide/pull/899)
+>    - Add section on using git [#890](https://github.com/rust-lang/rustc-dev-guide/pull/890)
+>    - add suggested workflow to setup nightly rustup for rust/ [#883](https://github.com/rust-lang/rustc-dev-guide/pull/883)
+>    - Describe how to generate graphviz diagrams for dataflow [#882](https://github.com/rust-lang/rustc-dev-guide/pull/882)
+>    - Add Salsa In More Depth lecture [#879](https://github.com/rust-lang/rustc-dev-guide/pull/879)
+>    - Document new way to not build LLVM [#878](https://github.com/rust-lang/rustc-dev-guide/pull/878)
+>    - Add a chapter on useful `@rustbot` commands [#874](https://github.com/rust-lang/rustc-dev-guide/pull/874)
+>    - Add a chapter on all the identifiers used through `rustc` [#872](https://github.com/rust-lang/rustc-dev-guide/pull/872)
+>    - Add information about default stages for x.py [#865](https://github.com/rust-lang/rustc-dev-guide/pull/865)
+>    - Document how to promote a target from cross-compiled to hosted [#860](https://github.com/rust-lang/rustc-dev-guide/pull/860)
+>    - Add section describing git hook functionality [#848](https://github.com/rust-lang/rustc-dev-guide/pull/848)
+>    - Document CGU partioning in case of generic and inline functions [#847](https://github.com/rust-lang/rustc-dev-guide/pull/847)
+>    
+>- Improvements and fixes
+>    - Recommend debug-logging instead of debug [#917](https://github.com/rust--lang/rustc-dev-guide/pull/917)
+>    - Link to the -Zmir-opt-level proposal [#888](https://github.com/rust-lang/rustc-dev-guide/pull/888)
+>    - Don't recommend building the compiler for running tests on the standard library [#887](https://github.com/rust-lang/rustc-dev-guide/pull/887)
+>    - Improve instructions for adding a new test [#881](https://github.com/rust-lang/rustc-dev-guide/pull/881)
+>    - Improve MIR sections in appendix [#880](https://github.com/rust-lang/rustc-dev-guide/pull/880)
+>    - Update prerequisites, with an eye towards windows [#863](https://github.com/rust-lang/rustc-dev-guide/pull/863)
+>    - update docs to refer to the `compiler/` move [#846](https://github.com/rust-lang/rustc-dev-guide/pull/846)
+>
+>#### Internal changes
+>
+>- Linkcheck only changed files (except for cron jobs) [#913](https://github.com/rust-lang/rustc-dev-guide/pull/913). This fixes persistent issues with CI spuriously failing.
+>- Allow anyone to change the status of a PR [#910](https://github.com/rust-lang/rustc-dev-guide/pull/910)
+>
+>### Changes in progress
+>
+>- Add a `check-in.sh` script to automate writing markdown links for weekly check-in [#930](https://github.com/rust-lang/rustc-dev-guide/pull/930)
+
+@*WG-llvm* checkin by @**Nikita Popov** :
+>The first parts of the mustprogress attribute have landed (https://reviews.llvm.org/D86233, https://reviews.llvm.org/D85393). This means that forward progress is now opt-in. Once this work is complete, this will resolve current bugs around infinite loops being optimized away. There isn't a patch for that yet, but I dare say the hardest part (convincing people that this is the right thing to do) is done now...
+>
+>MemorySSA-based DSE has been enabled by default (https://reviews.llvm.org/D87163), which means dead stores are eliminated across based blocks. Expect some compile-time regression... More importantly for rust, I've ported MemCpyOpt to MSSA (https://reviews.llvm.org/D89207), which will allow memcpy's to be eliminated across blocks as well, a long-standing optimization problem. It's not the first attempt to do this, but I'm optimistic :)
+>
+>Some older changes that I probably have not mentioned before. I've finally managed to make correlated value propagation optimize conditions based on local value ranges (https://reviews.llvm.org/D69686), which will resolve various missing bounds check optimizations where constant operands are involved. There is also a new constraint elimination pass (https://reviews.llvm.org/D84547) which is able to reason about complex implications symbolically. However, it is not enabled by default, and there's no roadmap to enable it at present.
+>
+>Also been a while ago, but someone took over my work for introducing saturating float to int casts (https://reviews.llvm.org/D54749). There's been some slow progress, and maybe there's a chance that this will land before the heat death of the universe... Rust has worked around this in the meantime, but once/if it lands we can improve codegen.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Tweak `if let` suggestion to be more liberal with suggestion and to not ICE" [rust#77283](https://github.com/rust-lang/rust/pull/77283)
+  - Opened by @**Esteban Küber** 
+  - Should fix [rust#77218](https://github.com/rust-lang/rust/issues/77218) (`P-high` beta regression) and [rust#77238](https://github.com/rust-lang/rust/issues/77238)
+- "Revert "Allow dynamic linking for iOS/tvOS targets."" [rust#77716](https://github.com/rust-lang/rust/pull/77716)
+  - (has not landed in nightly) 
+  - Opened by `@francesca64`
+  - Assigned to @**Jonas Schievink** 
+  - This patch reverts [rust#73516](https://github.com/rust-lang/rust/pull/73516) and **disallows** compiling against dynamic libs (Apple does not allow that and your App won't be published)
+  - Previous patch however **allowed** dynamic linking
+  - Reverting now the patch breaks code in production (as pointed out by `@aspenluxxxy`, previous patch author)
+  - @**Jonas Schievink** [suggests as last resort](https://github.com/rust-lang/rust/pull/77716#issuecomment-709364682) to revert the previous patch (although not the ideal solution) since this can now be considered a regression from stable
+  - `@cutsoy` implements a patch [adding a new parameter to cargo](https://github.com/rust-lang/rust/pull/77716#issuecomment-709410444)
+  - Issue reporter [suggests](https://github.com/rust-lang/rust/pull/77716#issuecomment-712492125) that the above patch works just fine
+  - Question: from the T-compiler point of view, anything else that can be done/investigated or the case is closed?
+- "Disable MatchBranchSimplification" [rust#78151](https://github.com/rust-lang/rust/pull/78151)
+  - Opened by `@tmiasko` 
+  - Mentions that this optimization can result in unsoundness, because it introduces additional uses of a place holding the discriminant value without ensuring that it is valid
+  - Patch found after adding the [-Zvalidate-mir](https://github.com/rust-lang/rust/pull/77369) validation
+- "Disable "optimization to avoid load of address" in InstCombine" [rust#78195](https://github.com/rust-lang/rust/pull/78195)
+    - Opened by `@tmiasko`
+    - Assigned to @**oli** 
+    - This fixes `P-critical` issue [rust#78192](https://github.com/rust-lang/rust/issues/78192) 
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Revert "Allow dynamic linking for iOS/tvOS targets."" [rust#77716](https://github.com/rust-lang/rust/pull/77716)
+  - This was also beta nominated
+- "Disable MatchBranchSimplification" [rust#78151](https://github.com/rust-lang/rust/pull/78151)
+  - This was also beta nominated
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Tracking issue for renaming crates inside compiler directory" [rust#76425](https://github.com/rust-lang/rust/issues/76425)
+  - References this [MCP](https://github.com/rust-lang/compiler-team/issues/336)
+  - The goal is to have all crates under `./compiler` have a consistent name
+  - @**nikomatsakis**  summarized the discussion in this [HackMD file](https://hackmd.io/1FgS1fZGSOyWrwhDMq98pw)
+  - cc @**DPC** @**Joshua Nelson** @**Eric Huss** @**mark-i-m** @**Vadim Petrochenkov**
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [6 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [3 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [48 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [29 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 4 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [2 P-critical, 2 P-high, 4 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 18 P-high, 63 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Increasingly slow compilation as more levels of `async` are added in Rust 1.46" [rust#75992](https://github.com/rust-lang/rust/issues/75992)
+  - Opened by @**Nicholas Bishop** 
+  - Unassigned, not easy to reproduce
+  - [@kellerkindt](https://github.com/rust-lang/rust/issues/75992#issuecomment-683270098) and [@algesten](https://github.com/rust-lang/rust/issues/75992#issuecomment-683274620) did some bisecting 
+  - @**Noah Kennedy** is trying to build a minimal repro 
+  - @**lcnr** suggests instead of reverting important patches a possible way forward could be implementing some caching like in [PR #76928](https://github.com/rust-lang/rust/issues/75992#issuecomment-713100226)
+- "Optimisation-caused UB during cross-crate compilation" [rust#76387](https://github.com/rust-lang/rust/issues/76387)
+  - This one was already discussed
+  - Assigned to @**Aaron Hill**
+  - [A different LLVM patch has been accepted](https://reviews.llvm.org/D88529) and will be included in LLVM 12
+  - The accepted patch is pretty small and self-contained, so we could cherry-pick it if we wanted to
+- "[ICE] Encountered errors resolving bounds after type-checking" [rust#77653](https://github.com/rust-lang/rust/issues/77653)
+  - This one was already discussed
+  - Nightly regression
+  - Opened by @**lzutao** to highlight comment from issue above :point_up: [rust#77638](https://github.com/rust-lang/rust/issues/77638#issuecomment-704892157)
+  - Bisected to commit [08e2d46](https://github.com/rust-lang/rust/commit/08e2d4616613716362b4b49980ff303f2b9ae654)
+  - [PR by @**Matthew Jasper** that fixes the issue is up and r+ed](https://github.com/rust-lang/rust/pull/77720) but with issues to go through
+- "ICE: Projection bound ... was applicable to ... but now is not" [rust#77656](https://github.com/rust-lang/rust/issues/77656)
+  - This one was already discussed
+  - Nightly regression that impacts code in a crate
+  - Bisected to commit [08e2d46](https://github.com/rust-lang/rust/commit/08e2d4616613716362b4b49980ff303f2b9ae654), merged in [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+  - [PR by @**Matthew Jasper** that fixes the issue is up and r+ed](https://github.com/rust-lang/rust/pull/77720) but with issues to go through
+- "InstCombine introduces an incorrect use of a local after its storage has ended" [rust#78192](https://github.com/rust-lang/rust/issues/78192)
+    - Opened by `tmiasko`
+    - MIR opt causes unsoundness
+    - Found by MIR validator PR [rust#77369](https://github.com/rust-lang/rust/pull/77369) & [rust#78147](https://github.com/rust-lang/rust/pull/78147)
+    - Bugs' origin [rust#76683](https://github.com/rust-lang/rust/pull/76683)
+    - Already merged PR [rust#78195](https://github.com/rust-lang/rust/pull/78195) to disable problematic parts of InstCombine optimization, waiting for beta backport
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- "regression: could not fully normalize type" [rust#78139](https://github.com/rust-lang/rust/issues/78139)
+    - Opened by @**simulacrum** 
+    - Regression seems to be in PR [rust#70793](https://github.com/rust-lang/rust/pull/70793)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "ICE: Expected module, found DefId" [rust#75982](https://github.com/rust-lang/rust/issues/75982)
+  - Reported by @**Daniel Henry-Mantilla|232018**
+  - Assigned to @**Aaron Hill** 
+  - Issue priority raised to `P-high`: issue reporter [mentions there was a test shadowing the ICE](https://github.com/rust-lang/rust/issues/75982#issuecomment-706100003) behind a compiler error. ICE persists after removing this test. 
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - A [possible workaround was added](https://github.com/rust-lang/rust/pull/77642) by @**Pietro Albini** but it doesn't seem to be confirmation if works or not.
+  - @**cuviper** believes the real issue stems in PR [rustc#74163](https://github.com/rust-lang/rust/pull/74163)
+  - There's a long technical analysis in the [last comment](https://github.com/rust-lang/rust/issues/76980#issuecomment-705800997)
+  - @**simulacrum** asked `jethrogb` and @**cuviper** if they could open a PR about it
+- "ICE on `if let Some() = ...` expression in loop with variable shadowing and missing let keyword" [rust#77218](https://github.com/rust-lang/rust/issues/77218)
+  - Opened by `zdenek-crha`
+  - Regression in PR [rust#75931](https://github.com/rust-lang/rust/pull/75931)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- "ICE:  tuple_fields called on non-tuple:  async fn with unknown macro" [rust#77993](https://github.com/rust-lang/rust/issues/77993)
+  - opened by @**NeoRaider** 
+  - reviewed by @**Vadim Petrochenkov** and @**LeSeulArtichaut** 
+  - This should fix an issue emerged in [#69274](https://github.com/rust-lang/rust/pull/69274) and [#70307](https://github.com/rust-lang/rust/issues/70307)
+    
+## Performance logs
+
+A variety of changes, nothing particularly notable from a performance
+perspective. [#77792](https://github.com/rust-lang/rust/issues/77792) is an
+interesting win on migrating to tracing values rather than the older log
+formatting. [#76859](https://github.com/rust-lang/rust/issues/76859) is also
+interesting, starting out as a functional fix but appears to have been a
+performance win for incremental benchmarks in some cases as well.
+
+[Triage](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs) done by **@simulacrum**.
+Revision range: [06a079c43efb062e335e6e6c9dabd3c750619980..22e6b9c68941996daa45786b4145e6196e51f0f4](https://perf.rust-lang.org/?start=06a079c43efb062e335e6e6c9dabd3c750619980&end=22e6b9c68941996daa45786b4145e6196e51f0f4&absolute=false&stat=instructions%3Au)
+
+4 Regressions, 7 Improvements, 0 Mixed
+2 of them in rollups
+
+### Regressions
+
+[#77755](https://github.com/rust-lang/rust/issues/77755)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e8529c79cce76b47b7b61060db36cf8201c688a3&end=2d6eccdb67aef48d0804cb473536b925f61a7f18&stat=instructions:u) (up to 1.3% on `full` builds of `deeply-nested-async-check`)
+- [Nag](https://github.com/rust-lang/rust/pull/77755#issuecomment-714086526)
+
+[#77873](https://github.com/rust-lang/rust/issues/77873)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=19e1aac6ea9879c6d10eed7106b3bc883e5bf9a5&end=93deabce03dc10a80244f5da3e3819452744da2a&stat=instructions:u) (up to 2.7% on `full` builds of `wg-grammar-check`)
+- Functional change. Regression not significantly major to warrant a revert.
+
+[#78060](https://github.com/rust-lang/rust/issues/78060)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ffeeb20398bb9a25c1f75599b942f57c85a2140d&end=043eca7f0b34d12e61c44206beca740628647080&stat=instructions:u) (up to 1.2% on `incr-unchanged` builds of `clap-rs-check`)
+- Rollup; likely due to BTreeMap or meta-prelude changes. Not worth deep
+  investigation: regression is minor and interesting changes are likely not
+  readily changeable.
+
+[#77250](https://github.com/rust-lang/rust/issues/77250)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=19356453cbfb734bc60a1853c10e3095d05e0342&end=22e6b9c68941996daa45786b4145e6196e51f0f4&stat=instructions:u) (up to 3.1% on `incr-unchanged` builds of `packed-simd-check`)
+- Functional change that we definitely want, performance regression is not too
+  significant.
+
+### Improvements
+
+[#76859](https://github.com/rust-lang/rust/issues/76859)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=06a079c43efb062e335e6e6c9dabd3c750619980&end=c71248b70870960af9993de4f31d3cba9bbce7e8&stat=instructions:u) (up to -58.0% on `incr-patched: Compiler new` builds of `regex-opt`)
+- Correctness is the key here, but it seems like our hand-rolled incremental
+  tracking was (at least on the perf benchmarks) worse anyway.
+
+[#77792](https://github.com/rust-lang/rust/issues/77792)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=8dae8cdcc8fa879cea6a4bbbfa5b32e97be4c306&end=abbdec3be6cfce1175d0dc6737a2999cf43b530d&stat=instructions:u) (up to -1.7% on `incr-unchanged` builds of `deeply-nested-async-opt`)
+- Switching to tracing spans and tracing's "values" over string-formatting seems
+  to have been a improvement here. Definitely an interesting result --
+  presumably tracing's handling is somehow more visible to LLVM?
+
+[#77796](https://github.com/rust-lang/rust/issues/77796)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=abbdec3be6cfce1175d0dc6737a2999cf43b530d&end=afb4514c099fde6e3102373602bea9e6dacd4f88&stat=instructions:u) (up to -1.4% on `full` builds of `deeply-nested-async-check`)
+- Seems like potentially a slight regression on wall times, but ultimately the
+  change is good on its merits, so no action is taken at this time.
+
+[#77947](https://github.com/rust-lang/rust/issues/77947)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b6e2dc6cdece6b498b876bc7e9377ff7d63d93e7&end=9bd740a8f17d75168b683bcfb077b6e450047df5&stat=instructions:u) (up to -7.4% on `incr-unchanged` builds of `cranelift-codegen-debug`)
+- Seems to be a mixed result on [wall
+  times](https://perf.rust-lang.org/compare.html?start=b6e2dc6cdece6b498b876bc7e9377ff7d63d93e7&end=9bd740a8f17d75168b683bcfb077b6e450047df5&stat=wall-time)
+  though.
+
+[#77373](https://github.com/rust-lang/rust/issues/77373)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=6af9846fcc8797bf97e9fb387385208c2219f3d0&end=ffeeb20398bb9a25c1f75599b942f57c85a2140d&stat=instructions:u) (up to -1.6% on `full` builds of `deeply-nested-async-check`)
+- Wall times are less positive, but mostly on incremental. Not deemed a concern.
+
+[#77908](https://github.com/rust-lang/rust/issues/77908)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=cb2462c53f2cc3f140c0f1ea0976261cab968a34&end=f90e6173053f7e6b377d7f75367b511ceee7d9d1&stat=instructions:u) (up to -1.8% on `full` builds of `inflate-check`)
+
+[#78151](https://github.com/rust-lang/rust/issues/78151)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=9832374f6e378971e1a933362cf9781b121bb845&end=981346fc07dd5ef414c5b1b21999f7604cece006&stat=instructions:u) (up to -7.6% on `incr-patched: println` builds of `regression-31157-opt`)
+
+### Nags requiring follow up
+
+- https://github.com/rust-lang/rust/pull/77755#issuecomment-714086526
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- Confusing type error due to strange inferred type for a closure argument [rustc#41078](https://github.com/rust-lang/rust/issues/41078)
+    - Longstsanding issue since 2017, has generated many duplicates since then
+    - Seems to impact more from an usability/ergonomics point of view since there are workarounds, example [this comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-298180037) and this [Stack Overflow](https://stackoverflow.com/questions/58773989) answer
+    - [First comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-293646723) by @**nikomatsakis** 
+    - More [recent comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-358385901) from @**nikomatsakis**
+    - [Another explaination](https://github.com/rust-lang/rust/issues/41078#issuecomment-552064766) from @**eddyb** 
+    - nightly from June shows a [slightly different error](https://github.com/rust-lang/rust/issues/41078#issuecomment-649465827)
+- "regression: target_feature no longer permitted in some places" [rust#78143](https://github.com/rust-lang/rust/issues/78143)
+  - Opened by @**simulacrum** 
+  - Should fix an issue caused by PR [rust#71205](https://github.com/rust-lang/rust/pull/71205)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Amend RFC2603 to allow mangled identifiers to start with a digit." [rfcs#2705](https://github.com/rust-lang/rfcs/pull/2705)
+  - Submitted by @**eddyb** 
+  - RFC proposes a new mangling scheme describing what the symbol names generated by the Rust compiler look like
+  - Suggested by @**pnkfelix**  [in this comment](https://github.com/rust-lang/rfcs/pull/2603#discussion_r279670424)
+- "RFC: -C export-executable-symbols" [rfcs#2841](https://github.com/rust-lang/rfcs/pull/2841)
+  - Submitted by `@MaulingMonkey`
+  - RFC proposes adding the ability to export symbols from executables, not just dylibs, via a new compiler flag `-C export-executable-symbols`
+  - @**pnkfelix** [has some questions](https://github.com/rust-lang/rfcs/pull/2841#issuecomment-569852146)

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-10-29.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-10-29.md
@@ -1,0 +1,236 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-10-29
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+- Pending FCP requests (check your boxes!)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+- Things in FCP (make sure you're good with it)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "inherit stable annotations in enum variants and field items" [compiler-team#370](https://github.com/rust-lang/compiler-team/issues/370)
+  - "TypeVisitor: use ops::ControlFlow instead of bool" [compiler-team#374](https://github.com/rust-lang/compiler-team/issues/374)
+  - "Move graphviz code out of the compiler into external crate" [compiler-team#380](https://github.com/rust-lang/compiler-team/issues/380)
+  - "Allow making `RUSTC_BOOTSTRAP` conditional on the crate name" [rust#77802](https://github.com/rust-lang/rust/pull/77802)
+- Accepted MCPs
+  - "Change type folding to take self by value" [compiler-team#371](https://github.com/rust-lang/compiler-team/issues/371)
+- Finalized FCPs (disposition merge)
+  - [T-lang] "Stabilize `Poll::is_ready` and `is_pending` as const" [rust#76227](https://github.com/rust-lang/rust/pull/76227)
+  - [T-lang] "passes: `check_attr` on more targets" [rust#77015](https://github.com/rust-lang/rust/pull/77015)
+  - [T-lang] "stop promoting union field accesses in 'const'" [rust#77526](https://github.com/rust-lang/rust/pull/77526)
+- Heads up: pnkfelix plans to check off all the remaining T-compiler checkboxes on [this fcp close for RFC 2048](https://github.com/rust-lang/rfcs/pull/2048#issuecomment-718123002)
+
+### WG checkins
+
+@*T-compiler/WG-meta* checkin by @**nikomatsakis**:
+> Checkin text
+
+@*WG-mir-opt* checkin by @**oli**:
+* MIR Inlining tracks source scopes [rust#68965](https://github.com/rust-lang/rust/pull/68965)
+* Add dest prop pass [rust#72632](https://github.com/rust-lang/rust/pull/72632)
+* Remove the copy prop pass for good [rust#77373](https://github.com/rust-lang/rust/pull/77373)
+* `-Zunsound-mir-opts` to enable experimental and broken passes [rust#77322](https://github.com/rust-lang/rust/pull/77322), [rust#76899](https://github.com/rust-lang/rust/pull/76899)
+* Optimize away drop calls on `!needs_drop` types [rust#76673](https://github.com/rust-lang/rust/pull/76673)
+* Optimize away `x == bool_const` and `x != bool_const` [rust#76067](https://github.com/rust-lang/rust/pull/76067)
+* Lots of improvements to dataflow [rust#71006](https://github.com/rust-lang/rust/pull/71006)
+* `mir::Body` now knows its source/owner [rust#77430](https://github.com/rust-lang/rust/pull/77430)
+* Make mir dumps less noisy [rust#75566](https://github.com/rust-lang/rust/pull/75566), [rust#75670](https://github.com/rust-lang/rust/pull/75670)
+* Reminder: MIR is now validated for correctness (example: [rust#75562](https://github.com/rust-lang/rust/pull/75562))
+    * Please put all testable invariants into the MIR validator
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Do not try to report on closures to avoid ICE" [rust#78268](https://github.com/rust-lang/rust/pull/78268)
+    - opened by @**Yuki Okushi**  and assigned to @**Esteban Küber**
+    - fixes [rust#78262](https://github.com/rust-lang/rust/issues/78262) (a P-medium panic when computing function signature of closure with trait object)
+- "Do not ICE on invalid input" [rust#78422](https://github.com/rust-lang/rust/pull/78422)
+    - opened by @**Esteban Küber** and assigned to @**eddyb**
+    - PR not yet reviewed
+    - Fixes [rust#78372](https://github.com/rust-lang/rust/issues/78372) (ICE on computing layout for a type)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Tracking issue for renaming crates inside compiler directory" [rust#76425](https://github.com/rust-lang/rust/issues/76425)
+  - "Discussed" last week but we didn't find an agreement, @**pnkfelix** suggested maybe a design meeting?
+  - References this [MCP](https://github.com/rust-lang/compiler-team/issues/336)
+  - The goal is to have all crates under `./compiler` have a consistent name
+  - @**nikomatsakis**  summarized the discussion in this [HackMD file](https://hackmd.io/1FgS1fZGSOyWrwhDMq98pw)
+  - cc @**DPC** @**Joshua Nelson** @**Eric Huss** @**mark-i-m** @**Vadim Petrochenkov**
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [46 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [29 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 2 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 5 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 18 P-high, 65 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Increasingly slow compilation as more levels of `async` are added in Rust 1.46" [rust#75992](https://github.com/rust-lang/rust/issues/75992)
+  - Opened by @**Nicholas Bishop**
+  - Unassigned, not easy to reproduce
+  - [@kellerkindt](https://github.com/rust-lang/rust/issues/75992#issuecomment-683270098) and [@algesten](https://github.com/rust-lang/rust/issues/75992#issuecomment-683274620) did some bisecting 
+  - @**lcnr** suggests instead of reverting important patches a possible way forward could be implementing some caching like in [PR #76928](https://github.com/rust-lang/rust/issues/75992#issuecomment-713100226)
+  - smallest [repro so far](https://github.com/rust-lang/rust/issues/75992#issuecomment-715557750) from @**pnkfelix** and [its stacktrace](https://github.com/rust-lang/rust/issues/75992#issuecomment-716740111)
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+    - opened by @**Jeff Muizelaar** and unassigned
+    - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+    - Affects only MSVC
+    - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+- "Regression parsing closing angle brackets near function ptr return type" [rust#78507](https://github.com/rust-lang/rust/issues/78507)
+    - reported by @**David Tolnay** 
+    - regression seems to be in [rust#78379](https://github.com/rust-lang/rust/pull/78379)
+    - assigned to @**Esteban Küber**, will work on a patch
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- "regression: could not fully normalize type" [rust#78139](https://github.com/rust-lang/rust/issues/78139)
+    - Opened and assigned to @**simulacrum** 
+    - Regression seems to be in PR [rust#70793](https://github.com/rust-lang/rust/pull/70793) and related to [rust#54114](https://github.com/rust-lang/rust/issues/54114)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - A [possible workaround was added](https://github.com/rust-lang/rust/pull/77642) by @**Pietro Albini** but it doesn't seem to be confirmation if works or not.
+  - @**cuviper** believes the real issue stems in PR [rustc#74163](https://github.com/rust-lang/rust/pull/74163)
+  - There's a long technical analysis in the [last comment](https://github.com/rust-lang/rust/issues/76980#issuecomment-705800997)
+  - @**simulacrum** asked `jethrogb` and @**cuviper** if they could open a PR about it
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- "ICE:  tuple_fields called on non-tuple:  async fn with unknown macro" [rust#77993](https://github.com/rust-lang/rust/issues/77993)
+  - opened by @**NeoRaider** 
+  - reviewed by @**Vadim Petrochenkov** and @**LeSeulArtichaut** 
+  - This should fix an issue emerged in [#69274](https://github.com/rust-lang/rust/pull/69274) and [#70307](https://github.com/rust-lang/rust/issues/70307)
+  - Fixed by PR [rust#78432](https://github.com/rust-lang/rust/pull/78432) already r+ed
+
+## Performance logs
+
+Triage done by **@simulacrum**.
+
+Relatively quiet week for performance.
+
+Revision range: [22e6b9c68941996daa45786b4145e6196e51f0f4..824f900a96d752da2d882863c65f9736e5f2b347](https://perf.rust-lang.org/?start=22e6b9c68941996daa45786b4145e6196e51f0f4&end=824f900a96d752da2d882863c65f9736e5f2b347&absolute=false&stat=instructions%3Au)
+
+0 Regressions, 2 Improvements, 3 Mixed
+1 in rollups.
+
+### Regressions
+
+Some mixed results, but no PRs with solely regressions this week.
+
+### Improvements
+
+[#78077](https://github.com/rust-lang/rust/issues/78077)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=1d2726726f8f3128e98191e4c6cb94bd76d0ddd4&end=1eaadebb3dee31669c7649b32747381d11614fae&stat=instructions:u) (up to -9.9% on `incr-full` builds of `deeply-nested-async-check`)
+
+[#77476](https://github.com/rust-lang/rust/issues/77476)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=3e0dd24a6c0812eedbb02182a75c352f8a7e184a&end=5171cc76c264fd46f32e140c2e460c77ca87d5e5&stat=instructions:u) (up to -6.2% on `incr-full` builds of `clap-rs-check`)
+- Interesting case where instruction counts show major improvement across the
+  board, but wall times are either a slight regression or largely unchanged
+  (within noise bound).
+
+### Mixed
+
+[#78334](https://github.com/rust-lang/rust/issues/78334)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=ffa2e7ae8fbf9badc035740db949b9dae271c29f&end=f58ffc93815f76576eb56df4bdeec2fe8f12b766&stat=instructions:u) (up to -1.5% on `full` builds of `match-stress-enum-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ffa2e7ae8fbf9badc035740db949b9dae271c29f&end=f58ffc93815f76576eb56df4bdeec2fe8f12b766&stat=instructions:u) (up to 1.2% on `full` builds of `unicode_normalization-check`)
+- Unclear as to causes, left nag; will folow-up in a future week.
+
+[#77187](https://github.com/rust-lang/rust/issues/77187)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=0da6d42f297642a60f2640ec313b879b376b9ad8&end=fd542592f08ca0d1f7255600115c2eafdf6b5da7&stat=instructions:u) (up to 2.9% on `full` builds of `regression-31157-debug`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=0da6d42f297642a60f2640ec313b879b376b9ad8&end=fd542592f08ca0d1f7255600115c2eafdf6b5da7&stat=instructions:u) (up to -1.1% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+- Roughly neutral (or an improvement) on wall times; and a long-desired change.
+  Not proposing a revert at this time.
+
+[#77876](https://github.com/rust-lang/rust/issues/77876)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=fd542592f08ca0d1f7255600115c2eafdf6b5da7&end=a4d30a7b490065f0aa56f58e508a11546445aea9&stat=instructions:u) (up to -8.1% on `full` builds of `ctfe-stress-4-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=fd542592f08ca0d1f7255600115c2eafdf6b5da7&end=a4d30a7b490065f0aa56f58e508a11546445aea9&stat=instructions:u) (up to 4.4% on `full` builds of `cranelift-codegen-opt`)
+- Regression has unclear cause; left a nag for next week.
+
+### Nags requiring follow up
+
+* [#78334](https://github.com/rust-lang/rust/pull/78334)
+* [#77876](https://github.com/rust-lang/rust/pull/77876#issuecomment-717326989)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- Confusing type error due to strange inferred type for a closure argument [rustc#41078](https://github.com/rust-lang/rust/issues/41078)
+    - Longstsanding issue since 2017, has generated many duplicates since then
+    - Seems to impact more from an usability/ergonomics point of view since there are workarounds, example [this comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-298180037) and this [Stack Overflow](https://stackoverflow.com/questions/58773989) answer
+    - [First comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-293646723) by @**nikomatsakis** 
+    - More [recent comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-358385901) from @**nikomatsakis**
+    - [Another explaination](https://github.com/rust-lang/rust/issues/41078#issuecomment-552064766) from @**eddyb** 
+    - nightly from June shows a [slightly different error](https://github.com/rust-lang/rust/issues/41078#issuecomment-649465827)
+- "Operators in patterns have incorrect priorities" [rust#48501](https://github.com/rust-lang/rust/issues/48501)
+    - Old 2018 tracking issue opened by @**Vadim Petrochenkov** for feature gate `half_open_range_patterns`
+    - Nominated because `@workingjubilee` (@_**workingj**  on Zulip?) [declared interest](https://github.com/rust-lang/rust/issues/48501#issuecomment-718170922) in drafting an RFC, asks if this issue needs more action
+- "SIGSEGV from rustc while building crate `legion`" [rust#77869](https://github.com/rust-lang/rust/issues/77869)
+    - Can't compile legion crate since 1.47
+    - Nominated so we can try to get eyes on the root cause of the issue.
+- "revert #75443 update mir validator" [rust#78410](https://github.com/rust-lang/rust/pull/78410)
+    - opened by @**lcnr** 
+    - assigned to @**nikomatsakis** 
+    - @**lcnr** mentions that this PR could result in a breaking change due to PR [rust#75443](https://github.com/rust-lang/rust/pull/75443) allowing to compile code [such as this](https://github.com/rust-lang/rust/pull/78410#issuecomment-717814133)
+    - Link to [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/generator.20upvars/near/214617274)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: -C export-executable-symbols" [rfcs#2841](https://github.com/rust-lang/rfcs/pull/2841)
+  - Submitted by `@MaulingMonkey`
+  - RFC proposes adding the ability to export symbols from executables, not just dylibs, via a new compiler flag `-C export-executable-symbols`
+  - @**pnkfelix** [has some questions](https://github.com/rust-lang/rfcs/pull/2841#issuecomment-569852146)
+  - not yet reached a consensus

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-11-05.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-11-05.md
@@ -1,0 +1,224 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-11-05
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow, friday 6th at <time:2020-11-06T15:00:00+00:00> we will have rustc regression review day. Due to daylight saving time in US the meeting may be 1 hour later than the usual slot for you.
+    - see also [compiler-team#382](https://github.com/rust-lang/compiler-team/issues/382), and the [proposed agenda](https://hackmd.io/Z7IGJx-JT_WGPYS7Kqxfbg)
+- New MCPs (take a look, see if you like them!)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "inherit stable annotations in enum variants and field items" [compiler-team#370](https://github.com/rust-lang/compiler-team/issues/370)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+- Old MCPs (not seconded, take a look)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+- Pending FCP requests (check your boxes!)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+- Things in FCP (make sure you're good with it)
+  - "Move graphviz code out of the compiler into external crate" [compiler-team#380](https://github.com/rust-lang/compiler-team/issues/380)
+- Accepted MCPs
+  - "TypeVisitor: use ops::ControlFlow instead of bool" [compiler-team#374](https://github.com/rust-lang/compiler-team/issues/374)
+- Finalized FCPs (disposition merge)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "inherit stable annotations in enum variants and field items" [compiler-team#370](https://github.com/rust-lang/compiler-team/issues/370)
+  - "Allow making `RUSTC_BOOTSTRAP` conditional on the crate name" [rust#77802](https://github.com/rust-lang/rust/pull/77802)
+  - [T-lang T-libs] "Tracking Issue for raw_ref_macros" [rust#73394](https://github.com/rust-lang/rust/issues/73394)
+  - [T-libs] "Implement TryFrom between NonZero types." [rust#77339](https://github.com/rust-lang/rust/pull/77339)
+  - [T-libs] "Define `fs::hard_link` to not follow symlinks." [rust#78026](https://github.com/rust-lang/rust/pull/78026)
+  - [T-libs] "Check for exhaustion in RangeInclusive::contains and slicing" [rust#78109](https://github.com/rust-lang/rust/pull/78109)
+
+### WG checkins
+
+@*WG-polymorphization* checkin by @**davidtwco**:
+> Not a lot has happened with the polymorphization working group, everyone involved has been focusing on other work recently.
+
+@*WG-polonius* checkin by @**lqd** and @**nikomatsakis** 
+> Nothing to report at this time
+
+### Unilateral beta approvals
+
+- "Add delay_span_bug to no longer ICE" [rust#78645](https://github.com/rust-lang/rust/pull/78645)
+  - Opened by [JulianKnodt](https://github.com/JulianKnodt)
+  - Assigned to and r+ from @**Esteban Küber** 
+  - Fixes [#78622](https://github.com/rust-lang/rust/issues/78622)
+  - pnkfelix beta-approved shortly before this meeting.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "revert #75443, update mir validator" [rust#78410](https://github.com/rust-lang/rust/pull/78410)
+  - opened by @**lcnr** 
+  - assigned to @**nikomatsakis** and r+'ed, left [some comments](https://github.com/rust-lang/rust/pull/78410#pullrequestreview-521756705)
+  - @**lcnr** mentions that this PR could result in a breaking change due to PR [rust#75443](https://github.com/rust-lang/rust/pull/75443) allowing to compile code [such as this](https://github.com/rust-lang/rust/pull/78410#issuecomment-717814133)
+  - Link to [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/generator.20upvars/near/214617274)
+
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [46 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [30 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 2 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 5 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 21 P-high, 67 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Increasingly slow compilation as more levels of `async` are added in Rust 1.46" [rust#75992](https://github.com/rust-lang/rust/issues/75992)
+  - Opened by @**Nicholas Bishop**
+  - Unassigned, not easy to reproduce
+  - [@kellerkindt](https://github.com/rust-lang/rust/issues/75992#issuecomment-683270098) and [@algesten](https://github.com/rust-lang/rust/issues/75992#issuecomment-683274620) did some bisecting 
+  - @**lcnr** suggests instead of reverting important patches a possible way forward could be implementing some caching like in [PR #76928](https://github.com/rust-lang/rust/issues/75992#issuecomment-713100226)
+  - smallest [repro so far](https://github.com/rust-lang/rust/issues/75992#issuecomment-715557750) from @**pnkfelix** and [its stacktrace](https://github.com/rust-lang/rust/issues/75992#issuecomment-716740111)
+  - @**pnkfelix** confirms a compile-time regression for a test case to be solved by PR [rust#78410](https://github.com/rust-lang/rust/pull/78410)
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - opened by @**Jeff Muizelaar** and unassigned
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- "regression: could not fully normalize type" [rust#78139](https://github.com/rust-lang/rust/issues/78139)
+  - Opened and assigned to @**simulacrum** 
+  - Regression seems to be in PR [rust#70793](https://github.com/rust-lang/rust/pull/70793) and related to [rust#54114](https://github.com/rust-lang/rust/issues/54114)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Build hang on Linux with nightly and beta toolchains" [rust#76980](https://github.com/rust-lang/rust/issues/76980)
+  - Unassigned
+  - Build hangs on beta
+  - @**Eric Huss** bisected it to [rust#73526](https://github.com/rust-lang/rust/pull/73526)
+  - @**cuviper** [is not aware of any LLVM 11 issue like that ](https://github.com/rust-lang/rust/issues/76980#issuecomment-695805807)
+  - A [possible workaround was added](https://github.com/rust-lang/rust/pull/77642) by @**Pietro Albini** but it doesn't seem to be confirmation if works or not.
+  - @**cuviper** believes the real issue stems in PR [rustc#74163](https://github.com/rust-lang/rust/pull/74163)
+  - There's a long technical analysis in the [last comment](https://github.com/rust-lang/rust/issues/76980#issuecomment-705800997)
+  - @**simulacrum** asked `jethrogb` and @**cuviper** if they could open a PR about it
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+Triage done by **@simulacrum**.
+
+A number of improvements on various benchmarks. The most notable news this week in compiler performance is the progress on instruction metric collection on a per-query level; see
+[measureme#143](https://github.com/rust-lang/measureme/pull/143) for the latest.
+
+Otherwise, this week was an excellent one for performance (though mostly on stress tests rather than commonly seen code).
+
+Revision range: [824f900a96d752da2d882863c65f9736e5f2b347..5cdf5b882da9e8b7c73b5cadeb7745cb68f6ff63](https://perf.rust-lang.org/?start=824f900a96d752da2d882863c65f9736e5f2b347&end=5cdf5b882da9e8b7c73b5cadeb7745cb68f6ff63&absolute=false&stat=instructions%3Au)
+
+0 Regressions, 5 Improvements, 0 Mixed
+
+### Improvements
+
+[#78323](https://github.com/rust-lang/rust/issues/78323)
+- Slight improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=db241bb0c8d257e13c1560f6250e49879477039e&end=2eb4fc800aaf5006f89af3af591e2aa34f469d81&stat=instructions:u) (up to -1.3% on `incr-unchanged` builds of `packed-simd-check`)
+- Possibly within noise; unclear.
+
+[#78508](https://github.com/rust-lang/rust/issues/78508)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=a53fb30e3bf2655b0563da6d561c23cda5f3ec11&end=6bdae9edd0cc099daa6038bca469dc09b6fc078a&stat=instructions:u) (up to -2.0% on `incr-unchanged` builds of `packed-simd-check`)
+
+[#78432](https://github.com/rust-lang/rust/issues/78432)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=c792f03379617efa7deb6ab8c20709c45e81670a&end=0d33ab7af4aebe786410b4c10367eb6ddf13af0b&stat=instructions:u) (up to -5.7% on `full` builds of `match-stress-enum-check`)
+- An unexpected improvement for a seemingly bugfix PR; would be good to verify
+  this is not an unintentional behavior change (nag left).
+
+[#78553](https://github.com/rust-lang/rust/issues/78553)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=e8cbaf2ae7fc5c564cacedbe55664797dc62d920&end=1899c489d4c30b2640d30b77ac04f0a548834d81&stat=instructions:u) (up to -10.1% on `full` builds of `match-stress-enum-check`)
+
+[#78448](https://github.com/rust-lang/rust/issues/78448)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=4c0c5e099a3b1f1c6ad53115189c2710495588b3&end=7b5a9e9cd27f01311b5e19cefa1fb574d086d3da&stat=instructions:u) (up to -95.4% on `full` builds of `externs-debug`)
+- Notable case of adding a new benchmark to perf; this is much appreciated and
+  illustrates that perf does not yet have full coverage of Rust code (though
+  this is not really expected either, though is always a goal).
+
+[#78430](https://github.com/rust-lang/rust/issues/78430)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=31ee872db5aae4750e3da1ca4ed1523c4356947f&end=f9187adaef2005b903f666bf323ac675cadf8407&stat=instructions:u) (up to -23.6% on `incr-patched: println` builds of `unicode_normalization-check`)
+- Fairly large refactor to the match checking infrastructure, with a
+  correspondigly large performance improvement. There does appear to be a slight
+  regression on #58319, but this is in the "Improvements" category since it seem
+  categorically a win.
+
+### Nags requiring follow up
+
+Compiler team attention requested:
+
+- <https://github.com/rust-lang/rust/pull/78432#issuecomment-721388323>
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- Confusing type error due to strange inferred type for a closure argument [rustc#41078](https://github.com/rust-lang/rust/issues/41078)
+  - Longstsanding issue since 2017, has generated many duplicates since then
+  - Seems to impact more from an usability/ergonomics point of view since there are workarounds, example [this comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-298180037) and this [Stack Overflow](https://stackoverflow.com/questions/58773989) answer
+  - [First comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-293646723) by @**nikomatsakis** 
+  - More [recent comment](https://github.com/rust-lang/rust/issues/41078#issuecomment-358385901) from @**nikomatsakis**
+  - [Another explaination](https://github.com/rust-lang/rust/issues/41078#issuecomment-552064766) from @**eddyb** 
+  - nightly from June shows a [slightly different error](https://github.com/rust-lang/rust/issues/41078#issuecomment-649465827)
+- "SIGSEGV from rustc while building crate `legion`" [rust#77869](https://github.com/rust-lang/rust/issues/77869)
+  - Can't compile legion crate since 1.47
+  - Nominated so we can try to get eyes on the root cause of the issue.
+- "revert #75443 update mir validator" [rust#78410](https://github.com/rust-lang/rust/pull/78410)
+  - beta nominated
+  - opened by @**lcnr** 
+  - assigned to @**nikomatsakis** 
+  - @**lcnr** mentions that this PR could result in a breaking change due to PR [rust#75443](https://github.com/rust-lang/rust/pull/75443) allowing to compile code [such as this](https://github.com/rust-lang/rust/pull/78410#issuecomment-717814133)
+  - Link to [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/generator.20upvars/near/214617274)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: -C export-executable-symbols" [rfcs#2841](https://github.com/rust-lang/rfcs/pull/2841)
+  - Submitted by `@MaulingMonkey`
+  - RFC proposes adding the ability to export symbols from executables, not just dylibs, via a new compiler flag `-C export-executable-symbols`
+  - @**pnkfelix** [has some questions](https://github.com/rust-lang/rfcs/pull/2841#issuecomment-569852146)
+  - not yet reached a consensus

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-11-12.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-11-12.md
@@ -1,0 +1,186 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-11-12
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow friday 13th is rustc RFC backlog day
+- Next Thursday 19th we are releasing Rust 1.48
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+- Pending FCP requests (check your boxes!)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+- Things in FCP (make sure you're good with it)
+  - "TypeVisitor: do not hard-code a `ControlFlow<()>` result" [compiler-team#383](https://github.com/rust-lang/compiler-team/issues/383)
+- Accepted MCPs
+  - "Move graphviz code out of the compiler into external crate" [compiler-team#380](https://github.com/rust-lang/compiler-team/issues/380)
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Rename/Deprecate LayoutErr in favor of LayoutError" [rust#77691](https://github.com/rust-lang/rust/pull/77691)
+  - [T-lang] "repr(transparent) on generic type skips "exactly one non-zero-sized field" check" [rust#77841](https://github.com/rust-lang/rust/issues/77841)
+  - [T-lang] "consider assignments of union field of ManuallyDrop type safe" [rust#78068](https://github.com/rust-lang/rust/pull/78068)
+
+### WG checkins
+
+@*WG-rfc-2229* checkin by @**nikomatsakis** and @**Matthew Jasper**:
+- PR (#78801) in review for implementing precise capture analysis, and adding feature gate for 2229 `capture_disjoint_fields`
+- Known issue: Statements like `let _ = x` will make the compiler ICE when used within a closure with the feature enabled. More generally speaking the issue is caused by let statements that create no bindings and are init'ed using a Place expression.
+- Immediate next work: start updating MIR lowering
+
+@*WG-rls2.0* checkin by @**matklad**:
+
+Nothing super big happened, the last couple of months were rather quite.
+
+- a lot of quality-of-life improvements, assits & buf fixes
+- rust-analyzer pre-warms caches on startup, whihc should reduce latency in some cases.
+- improved syntax tree editing infra, which powers new configurable auto-import
+- better support for conditional compilation (un-cfged code is grayed out)
+- hack to support `cfg-if` in standard libray. 
+  This is a bit of an open question: how rust-analyzer should deal with crates.io deps of std? They are not vendored into rust-src component. Might be changing soon!
+  
+Note to @matklad: The last changelog as of this checkin is https://rust-analyzer.github.io/thisweek/2020/11/09/changelog-50.html
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Revert "Revert "resolve: Avoid "self-confirming" import resolutions in one more case""" [rust#78784](https://github.com/rust-lang/rust/pull/78784)
+  - opened by @**simulacrum** 
+  - r+'ed by @**Vadim Petrochenkov** 
+  - scheduled for 1.49
+  - reverts [rust#77421](https://github.com/rust-lang/rust/pull/77421) to fix [rust#77586](https://github.com/rust-lang/rust/issues/77586) (error on import resolution)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [45 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [29 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 1 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 5 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 21 P-high, 67 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - opened by @**Jeff Muizelaar**
+  - assigned to  @**pnkfelix** 
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+  - @**pnkfelix** has patch in progress for LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943)
+- "No error reported when a generic parameter doesn't meet the requirement of an associated type" [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - Nightly regression
+  - Regressed on [rust#73905](https://github.com/rust-lang/rust/pull/73905) cc @**Matthew Jasper**
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+A mixed week with improvements still outweighing regressions. Perhaps the biggest highlight was the move to compiling rustc crates [with the initial-exec TLS model](https://github.com/rust-lang/rust/pull/78201) which results in fewer calls to `_tls_get_addr` and thus faster compile times.
+
+Triage done by **@rylevick**.
+Revision range: [5cdf5b882da9e8b7c73b5cadeb7745cb68f6ff63..cf9cf7c923eb01146971429044f216a3ca905e06](https://perf.rust-lang.org/?start=5cdf5b882da9e8b7c73b5cadeb7745cb68f6ff63&end=cf9cf7c923eb01146971429044f216a3ca905e06&absolute=false&stat=instructions%3Au)
+
+1 Regressions, 2 Improvements, 2 Mixed
+
+### Regressions
+
+[#78267](https://github.com/rust-lang/rust/issues/78267)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f92b931045dabb00b892519d3451cb41d41f2d31&end=8532e742fc6ec210fab69b8192190bc40c685912&stat=instructions:u) (up to 1.2% on `full` builds of `deeply-nested-async-check`)
+- This might be noise as this only affects one benchmark negatively, and that benchmark tends to be on the noisier side. 
+
+### Improvements
+
+[#78280](https://github.com/rust-lang/rust/issues/78280)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=75f1db1102076e416e1154b241b4fc95c01c0d7b&end=89631663b7ad2d46d3e4f52bcfa7bee2be9eb82b&stat=instructions:u) (up to -1.3% on `incr-patched: new row` builds of `tuple-stress-opt`)
+
+[#78201](https://github.com/rust-lang/rust/issues/78201)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=fe8f02690804d5ee696bd3bca9515f5f71857e3b&end=25f6938da459a57b43bdf16ed6bdad3225b2a3ce&stat=instructions:u) (up to -7.2% on `incr-full` builds of `webrender-wrench-check`)
+- This change may produce similar performance gains in related tooling such as rustdoc and clippy.
+
+### Mixed
+
+[#77227](https://github.com/rust-lang/rust/issues/77227)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=601c13c6fda6a7db423c974797e36c79a9a0c0ac&end=75f1db1102076e416e1154b241b4fc95c01c0d7b&stat=instructions:u) (up to -5.0% on `incr-unchanged` builds of `deeply-nested-async-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=601c13c6fda6a7db423c974797e36c79a9a0c0ac&end=75f1db1102076e416e1154b241b4fc95c01c0d7b&stat=instructions:u) (up to 1.3% on `full` builds of `ctfe-stress-4-check`)
+
+[#78410](https://github.com/rust-lang/rust/issues/78410)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=f2ea2f648e117013b0217f001088ae89e0f163ca&end=87a0997ef9c0bfad0ba362741afa601d8fb285b8&stat=instructions:u) (up to -26.0% on `incr-unchanged` builds of `deeply-nested-async-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f2ea2f648e117013b0217f001088ae89e0f163ca&end=87a0997ef9c0bfad0ba362741afa601d8fb285b8&stat=instructions:u) (up to 3.8% on `full` builds of `ctfe-stress-4-check`)
+- This change is a revert of [a previous change](https://github.com/rust-lang/rust/pull/75443), and at least one user was reporting [massive performance gains](https://github.com/rust-lang/rust/pull/78410#issuecomment-716829861).
+
+### Nags requiring follow up
+
+The compiler team is once again requested to look into:
+
+- <https://github.com/rust-lang/rust/pull/78432#issuecomment-721388323>
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "SIGSEGV from rustc while building crate `legion`" [rust#77869](https://github.com/rust-lang/rust/issues/77869)
+  - Can't compile legion crate since 1.47
+  - Nominated so we can try to get eyes on the root cause of the issue.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-11-19.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-11-19.md
@@ -1,0 +1,254 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-11-19
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Rust 1.48 is going to be released today!!! :tada:
+- Tomorrow we have our [planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html) at <time:2020-11-20T15:00:00-00:00>
+- New MCPs (take a look, see if you like them!)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Rename `rustc_ty`" [compiler-team#387](https://github.com/rust-lang/compiler-team/issues/387)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+- Old MCPs (not seconded, take a look)
+  - "Decentralize queries" [compiler-team#277](https://github.com/rust-lang/compiler-team/issues/277)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "Accept RFC 2951 "Linking modifiers for native libraries"" [compiler-team#356](https://github.com/rust-lang/compiler-team/issues/356)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+- Pending FCP requests (check your boxes!)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - "TypeVisitor: do not hard-code a `ControlFlow<()>` result" [compiler-team#383](https://github.com/rust-lang/compiler-team/issues/383)
+- Finalized FCPs (disposition merge)
+  - [T-lang] "Add checking for no_mangle to unsafe_code lint" [rust#72209](https://github.com/rust-lang/rust/pull/72209)
+  - [T-libs] "Implement Error for &(impl Error)" [rust#75180](https://github.com/rust-lang/rust/pull/75180)
+  - [T-libs] "Stabilize clamp" [rust#77872](https://github.com/rust-lang/rust/pull/77872)
+
+### WG checkins
+
+@*WG-self-profile* checkin by @**Wesley Wiser**:
+> Things have settled down a bit since the last checkin but we still have a few items to highlight:
+> 
+> - @**eddyb** has opened their PR for hardware performance counter support in `measureme` [measureme#143](https://github.com/rust-lang/measureme/pull/143). They've also written an extensive and fascinating post about this project [here](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view)).
+> - @**mw** contributed a fix that allows us to profile extremely large crates like `rustc_middle`. Previously, this would trip an internal assertion and ICE the compiler [measureme#137](https://github.com/rust-lang/measureme/pull/137).
+> - @**wesleywiser** added a function that allows recording multiple arguments per event, not just a single one [measureme#138](https://github.com/rust-lang/measureme/pull/138). This is used downstream in rustc to record both CGU names as well as the estimated size during codegen [rustc#78702](https://github.com/rust-lang/rust/pull/78702).
+> - @**Mark-Simulacrum** contributed a fix to allow perf.rlo to continue processing the new storage format in-memory in the web server [measureme#142](https://github.com/rust-lang/measureme/pull/142).
+> - Finally, we shipped measureme 9.0 with all of the above improvements and fixes :tada:
+
+@*WG-traits* checkin by @**nikomatsakis** and @**Jack Huey**:
+> Most of the work has been focused around aligning chalk-ir and rustc, with the eventual goal of extracting out a shared type library.
+>
+> On Chalk side:
+> - Add support for `Variance` ([chalk#609](https://github.com/rust-lang/chalk/pull/609))
+> - Rename `TyData` to `TyKind` ([chalk#628](https://github.com/rust-lang/chalk/pull/628))
+> - Remove `TypeName` and merge into `TyKind` ([chalk#629](https://github.com/rust-lang/chalk/pull/629))
+> - Remove `TargetInterner` ([chalk#648](https://github.com/rust-lang/chalk/pull/648))
+> - Use `ControlFlow` and `BreakTy` for `Visitor` ([chalk#645](https://github.com/rust-lang/chalk/pull/645) and [chalk#651](https://github.com/rust-lang/chalk/pull/651))
+> - Add Empty and Erased regions ([chalk#650](https://github.com/rust-lang/chalk/pull/650))
+> - Many bug fixes
+>
+> On rustc side:
+> - Continued work on tracking late-bound vars
+> - Chalk updates
+> - Initial work on removing `ty::Param`
+
+[chalk#609]: https://github.com/rust-lang/chalk/pull/609
+[chalk#628]: https://github.com/rust-lang/chalk/pull/628
+[chalk#629]: https://github.com/rust-lang/chalk/pull/629
+[chalk#648]: https://github.com/rust-lang/chalk/pull/648
+[chalk#645]: https://github.com/rust-lang/chalk/pull/645
+[chalk#650]: https://github.com/rust-lang/chalk/pull/650
+[chalk#651]: https://github.com/rust-lang/chalk/pull/651
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- No beta nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Don't leak return value after panic in drop" [rust#78373](https://github.com/rust-lang/rust/pull/78373)
+  - Opened by @**Matthew Jasper** 
+  - Assigned to @**pnkfelix**
+  - Reviewwed by @**davidtwco**
+  - Closes [rust#47949](https://github.com/rust-lang/rust/issues/47949), a `P-medium` unsoundness by which panics in destructors could cause the return value to be leaked
+  - @**pnkfelix** has [some comments](https://github.com/rust-lang/rust/pull/78373#issuecomment-726470113) w.r.t. the perf regression (~5% acceptable being an unsoundness bug) but perhaps not rush a merge in this release cycle.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [46 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [30 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 3 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [2 P-critical, 0 P-high, 7 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 22 P-high, 67 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - [Discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482008)
+  - opened by @**Jeff Muizelaar**
+  - assigned to  @**pnkfelix** 
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+  - @**pnkfelix** has patch in progress for LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943)
+- "No error reported when a generic parameter doesn't meet the requirement of an associated type" [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - [Discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482210), and [a topic was created to discuss it on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/.2378893.20no.20err.20when.20genrc.20param.20doesnt.20meet.20req.20of.20assoc.20type)
+  - Nightly regression
+  - Regressed on [rust#73905](https://github.com/rust-lang/rust/pull/73905) cc @**Matthew Jasper**
+- "alacritty/vte fails to build on rustc master   (mutable references are not allowed in constant functions)" [rust#79152](https://github.com/rust-lang/rust/issues/79152)
+  - Reported by @**matthiaskrgr**
+  - Affects Alacritty/vte
+  - Nightly regression
+  - [There's a very simple MCVE](https://github.com/rust-lang/rust/issues/79152#issuecomment-729318274)
+  - It seems that the culprit is [rust#74989](https://github.com/rust-lang/rust/pull/74989)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "New "warning incompatible with previous forbid in same scope" error" [rust#77713](https://github.com/rust-lang/rust/issues/77713)
+  - Opened by @**Nemo157** 
+  - Assigned to @**simulacrum**
+  - @**simulacrum** has a PR [#78864](https://github.com/rust-lang/rust/pull/78864) which is in proposed FCP with intention to merge state.
+- "1.48 beta broken on mips due to copy_file_range EOVERFLOW" [rust#78979](https://github.com/rust-lang/rust/issues/78979)
+  - Reviewed by @**simulacrum**
+  - Beta regression
+  - This is already fixed on stable and nightly and a beta backport is approved and waiting to be done.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+This was a relatively mixed week, with some very large performance wins balanced out by a relatively large range of benchmarks seeing small performance regressions. 
+
+The winner this week for largest performance improvement was [#78826](https://github.com/rust-lang/rust/issues/78826) which saw huge gains in the relatively new derive stress benchmark.
+
+[Triage done by **@rylevick**](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs).
+Revision range: [cf9cf7c923eb01146971429044f216a3ca905e06..c919f490bbcd2b29b74016101f7ec71aaa24bdbb](https://perf.rust-lang.org/?start=cf9cf7c923eb01146971429044f216a3ca905e06&end=c919f490bbcd2b29b74016101f7ec71aaa24bdbb&absolute=false&stat=instructions%3Au)
+
+5 Regressions, 5 Improvements, 2 Mixed
+
+6 rollups had perfomance impacts (3 negative, 1 positive, 2 mixed)
+
+### Regressions
+
+[#76256](https://github.com/rust-lang/rust/issues/76256)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7f5a42b073dc2bee2aa625052eb066ee07072048&end=9722952f0bed5815cb22cb4878be09fb39f92804&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `externs-check`)
+- Changes to the serialization of span end line/column.
+- This regresses performance slightly but is a necessary correctness fix that was affecting incremental builds (see the linked PR for many related issues). The performance lost here is balanced out by a related change to the [hashing algorithm](https://github.com/rust-lang/rust/pull/77476) introduced previously.
+
+[#78998](https://github.com/rust-lang/rust/issues/78998)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9722952f0bed5815cb22cb4878be09fb39f92804&end=e80ee05bfc135d7d800f3fcc89bc005d6858cd9b&stat=instructions:u) (up to 1.2% on `incr-unchanged` builds of `deep-vector-check`)
+- Rollup
+- Most likely introduced by [#78836](https://github.com/rust-lang/rust/pull/78836) (Implement destructuring assignment for structs and slices)
+
+[#79065](https://github.com/rust-lang/rust/issues/79065)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=361c4ea22486557ec50c4fc6a93d60e7476ecbea&end=75042566d1c90d912f22e4db43b6d3af98447986&stat=instructions:u) (up to 2.9% on `full` builds of `deeply-nested-async-check`)
+- Rollup
+
+[#78801](https://github.com/rust-lang/rust/issues/78801)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9b2b02a840f358bcadef5c3ae861d2852da20b3d&end=b5c37e86ff1782923e3abfbf5491dd383fcf827d&stat=instructions:u) (up to 2.3% on `full` builds of `inflate-check`)
+- Initial implementation of precise capture analysis in closures
+
+[#79128](https://github.com/rust-lang/rust/issues/79128)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=54508a26eb0595eb8417a4643f2ee572d6ca33d3&end=efcb3b39203a0d54269ca274601b8f73207fe10d&stat=instructions:u) (up to 2.5% on `full` builds of `ctfe-stress-4-check`)
+- Rollup
+- The affected benchmark is prone to noise, so it's not sure that this is an actual regression.
+
+### Improvements
+
+[#78826](https://github.com/rust-lang/rust/issues/78826)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=f036a8f3bee55ea7566ac7a631ad3193696204b4&end=a38f8fb674e6a0a6fc358655c6ce6069235f621a&stat=instructions:u) (up to -49.0% on `incr-unchanged` builds of `derive-check`)
+- Change how macro_rules scopes are tracked during expansion so that they do not grow to big.
+- This was particularly helpful in the new derive stress test benchmark, but yielded improvements in several other benchmarks.
+
+[#78825](https://github.com/rust-lang/rust/issues/78825)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=38030ffb4e735b26260848b744c0910a5641e1db&end=d4ea0b3e46a0303d5802b632e88ba1ba84d9d16f&stat=instructions:u) (up to -1.5% on `incr-patched: println` builds of `coercions-debug`)
+- Changes several usages of `unwrap_or` to `unwrap_or_else` so that the else case is lazily evaluated.
+
+[#78956](https://github.com/rust-lang/rust/issues/78956)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5404efc28a0cddee103ef6396c48ea71ff9631c8&end=77180db6f81ffdacd14545f1df0a5db55dac1706&stat=instructions:u) (up to -1.1% on `incr-patched: println` builds of `coercions-debug`)
+- Rollup
+
+[#78313](https://github.com/rust-lang/rust/issues/78313)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=c6a6105bccd5599daf0ecef40c4b5ffa175fc1c1&end=9b2b02a840f358bcadef5c3ae861d2852da20b3d&stat=instructions:u) (up to -2.1% on `full` builds of `inflate-check`)
+- Internal refactor ([proposed here](https://github.com/rust-lang/compiler-team/issues/371)) where `TypeFoldable` takes self by value instead of reference.
+
+[#78779](https://github.com/rust-lang/rust/issues/78779)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=efcb3b39203a0d54269ca274601b8f73207fe10d&end=e0ef0fc392963438af5f0343bf7caa46fb9c3ec3&stat=instructions:u) (up to -2.0% on `full` builds of `inflate-check`)
+- Internal refactoring which introduces `BreakTy` in `TypeVisitor`.
+
+### Mixed
+
+[#78920](https://github.com/rust-lang/rust/issues/78920)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=cf9cf7c923eb01146971429044f216a3ca905e06&end=38030ffb4e735b26260848b744c0910a5641e1db&stat=instructions:u) (up to -2.5% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=cf9cf7c923eb01146971429044f216a3ca905e06&end=38030ffb4e735b26260848b744c0910a5641e1db&stat=instructions:u) (up to 1.5% on `incr-patched: println` builds of `coercions-debug`)
+- Rollup
+
+[#79104](https://github.com/rust-lang/rust/issues/79104)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f5230fbf76bafd86ee4376a0e26e551df8d17fec&end=c6a6105bccd5599daf0ecef40c4b5ffa175fc1c1&stat=instructions:u) (up to 6.5% on `full` builds of `keccak-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=f5230fbf76bafd86ee4376a0e26e551df8d17fec&end=c6a6105bccd5599daf0ecef40c4b5ffa175fc1c1&stat=instructions:u) (up to -2.1% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+- Rollup
+
+### Nags requiring follow up
+
+No nags this week.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Don't leak return value after panic in drop" [rust#78373](https://github.com/rust-lang/rust/pull/78373)
+  - waiting on team, see :point_up_2: 
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-12-03.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-12-03.md
@@ -1,0 +1,317 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-12-03
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Members of the compiler team and the compiler contributors team received a mail and a github ping this morning about the foundation, please check it out!
+- Rustc Steering Mtg Friday Dec 4: Performance Goals for 2021
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+- Pending FCP requests (check your boxes!)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Tracking issue for methods converting `bool` to `Option<T>`" [rust#64260](https://github.com/rust-lang/rust/issues/64260)
+  - [T-libs] "Stabilize the backtrace feature." [rust#72981](https://github.com/rust-lang/rust/pull/72981)
+  - [T-libs] "Stabilize `IpAddr::is_ipv4` and `is_ipv6` as const" [rust#76226](https://github.com/rust-lang/rust/pull/76226)
+  - [T-libs] "stabilize const_int_pow" [rust#76829](https://github.com/rust-lang/rust/pull/76829)
+  - [T-libs] "Impl Default for PhantomPinned" [rust#77893](https://github.com/rust-lang/rust/pull/77893)
+  - [T-libs] "Stabilize alloc::Layout const functions" [rust#78305](https://github.com/rust-lang/rust/pull/78305)
+  - [T-libs] "Stabilize refcell_take" [rust#78608](https://github.com/rust-lang/rust/pull/78608)
+  - [T-libs] "Implement PartialEq for proc_macro::Ident == strings" [rust#78634](https://github.com/rust-lang/rust/pull/78634)
+  - [T-libs] "Add PartialEq<char> for proc_macro::Punct" [rust#78636](https://github.com/rust-lang/rust/pull/78636)
+
+### WG checkins
+
+@*WG-async-foundations* checkin by @**tmandry** @**nikomatsakis**:
+
+> The [Stream RFC](https://github.com/rust-lang/rfcs/pull/2996) has been making progress (nearly ready for FCP imo) and the [must_not_await_lint RFC](https://github.com/rust-lang/rfcs/pull/3014) has just entered FCP. Compiler-wise, we still need more help with fixing bugs and improving diagnostics. I'm happy to mentor anyone and everyone who wants to contribute. The ongoing and upcoming work can be seen on our [project board](https://github.com/orgs/rust-lang/projects/2).
+
+@*WG-diagnostics* checkin by @**Esteban Küber**:
+
+> lots of great progress on bringing const generics to the level of quality we want, some improvements in parser and macro diagnostics, new suggestions, quite a bit of clean up throughout despite these last two months being "quieter" than normal.
+For the next cycle I will have more time to dedicate to increased tracking and focus of the work, so hopefully next update will be more substantive.
+> 
+> - List of [user visible changes](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-12-03.20.2354818/near/218665719)
+> - List of [Infra changes](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-12-03.20.2354818/near/218665746)
+> 
+> Full detailed checkin [at this Zulip link](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-12-03.20.2354818/near/218665719)
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Check projection predicates satisfy bounds" [rust#79543](https://github.com/rust-lang/rust/pull/79543)
+  - Opened by @**Matthew Jasper**
+  - Not merged yet, Waiting for review
+  - Fixes a `P-critical` issue [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - Restores the behaviour antecedent of [rust#73905](https://github.com/rust-lang/rust/pull/73905) and fixes [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Revert "Allow dynamic linking for iOS/tvOS targets."" [rust#77716](https://github.com/rust-lang/rust/pull/77716)
+  - Reverts a [previous patch](https://github.com/rust-lang/rust/pull/73516) that allowed dynamic libs linking on iOS/tvOS builds. This patch **blocks** again dynamic libs linking and restores building again code that is running in production
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [48 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [32 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 3 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [2 P-critical, 0 P-high, 8 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 25 P-high, 67 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Switching to opt-level=z on i686-windows-msvc triggers STATUS_ACCESS_VIOLATION" [rust#67497](https://github.com/rust-lang/rust/issues/67497)
+  - Opened by @**dignifiedquire** 
+  - Not yet assigned
+  - [Rust 1.36.0 through 1.48.0](https://github.com/rust-lang/rust/issues/67497#issuecomment-733699197) all have broken builds on Windows i686-windows-msvc 
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482008)
+  - opened by @**Jeff Muizelaar**
+  - assigned to  @**pnkfelix** 
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+  - @**pnkfelix** has patch in progress for LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943)
+- "No error reported when a generic parameter doesn't meet the requirement of an associated type" [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482210), and [a topic was created to discuss it on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/.2378893.20no.20err.20when.20genrc.20param.20doesnt.20meet.20req.20of.20assoc.20type)
+  - Nightly regression
+  - Regressed on [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+  - @**Matthew Jasper** provides a fix in PR [rust#79543](https://github.com/rust-lang/rust/pull/79543)
+- "Internal Compiler Error while compiling diesel" [rust#79560](https://github.com/rust-lang/rust/issues/79560)
+  - ICE when compiling Diesel (master branch)
+  - Caused by [rust#79209](https://github.com/rust-lang/rust/pull/79209)
+  - @**Santiago Pastorino** reverted [rust#79209](https://github.com/rust-lang/rust/pull/79209) in [rust#79637](https://github.com/rust-lang/rust/pull/79637) (which is already r+ed) to buy time to work on a proper solution
+  - @**Santiago Pastorino** is working on a proper solution
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "New "warning incompatible with previous forbid in same scope" error" [rust#77713](https://github.com/rust-lang/rust/issues/77713)
+  - Opened by @**Nemo157** 
+  - Assigned to @**simulacrum**
+  - @**simulacrum** has a PR [#78864](https://github.com/rust-lang/rust/pull/78864) which is in proposed FCP with intention to merge state.
+- "1.48 beta broken on mips due to copy_file_range EOVERFLOW" [rust#78979](https://github.com/rust-lang/rust/issues/78979)
+  - Reviewed by @**simulacrum**
+  - Beta regression
+  - This is already fixed on stable and nightly and a beta backport is approved and waiting to be done.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+### 2020-11-24 Triage Log
+
+This week saw landing of #79237 which by itself provides no wins but opens the
+door to support for split debuginfo on macOS. This'll eventually show huge wins
+as we can likely avoid re-collecting debuginfo while retaining support for
+lldb and Rust backtraces. #79361 tracks the stabilization of the rustc flag, but
+the precise rollout to stable users is not yet 100% clear.
+
+Triage done by **@jyn514** and **@simulacrum**.
+Revision range: [c919f490bbcd2b29b74016101f7ec71aaa24bdbb..25a691003cf6676259ee7d4bed05b43cb6283cea](https://perf.rust-lang.org/?start=c919f490bbcd2b29b74016101f7ec71aaa24bdbb&end=25a691003cf6676259ee7d4bed05b43cb6283cea&absolute=false&stat=instructions%3Au)
+
+4 regressions, 4 improvements, 2 mixed results.
+5 of them in rollups.
+
+#### Regressions
+
+[#79167](https://github.com/rust-lang/rust/issues/79167): linux: try to use libc getrandom to allow interposition #78785
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7d747db0d5dd8f08f2efb073e2e77a34553465a7&end=8d2d0014922e9f541694bfe87642749239990e0e&stat=instructions:u) (up to 7.7% on `incr-unchanged` builds of `deeply-nested-async-opt`)
+- The PR allows intercepting `getrandom` at runtime with `LD_PRELOAD`, so it's possible a regression was expected. However, 40% increased bootstrap times for `libcore` seems excessive.
+- Landed in a rollup, so it's possible another PR may be to blame. Opened [#79389](https://github.com/rust-lang/rust/pull/79389) measuring the impact.
+
+[#78646](https://github.com/rust-lang/rust/issues/78646): Use `PackedFingerprint` in `DepNode` to reduce memory consumption
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=172acf8f61018df3719e42e633ffd62ebecaa1e7&end=ae6aa22cf26fede2177abe4ff974030058885b7a&stat=instructions:u) (up to 3.2% on `full` builds of `keccak-check`)
+- Major improvement in [memory usage](https://perf.rust-lang.org/compare.html?start=172acf8f61018df3719e42e633ffd62ebecaa1e7&end=ae6aa22cf26fede2177abe4ff974030058885b7a&stat=max-rss) (up to 21.6 on `full` builds of `keccak-opt`)
+- The regression in cycle count is worse than the last perf run on the PR, but overall seems to be expected. Not leaving a comment.
+
+[#79237](https://github.com/rust-lang/rust/issues/79237): std: Update the backtrace crate submodule
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=d806d656578c2d6b34cf96809862e8cffb293a68&end=3adedb8f4c5bb71e9e8a21a047cf8ed121ce0e75&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `unify-linearly-debug`), mostly on `debug` and `opt` builds.
+- **@ehuss** reports a 600% decrease in incremental builds when using `-Z run-dsymutil=no` on MacOS (!!). [#79361](https://github.com/rust-lang/rust/issues/79361) tracks enabling `-Z run-dsymutil=no` by default.
+- **@alexcrichton** theorizes the regression is because there's more code in libstd overall (since it now handles archives of debug symbol).
+- Not leaving a nag, since the regression is small and the improvement more than makes up for it.
+
+[#79273](https://github.com/rust-lang/rust/issues/79273): Rollup of 8 pull requests
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=3adedb8f4c5bb71e9e8a21a047cf8ed121ce0e75&end=da384694807172f0ca40eca2e49a11688aba6e93&stat=instructions:u) (up to 1.8% on `full` builds of `coercions-debug`). **@Mark-Simulacrum** thinks this is a false positive, since there are no similar regressions in `-opt` or `-check` builds.
+- Minor improvements in [instruction counts](https://perf.rust-lang.org/compare.html?start=3adedb8f4c5bb71e9e8a21a047cf8ed121ce0e75&end=da384694807172f0ca40eca2e49a11688aba6e93&stat=instructions:u) on `doc` builds (up to .4% on `unused-warnings-doc`). Likely due to [#79264](https://github.com/rust-lang/rust/pull/79264): Get rid of some doctree items.
+- Most regressions are in LLVM/codegen, so likely due to [#79067](https://github.com/rust-lang/rust/pull/79067/): Refactor the abi handling code a bit.
+
+#### Improvements
+
+[#79200](https://github.com/rust-lang/rust/issues/79200): Rollup of 14 pull requests
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=3d3c8c5e0d534cdd794f1b3359089eba031d492c&end=fe982319aa0aa5bbfc2795791a753832292bd2ba&stat=instructions:u) (up to -1.9% on `full` builds of `ctfe-stress-4-opt`, up to -5.5 on `doc` builds)
+- Improvement is almost completely due to a -8.5% improvement on `eval_to_allocation_raw`
+- Unclear which PR caused the improvement; both [#79149](https://github.com/rust-lang/rust/pull/79149) and [#79101](https://github.com/rust-lang/rust/pull/79101) are likely candidates. [Left a nag](https://github.com/rust-lang/rust/pull/79200#issuecomment-733237927) asking the authors to use `rollup=never` in the future.
+
+[#79220](https://github.com/rust-lang/rust/issues/79220)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=09c9c9f7da72b774cc445c0f56fc0b9792a49647&end=4ec27e4b79891b0ebc2ad71a3c4ac94f67d93f93&stat=instructions:u) (up to -3.3% on `full` builds of `deeply-nested-async-check`)
+- Improvement is almost completely due to a -25.6% improvement in `normalize_generic_arg_after_erasing_regions` and -24.7% improvement in `erase_regions_ty`.
+- Likely due to [#79193](https://github.com/rust-lang/rust/pull/79193), which reverts an earlier PR. We should keep an eye on this, since it will likely regress again when the validation is re-enabled.
+
+[#78088](https://github.com/rust-lang/rust/issues/78088): Add lint for `panic!("{}")`
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=4ec27e4b79891b0ebc2ad71a3c4ac94f67d93f93&end=74285eb3a83eac639f9c54ba8c4ccf9879b3b00a&stat=instructions:u) (up to -3.3% on `incr-full` builds of `futures-opt`)
+- The improvement is likely because the desugaring of `panic!` changed.
+
+[#78343](https://github.com/rust-lang/rust/issues/78343)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=d9a105fdd46c926ae606777a46dd90e5b838f92f&end=f32a0cce2fd5aaf5f361192af59cf1f2afa5f0ac&stat=instructions:u) (up to -3.0% on `incr-full` builds of `wg-grammar-opt`)
+- The improvement is likely because the way `panic!` is expanded changed.
+
+[#79319](https://github.com/rust-lang/rust/issues/79319)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=a0d664bae6ca79c54cc054aa2403198e105190a2&end=32da90b431919eedb3e281a91caea063ba4edb77&stat=instructions:u) (up to -26.4% on `incr-patched: println` builds of `cargo-opt`)
+- Predominantly incremental perf getting better, likely due to
+  #77697 Split each iterator adapter and source into individual modules
+  which presumably shuffled CGU ordering in core/std, avoiding multiple LLVM
+  module invalidations.
+
+#### Mixed
+
+[#78461](https://github.com/rust-lang/rust/issues/78461)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=da384694807172f0ca40eca2e49a11688aba6e93&end=a1a13b2bc4fa6370b9501135d97c5fe0bc401894&stat=instructions:u) (up to 36.6% on `incr-patched: println` builds of `clap-rs-debug`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=da384694807172f0ca40eca2e49a11688aba6e93&end=a1a13b2bc4fa6370b9501135d97c5fe0bc401894&stat=instructions:u) (up to -2.6% on `incr-patched: Compiler new` builds of `regex-opt`)
+- Pretty much limited to just incremental builds, likely the addition of
+  allocators to Vec is causing some problems in incremental caching.
+  Potentially worth tracking down the specific cause.
+
+[#79186](https://github.com/rust-lang/rust/issues/79186)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=068320b39e3e4839d832b3aa71fa910ba170673b&end=40cf72108edb9b8633a9d284b238988309204494&stat=instructions:u) (up to -4.5% on `full` builds of `regression-31157-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=068320b39e3e4839d832b3aa71fa910ba170673b&end=40cf72108edb9b8633a9d284b238988309204494&stat=instructions:u) (up to 4.4% on `full` builds of `deeply-nested-async-check`)
+- Seems to largely be an improvement due to less queries being run in some
+  cases, but there is some upfront cost -- presumably the regressed test case
+  didn't end up calling/using the now less needed queries, but paid the price in
+  metadata decoding.
+
+#### Nags requiring follow up
+
+- [Left a comment](https://github.com/rust-lang/rust/pull/79167#issuecomment-733207145) nagging the author of the `LD_PRELOAD` PR.
+- [Left a comment](https://github.com/rust-lang/rust/pull/79273#issuecomment-733224830) asking why a codegen refactor could have regressed instruction count.
+
+#### Compiler team notes
+
+* https://github.com/rust-lang/rust/pull/78461 regressed incremental performance
+  on debug builds of clap (interestingly, not opt builds). It may be worth
+  investigating why, as the pattern of adding a generic parameter with a default
+  really should not be causing regressions in downstream code. Not all of the
+  regression is in LLVM.
+  See by-query breakdown:
+  https://perf.rust-lang.org/detailed-query.html?commit=a1a13b2bc4fa6370b9501135d97c5fe0bc401894&base_commit=da384694807172f0ca40eca2e49a11688aba6e93&benchmark=clap-rs-debug&run_name=incr-patched:%20println.
+
+### 2020-12-03 Triage Log
+
+A fairly mixed week with regressions and improvements mainly washing each other out with the exception of the very large improvement to [incremental compilation](https://github.com/rust-lang/rust/issues/74967) with huge gains in a large portion of the perf test suite.
+
+Triage done by **@rylevick**.
+Revision range: [25a691003cf6676259ee7d4bed05b43cb6283cea..c7cff213e937c1bb301be807ce04fcf6092b9163](https://perf.rust-lang.org/?start=25a691003cf6676259ee7d4bed05b43cb6283cea&end=c7cff213e937c1bb301be807ce04fcf6092b9163&absolute=false&stat=instructions%3Au)
+
+2 Regressions, 2 Improvement, 2 Mixed
+0 of them in rollups
+
+#### Regressions
+
+[#79284](https://github.com/rust-lang/rust/issues/79284)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=6a889570e46c03d7b156ec08f3f4cb4d145924a3&end=fd6b5376b723e22e3d98542e2e693d2717700900&stat=instructions:u) (up to 31.5% on `full` builds of `match-stress-enum-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=6a889570e46c03d7b156ec08f3f4cb4d145924a3&end=fd6b5376b723e22e3d98542e2e693d2717700900&stat=instructions:u) (up to -1.2% on `full` builds of `issue-58319-check`)
+- The very large regression outweighs the moderate improvement.
+- It's hard to tell what the issue is currently since the change involved moving large chunks of code to different files making it hard to tell what the actual changes are.
+
+[#78725](https://github.com/rust-lang/rust/issues/78725)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=29c4358c189fbb3bd3fd7ac3d7a95fac7b97814c&end=c4926d01ada661d4fbffb0e5b1708ae5463d47b3&stat=instructions:u) (up to 2.6% on `full` builds of `ctfe-stress-4-check`)
+- This change was a removal in an unneeded call to `upvar_tys`, and is not immeadiately obvious to the author where the regression is coming from.
+
+#### Improvements
+
+[#74967](https://github.com/rust-lang/rust/issues/74967)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b2dd82929b5b956972446d9720ceabdee171d405&end=4cbda829c00af2c3ac362c979fa97ea90be0be7d&stat=instructions:u) (up to -37.5% on `incr-unchanged` builds of `helloworld-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=b2dd82929b5b956972446d9720ceabdee171d405&end=4cbda829c00af2c3ac362c979fa97ea90be0be7d&stat=instructions:u) (up to 1.5% on `incr-unchanged` builds of `clap-rs-check`)
+- A huge win for incremental compilation almost across the board with only a small regression in one test. 🎉
+
+[#79523](https://github.com/rust-lang/rust/issues/79523)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=88b81970ba7a989a728b32039dd075dc206f1360&end=b776d1c3e3db8befabb123ebb1e46c3531eaed46&stat=instructions:u) (up to -2.3% on `full` builds of `unicode_normalization-check`)
+- Small fix on exhaustiveness checking for `isize/usize` range patterns.
+- Hard to tell where the perf gain comes from though it might be that part of the implementation was simplified enough to be inlined. 
+- Unfortunately these perf gains are completely canceled out by the regression in [#79284](https://github.com/rust-lang/rust/issues/79284)
+
+#### Mixed
+
+[#79318](https://github.com/rust-lang/rust/issues/79318)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=361543d776d832b42f022f5b3aa1ab77263bc4a9&end=c9228570668803e3e6402770d55f23a12c9ae686&stat=instructions:u) (up to -4.7% on `incr-unchanged` builds of `deeply-nested-async-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=361543d776d832b42f022f5b3aa1ab77263bc4a9&end=c9228570668803e3e6402770d55f23a12c9ae686&stat=instructions:u) (up to 4.6% on `incr-full` builds of `externs-check`)
+- A ~4% regression occured in the `extern` stress test which is likely to exercise this change quite a bit.
+
+[#79547](https://github.com/rust-lang/rust/issues/79547)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=d37afad0cc87bf709ad10c85319296ac53030f03&end=a094ff9590b83c8f94d898f92c2964a5803ded06&stat=instructions:u) (up to -1.9% on `incr-unchanged` builds of `html5ever-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=d37afad0cc87bf709ad10c85319296ac53030f03&end=a094ff9590b83c8f94d898f92c2964a5803ded06&stat=instructions:u) (up to 1.7% on `full` builds of `deeply-nested-debug`)
+- This change makes small arguments (those equal to or less than `2 * size_of::<usize>()`) passed to functions in registers instead of by reference. This is unlikely to have too much effect on the compiler due to the compiler normally pasing large arguments to functions but it might help other workloads.
+
+#### Nags requiring follow up
+
+- Three pull requests require a follow up on their regressions: [#79318](https://github.com/rust-lang/rust/issues/79318), [#79284](https://github.com/rust-lang/rust/issues/79284), and [#78725](https://github.com/rust-lang/rust/issues/78725).
+- [One of last week's nags](https://github.com/rust-lang/rust/pull/79167#issuecomment-733207145) has yet to be fully resolved.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+  
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-12-10.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-12-10.md
@@ -1,0 +1,258 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-12-10
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+- Pending FCP requests (check your boxes!)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+  - "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-lang] "remove this weird special case from promotion" [rust#78363](https://github.com/rust-lang/rust/pull/78363)
+
+### WG checkins
+
+@*WG-rustc-dev-guide* checkin by @**Santiago Pastorino** and @**Joshua Nelson**:
+
+>#### Changes
+>
+>- Adds a dev guide section on Rust Coverage [#985](https://github.com/rust-lang/rustc-dev-guide/pull/985)
+>- Add notes about running the UI test suite [#977](https://github.com/rust-lang/rustc-dev-guide/pull/977)
+>- Document what 'sysroot' means [#976](https://github.com/rust-lang/rustc-dev-guide/pull/976)
+>- Add information about common git issues [#974](https://github.com/rust-lang/rustc-dev-guide/pull/974)
+>- Improve contributor experience for the dev-guide itself [#973](https://github.com/rust-lang/rustc-dev-guide/pull/973)
+>- Update bootstrap documentation with the new envvars for RUSTFLAGS [#970](https://github.com/rust-lang/rustc-dev-guide/pull/970)
+>- Document how to modify feature gates [#968](https://github.com/rust-lang/rustc-dev-guide/pull/968)
+>- Document when errors should have an associated error code [#967](https://github.com/rust-lang/rustc-dev-guide/pull/967)
+>- add mir-opt section for optimization fuel [#963](https://github.com/rust-lang/rustc-dev-guide/pull/963)
+>- Document the SessionDiagnostic derive macro. [#961](https://github.com/rust-lang/rustc-dev-guide/pull/961)
+>- Add some more examples of using the compiler [#952](https://github.com/rust-lang/rustc-dev-guide/pull/952)
+>- Add a section on identifiers in the MIR [#951](https://github.com/rust-lang/rustc-dev-guide/pull/951)
+>- Add a section on data-flow convergence [#950](https://github.com/rust-lang/rustc-dev-guide/pull/950)
+>- Document `src/tools/x`, an `x.py` wrapper [#945](https://github.com/rust-lang/rustc-dev-guide/pull/945)
+>
+>#### Changes in progress
+>
+>- Document lang items [#978](https://github.com/rust-lang/rustc-dev-guide/pull/978)
+
+@*wg-incr-comp* checkin by @**Wesley Wiser** and @**pnkfelix**:
+> *wg-incr-comp* has been meeting every two weeks and discussing any open PRs and doing some issue triage. All of the members are busy so not a lot is going on, but here's some of what was discussed in recent meetings:
+>
+> - @_**Santiago Pastorino** and @_**Wesley Wiser** have been working on changes to whether  or not we make copies of inline functions in debug mode (#76896). Waiting on review from @_**davidtwco**.
+> - @_**Aaron Hill** implemented lazy decoding of `DefPathTable` from crate metadata (#74967). This had some great performance wins in incremental mode and has been merged after approval by @_**pnkfelix**.
+> - @_**Wesley Wiser** started including the estimated size of codegen units in self-profile data (#78702). This was merged after approval by @_**simulacrum**.
+> - @_**davidtwco** has been working on implementing Split DWARF support (#77117). It's currently completely functioning and passing our existing debuginfo tests. PR has been approved by @_**nagisa** but is blocked on #79536.
+>
+> Issue triage has revealed some recurring themes in the bugs we've looked at:
+> 
+> 1. Incremental bugs tend 
+@*wg-incr-comp* checkin by @**Wesley Wiser** and @**pnkfelix**:
+> *wg-incr-comp* has been meeting every two weeks and discussing any open PRs and doing some issue triage. All of the members are busy so not a lot is going on, but here's some of what was discussed in recent meetings:
+>
+> - @_**Santiago Pastorino** and @_**Wesley Wiser** have been working on changes to whether  or not we make copies of inline functions in debug mode (#76896). Waiting on review from @_**davidtwco**.
+> - @_**Aaron Hill** implemented lazy decoding of `DefPathTable` from crate metadata (#74967). This had some great performance wins in incremental mode and has been merged after approval by @_**pnkfelix**.
+> - @_**Wesley Wiser** started including the estimated size of codegen units in self-profile data (#78702). This was merged after approval by @_**simulacrum**.
+> - @_**davidtwco** has been working on implementing Split DWARF support (#77117). It's currently completely functioning and passing our existing debuginfo tests. PR has been approved by @_**nagisa** but is blocked on #79536.
+>
+> Issue triage has revealed some recurring themes in the bugs we've looked at:
+> 
+> 1. Incremental bugs tend to be very hard to reproduce because they depend not only on the current state of the code being compiled, but on previous compilations as well. There's been some discussion of building better tools to help diagnose and report issues in a way that makes it easier for us to fix.
+> 2. We've seen a number of issues related to the filesystem. The incremental cache uses some features like linking which are just not supported on certain platforms (Android for example). In other cases, using filesystem features reveals poor performance in the underlying filesystem.
+> 
+> We don't currently have anything to announce but we're beginning to think about forming project groups to tackle these problems.
+to be very hard to reproduce because they depend not only on the current state of the code being compiled, but on previous compilations as well. There's been some discussion of building better tools to help diagnose and report issues in a way that makes it easier for us to fix.
+> 2. We've seen a number of issues related to the filesystem. The incremental cache uses some features like linking which are just not supported on certain platforms (Android for example). In other cases, using filesystem features reveals poor performance in the underlying filesystem.
+> 
+> We don't currently have anything to announce but we're beginning to think about forming project groups to tackle these problems.
+
+## Beta-nominations
+
+Friendly reminder: add `T-compiler` label when nominating issues. We usually catch them up anyway, but some of them were missing due to some github searches misbehaving.
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Fix exhaustiveness in case a byte string literal is used at slice type" [rust#79072](https://github.com/rust-lang/rust/pull/79072)
+  - opened by @**oli**
+  - reviewed and r+'d by @**Esteban Küber** 
+  - Fixes [rust#79048](https://github.com/rust-lang/rust/issues/79048), an incorrect "unreachable pattern" warning on nightly
+  
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- "fix soundness issue in `make_contiguous`" [rust#79814](https://github.com/rust-lang/rust/pull/79814)
+  - opened by  @**lcnr** 
+  - reviewed by @**Camelid** and  @**lcnr** 
+  - not yet r+'d
+  - fixes unsoundness in VecDeque::make_contiguous, issue [rust#79808](https://github.com/rust-lang/rust/issues/79808)
+
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Transform post order walk to an iterative approach" [rust#78607](https://github.com/rust-lang/rust/pull/78607)
+  - opened by [HeroicKatora](https://github.com/HeroicKatora)
+  - reviewed and approved by **@davidtwco** 
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- "fix soundness issue in `make_contiguous`" [rust#79814](https://github.com/rust-lang/rust/pull/79814)
+  - opened by  @**lcnr** 
+  - reviewed by @**Camelid** 
+  - not yet r+'ed
+  - fixes unsoundness in VecDeque::make_contiguous, issue [rust#79808](https://github.com/rust-lang/rust/issues/79808)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [53 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [36 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 3 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 8 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 28 P-high, 69 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Switching to opt-level=z on i686-windows-msvc triggers STATUS_ACCESS_VIOLATION" [rust#67497](https://github.com/rust-lang/rust/issues/67497)
+  - Opened by @**dignifiedquire** 
+  - Not yet assigned
+  - [Rust 1.36.0 through 1.48.0](https://github.com/rust-lang/rust/issues/67497#issuecomment-733699197) all have broken builds on Windows i686-windows-msvc 
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482008)
+  - opened by @**Jeff Muizelaar**
+  - assigned to  @**pnkfelix** 
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+  - @**pnkfelix** has patch in progress for LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943)
+- "No error reported when a generic parameter doesn't meet the requirement of an associated type" [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482210), and [a topic was created to discuss it on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/.2378893.20no.20err.20when.20genrc.20param.20doesnt.20meet.20req.20of.20assoc.20type)
+  - Nightly regression
+  - Regressed on [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+  - @**Matthew Jasper** provides a fix in PR [rust#79543](https://github.com/rust-lang/rust/pull/79543)
+- "Miscompilation of AVX2 code under --release" [rust#79865](https://github.com/rust-lang/rust/issues/79865)
+  - opened by @**Tony Arcieri** 
+  - not yet assigned (opened yesterday)
+  - unsoundness that impacts cryptographic code
+  - no mcve yet, but various bits may help build the case (example: [refactoring some code from a lambda into a function](https://github.com/rust-lang/rust/issues/79865#issuecomment-742039745) makes the issue disappear, adding `dbg!()` statements, etc.) 
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- "VecDeque: length 0 underflow and bogus values from pop_front(), triggered by a certain sequence of reserve(), push_back(), make_contiguous(), pop_front()" [rust#79808](https://github.com/rust-lang/rust/issues/79808)
+  - assigned to @**lcnr**
+  - fixes unsoundness in VecDeque::make_contiguous, issue [rust#79808](https://github.com/rust-lang/rust/issues/79808)
+  - beta and stable nominated
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "1.48 beta broken on mips due to copy_file_range EOVERFLOW" [rust#78979](https://github.com/rust-lang/rust/issues/78979)
+  - Reviewed by @**simulacrum**
+  - This is already fixed on stable and nightly and a beta backport is approved and waiting to be done.
+- "rustc nightly hangs and leaks memory" [rust#79714](https://github.com/rust-lang/rust/issues/79714)
+  - opened by @**Isaac Leonard** 
+  - not yet assigned
+  - [JohnTitor](https://github.com/JohnTitor) mentions likely culprit PR [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- "Failed to recover key for type_of with hash" [rust#79890](https://github.com/rust-lang/rust/issues/79890)
+  - ICE when running `cargo test` over code that pulls an external crate
+  - Reporter also [bisected the issue](https://github.com/rust-lang/rust/issues/79890#issuecomment-742380554)
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+Quiet week.
+
+Triage done by **@simulacrum**.
+Revision range: [c7cff213e937c1bb301be807ce04fcf6092b9163..4fd4a98d4788bc987d7f7add9df5f5ead6a1c15e](https://perf.rust-lang.org/?start=c7cff213e937c1bb301be807ce04fcf6092b9163&end=4fd4a98d4788bc987d7f7add9df5f5ead6a1c15e&absolute=false&stat=instructions%3Au)
+
+0 Regressions, 2 Improvements, 1 Mixed
+0 of them in rollups
+
+### Regressions
+
+### Improvements
+
+[#79594](https://github.com/rust-lang/rust/issues/79594)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=c7cff213e937c1bb301be807ce04fcf6092b9163&end=d015f0d92144f0e72735a918aee8510b0fe2cff5&stat=instructions:u) (up to -1.7% on `incr-full` builds of `ctfe-stress-4-debug`)
+- Likely due to the stress test not reflecting benefits of memoizing CTFE, which
+  this partially removed (due to the addition of heap allocation, which should
+  not be deduplicated).
+
+[#79680](https://github.com/rust-lang/rust/issues/79680)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=e6225434fff7d493baac0aa91c57f2da923ea196&end=2218520b8adf8b8e64b817537d9eb0a84840e2f1&stat=instructions:u) (up to -20.6% on `full` builds of `match-stress-enum-check`)
+- Fixes a regression from last week by adding a `#[inline]` attribute on some
+  hot code. Improvements are likely not significant outside stress tests.
+
+### Mixed
+
+[#78373](https://github.com/rust-lang/rust/issues/78373)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=551a2c6cbcf239f662a18233cf647bf67e5a74ed&end=9122b769c8306b1cb3c8d1f96fca3ea3e208e22e&stat=instructions:u) (up to -28.4% on `incr-patched: println` builds of `clap-rs-debug`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=551a2c6cbcf239f662a18233cf647bf67e5a74ed&end=9122b769c8306b1cb3c8d1f96fca3ea3e208e22e&stat=instructions:u) (up to 9.9% on `incr-patched: println` builds of `regression-31157-opt`)
+- Soundness fix ("Don't leak return value after panic in drop") and the perf
+  results are mixed, largest ones mostly in incremental and generally likely
+  just "generating more (necessary) LLVM IR".
+
+### Nags requiring follow up
+
+- stdarch expansion causing a 40% libcore compile time regression is still not
+  resolved, and resolution is unclear. It seems likely that this could be one of
+  our key elements for improving std compile times at least, though.
+- No new nags.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Miscompilation root-caused to llvm bug" [rust#79708](https://github.com/rust-lang/rust/issues/79708)
+    - Reported by @_**Jeremy Fitzhardinge**
+    - LLVM alias analysis bug that is causing soundness issues for production users
+    - Apparantly appeared in Rust 1.47.0, but the LLVM bug is present since 2015 ([relevant comment](https://github.com/rust-lang/rust/issues/79708#issuecomment-738993565))
+    - Fixed in LLVM upstream on December 3rd ([review](https://reviews.llvm.org/D91576), [commit](https://github.com/llvm/llvm-project/commit/18603319321a6c1b158800bcc60035ee01549516))
+    - Nominated to discuss if a cherry-pick of the fix is warranted
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-12-17.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-12-17.md
@@ -1,0 +1,278 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-12-17
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow (friday 18th) at the same time as this meeting, we have the "Compiler Team Foundation Q&A"
+- Following meetings are on 24th and 31st (note for @pnkfelix: unsure if we will have these meetings and who will be around)
+- We will be releasing 1.49 on December 31st
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+- Pending FCP requests (check your boxes!)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+  - "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-lang] "Use true previous lint level when detecting overriden forbids" [rust#78864](https://github.com/rust-lang/rust/pull/78864)
+  - [T-rustdoc] "rustdoc: stabilise --default-theme command line option" [rust#79642](https://github.com/rust-lang/rust/pull/79642)
+
+
+### WG checkins
+
+@*WG-llvm* checkin by @**nagisa**:
+
+> * Subjectively it seems like there has been an uptick of soundness issues/miscompilations related to LLVM (or perhaps people are now trying to use more obscure features of it, new targets?)
+> * Besides a regular submodule bump ([#79861](https://github.com/rust-lang/rust/issues/79861)), there hasn't been much development, notable outstanding and related stuff is: [#77885](https://github.com/rust-lang/rust/issues/77885) using inline-asm stack probes which is blocked on 11.0.1 and a couple of changes as part of work to enable split dwarf support ([#80087](https://github.com/rust-lang/rust/issues/80087), [#77117](https://github.com/rust-lang/rust/issues/77117))
+
+@*T-compiler/WG-meta* checkin by @**nikomatsakis**:
+> * wesleywiser is now the new compiler team co-lead!
+> * nikomatsakis floated a proposal around "compiler team officers", the idea being to identify various special roles within compiler team that get elected to fixed terms (including a set of folks who decide on RFCs), and to generally "flatten" the team structure so that contribuors/members both elect these officers
+> * The core team roadmap draft is going to focus on governance, such as defining team charters and other work, so nikomatsakis expects next year that meta will take on some of that work
+> * One question is whether nikomatsakis should continue as lead of the working group, or whether wesleywiser/pnkfelix (or someone else) would be better! nikomatsakis is open to stepping back from that role, if others are pscyched to fill it, and eager to contribute help and thoughts either way.
+> * Enjoy the upcoming holidays and take care of yourselves, folks! :heart_eyes: 
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Resolve enum field visibility correctly" [rust#79956](https://github.com/rust-lang/rust/pull/79956)
+  - Fixes [rust#79593](https://github.com/rust-lang/rust/issues/79593)
+  - opened by @**Camelid** 
+  - nominates for beta backport since error [comes up fairly frequently](https://github.com/rust-lang/rust/pull/79956#issuecomment-744091095)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "MIR-OPT: Pass to deduplicate blocks" [rust#77551](https://github.com/rust-lang/rust/pull/77551)
+  - opened by @**Simon Vandel Sillesen** 
+  - assigned to @**oli**
+  - The performance gain seems to be not very clear. Relevant comments [from here](https://github.com/rust-lang/rust/pull/77551#issuecomment-713417158). 
+- "BPF target support" [rust#79608](https://github.com/rust-lang/rust/pull/79608)
+  - opened by @**Alessandro Decina**, suggests a Tier 2 for this target
+  - assigned to @**simulacrum** 
+  - Adds targets `bpfel-unknown-none` and `bpfeb-unknown-none` (more info [here](https://github.com/alessandrod/bpf-linker))
+  - @_*simulacrum* suggests waiting to have a policy for that
+  - @**Josh Triplett** [is working on it](https://github.com/rust-lang/rust/pull/79608#issuecomment-744211807)
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [6 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [51 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [32 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 1 P-high, 0 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 8 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 28 P-high, 70 P-medium, 5 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Switching to opt-level=z on i686-windows-msvc triggers STATUS_ACCESS_VIOLATION" [rust#67497](https://github.com/rust-lang/rust/issues/67497)
+  - Discussed last week
+  - Opened by @**dignifiedquire** 
+  - Assigned to @**pnkfelix**
+  - [Rust 1.36.0 through 1.48.0](https://github.com/rust-lang/rust/issues/67497#issuecomment-733699197) all have broken builds on Windows i686-windows-msvc 
+- "missing_fragment_specifier hard error" [rust#76605](https://github.com/rust-lang/rust/issues/76605)
+  - opened by @**Pietro Albini** 
+  - assigned to @**Esteban Küber** 
+  - A deprecation warning since 2017 becomes hard error and breakes many packages (catched by the release team)
+  - @**simulacrum** ~~05#issuecomment-702811192) for the beta,~~ suggests to create a patch for nightly also [to make it a hard warning](https://github.com/rust-lang/rust/issues/76605#issuecomment-742711664)
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482008)
+  - opened by @**Jeff Muizelaar**
+  - assigned to  @**pnkfelix** 
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+  - @_**pnkfelix** has patch in progress for LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943) (got feedback recently from @_**Nikita Popov**)
+- "No error reported when a generic parameter doesn't meet the requirement of an associated type" [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482210), and [a topic was created to discuss it on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/.2378893.20no.20err.20when.20genrc.20param.20doesnt.20meet.20req.20of.20assoc.20type)
+  - Nightly regression
+  - Regressed on [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+  - @**Matthew Jasper** provides a fix in PR [rust#79543](https://github.com/rust-lang/rust/pull/79543)
+- "Miscompilation of AVX2 code under --release" [rust#79865](https://github.com/rust-lang/rust/issues/79865)
+  - Discussed last week
+  - opened by @**Tony Arcieri** 
+  - not yet assigned
+  - unsoundness that impacts cryptographic code
+  - reporter mentions a workaround ([pulling code out of a lamba](https://github.com/rust-lang/rust/issues/79865#issuecomment-742039745)) to fix the error 
+  - shortest [mcve so far](https://github.com/rust-lang/rust/issues/79865#issuecomment-742861255) provided by @**lqd**
+- "Miscompilation in webrender on aarch64-apple-darwin" [rust#80111](https://github.com/rust-lang/rust/issues/80111)
+  - opened by @**Mike Hommey** 
+  - Firefox nightly would crash on startup on arm64 macos 
+  - seems that different LTO parameters trigger the issue
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "regression 1.49: macro_rules unexpected tokens" [rust#79908](https://github.com/rust-lang/rust/issues/79908)
+  - opened by @**simulacrum**
+  - assigned to @**Camelid**
+  - A crater test run find a regression. There are two crates involved (`fourier` and `tiger`), the latter is relevant to this regression
+  - we have an [mcve](https://github.com/rust-lang/rust/issues/79908#issuecomment-747085341)
+  - @_**Camelid** is working on a patch
+  
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+A week dominated by small regressions with only 1 modest yet clear performance gain. None of the regressions are large enough to cause concern, but there should be a followup to some to ensure that those regressions are at least examined.
+
+Triage done by **@rylevick**.
+Revision range: [4fd4a98d4788bc987d7f7add9df5f5ead6a1c15e..e1cce06e4ff5206daf397e1dcf91ed53653be171](https://perf.rust-lang.org/?start=4fd4a98d4788bc987d7f7add9df5f5ead6a1c15e&end=e1cce06e4ff5206daf397e1dcf91ed53653be171&absolute=false&stat=instructions%3Au)
+
+6 Regressions, 1 Improvements, 2 Mixed
+0 of them in rollups
+
+### Regressions
+
+Also generate `StorageDead` in constants[#78679](https://github.com/rust-lang/rust/issues/78679)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=c0bfe3485f97f267cc8adec724f109c56dab5526&end=cc03ee6702053ded253c3656cbd02f0bfdf25c73&stat=instructions:u) (up to 5.7% on `incr-patched: new row` builds of `tuple-stress-check`)
+- A removal of special casing of not marking statics and constants as `StorageDead` inside rustc_mir. 
+- This was regression was [deemed as acceptable](https://github.com/rust-lang/rust/pull/78679#issuecomment-729030782) due to being more correct than the previous implementation. 
+
+Properly re-use def path hash in incremental mode[#79721](https://github.com/rust-lang/rust/issues/79721)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=cc03ee6702053ded253c3656cbd02f0bfdf25c73&end=fa55f668e5ea5388ec98b9340969527252239151&stat=instructions:u) (up to 1.5% on `incr-unchanged` builds of `deeply-nested-opt`)
+- Fixes a p-high [ICE issue](https://github.com/rust-lang/rust/issues/79661), and so the perf regressions were deemed acceptable.
+- This is a fix for [#74967](https://github.com/rust-lang/rust/pull/74967) which saw [large perf gains](https://perf.rust-lang.org/compare.html?start=db79d2f63780613e700cb58b4339c48287555ae0&end=bf8e95436e60effbeb46a32e17df8ab7fcb0c6ad).
+
+Accept arbitrary expressions in key-value attributes at parse time[#78837](https://github.com/rust-lang/rust/issues/78837)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=1cc410710993d036730c11556039e40109f6ab41&end=58d2bad9f7ab0971495247b6c94978848760ca9d&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `match-stress-exhaustive_patterns-check`)
+- [Pinged in the PR about this issue](https://github.com/rust-lang/rust/pull/78837#issuecomment-745380762)
+
+Capture precise paths in THIR and MIR[#79553](https://github.com/rust-lang/rust/issues/79553)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9eb3a7ceafd1e2c1924177caa18c7cc0c25b413e&end=5bd9b60333b3dc0a51e7a5607cd1e0d537a9f718&stat=instructions:u) (up to 4.5% on `incr-unchanged` builds of `clap-rs-check`)
+- While this change powers a feature behind a feature flag (`capture_disjoint_fields`), it looks like it's still causing perf regressions in workloads not using this feature.
+- This is a known issue with [a plan](https://github.com/rust-lang/rust/pull/79553#issuecomment-745437806) for how to recover the performance loss.
+
+Create `rustc_type_ir`[#79169](https://github.com/rust-lang/rust/issues/79169)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=c3ed6681ff8d446e68ce272be4bf66f4145f6e29&end=3f2088aa603d2cd3f43c20795872de9cd6ec7735&stat=instructions:u) (up to 3.1% on `full` builds of `ctfe-stress-4-check`)
+* This mainly seems to be moving code around so it might be an inlining issue. 
+* [Pinged in the PR about this issue](https://github.com/rust-lang/rust/pull/79169#issuecomment-745388674)
+
+Update stdarch submodule[#79938](https://github.com/rust-lang/rust/issues/79938)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=fa416394275d2468d104b8f72ac31b1ddf7ee52e&end=8b3ee82eb68cb35030bb745c23f8aa76d9de5bee&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `deeply-nested-debug`)
+- This was a wholesale update of the stdarch submodule. 
+- stdarch is using const arguments that would benefit from const generics. This might explain why compilation suffers.
+* [Pinged in the PR about this issue](https://github.com/rust-lang/rust/pull/79938#issuecomment-745393740)
+
+### Improvements
+
+Compress RWU from at least 32 bits to 4 bits[#79727](https://github.com/rust-lang/rust/issues/79727)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5e6e1e33a11d140a4d70f946730137f241224eb3&end=1700ca07c6dd7becff85678409a5df6ad4cf4f47&stat=instructions:u) (up to -4.8% on `full` builds of `clap-rs-check`)
+- This was explicitly an experiment to gain performance, and it seems to worked fairly well. Other bit representations were tested but the one chosen was the most efficient. 
+
+### Mixed
+
+Use `def_path_hash_to_def_id` when re-using a `RawDefId`[#79915](https://github.com/rust-lang/rust/issues/79915)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=a2e29d67c26bdf8f278c98ee02d6cc77a279ed2e&end=19eb1c4c526071c430c05fffc64da71ac057a3d5&stat=instructions:u) (up to -3.5% on `incr-unchanged` builds of `clap-rs-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a2e29d67c26bdf8f278c98ee02d6cc77a279ed2e&end=19eb1c4c526071c430c05fffc64da71ac057a3d5&stat=instructions:u) (up to 2.7% on `incr-patched: dummy fn` builds of `unused-warnings-check`)
+- The amount of regressions outweighs the improvements (which were just in the clap benchmark).
+- This is a followup fix to [#79721](https://github.com/rust-lang/rust/issues/79721). Overall these regressions still represent a perf gain when compared to before the changes introduced in [#74967](https://github.com/rust-lang/rust/pull/74967).
+
+Lower `discriminant_value` intrinsic[#79922](https://github.com/rust-lang/rust/issues/79922)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=8b3ee82eb68cb35030bb745c23f8aa76d9de5bee&end=5d77fc8d0db3b69f3a3691d86eba23e4cdc390e1&stat=instructions:u) (up to -3.9% on `full` builds of `match-stress-enum-check`)
+- Smaller regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=8b3ee82eb68cb35030bb745c23f8aa76d9de5bee&end=5d77fc8d0db3b69f3a3691d86eba23e4cdc390e1&stat=instructions:u) (up to 1.3% on `incr-unchanged` builds of `clap-rs-check`)
+- The improvement outweighs the regression.
+
+### Nags requiring follow up
+
+- Several regressions need followup investigations. See their respective entries above for the issue.
+- As mentioned last week, stdarch expansion causing a 40% libcore compile time regression is still not resolved, and resolution is unclear. This is likely a related issue to the stdarch regression listed above.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+Preamble: there are 3 issues below (#76213, #79246, #79564) somehow all pointing to the same PR [rust#76030](https://github.com/rust-lang/rust/pull/76030) which exposed an existing [bug in loop vectorize in LLVM](https://bugs.llvm.org/show_bug.cgi?id=48340). We (as in: me @**apiraino**) are not 100% sure if they are all correlated, but thought to nominate them all to reason about their priority and (if any) find a common theme.
+
+- "llvm segfaults during bootstrap of rustc_middle in stage 1" [rust#76213](https://github.com/rust-lang/rust/issues/76213)
+  - opened by @**matthiaskrgr**
+  - not yet assigned
+  - `P-high` regression, might be related to [rust#79564](https://github.com/rust-lang/rust/issues/79564)
+  - still crashes after upgrade to [LLVM 11.0.0-rc3](https://github.com/rust-lang/rust/issues/76213#issuecomment-697361038)
+- "Performance regression in `1.48.0`" [rust#79246](https://github.com/rust-lang/rust/issues/79246)
+  - opened by @**marmeladema** 
+  - regression from stable to stable not yet assigned
+  - issue reporter suggests bisection seems to point to [rust#70793](https://github.com/rust-lang/rust/pull/70793)
+  - issue reporter comments that reverting PR [rust#76030](https://github.com/rust-lang/rust/issues/79246#issuecomment-731836309) fixes the regression
+- "Segfault in 1.48.0 while release-building with `pango` crate with `target-cpu=native`" [rust#79564](https://github.com/rust-lang/rust/issues/79564)
+  - opened by [twistedfall](https://github.com/twistedfall)
+  - not yet assigned, unsure about the priority
+  - @**matthiaskrgr** comments it could be related to [rust#76213](https://github.com/rust-lang/rust/issues/79564#issuecomment-735842549) and this issue provides a smaller reproducible sample
+  - [tmiasko](https://github.com/tmiasko) comments that is could related to PR [rust#76030](https://github.com/rust-lang/rust/issues/79564#issuecomment-736102763) which exposes an [LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=48340)
+  - nominating to discuss if this issue is related to the same LLVM issue as issue #76213
+- "Miscompilation root-caused to llvm bug" [rust#79708](https://github.com/rust-lang/rust/issues/79708)
+    - Reported by @_**Jeremy Fitzhardinge**
+    - LLVM alias analysis bug that is causing soundness issues for production users
+    - Apparently appeared in Rust 1.47.0, but the LLVM bug is present since 2015 ([relevant comment](https://github.com/rust-lang/rust/issues/79708#issuecomment-738993565))
+    - Fixed in LLVM upstream on December 3rd ([review](https://reviews.llvm.org/D91576), [commit](https://github.com/llvm/llvm-project/commit/18603319321a6c1b158800bcc60035ee01549516))
+    - Nominated to discuss if a cherry-pick [of the fix](https://github.com/rust-lang/rust/issues/79708#issuecomment-740982542) is warranted
+- "Unsafe checking skips pointer dereferences in unused places" [rust#80059](https://github.com/rust-lang/rust/issues/80059)
+  - Opened by @**scottmcm**
+  - `P-medium` issue has been this way for over 3 years
+  - Nominated for further discussion after T-lang meeting of 2020-12-15 
+  - Linking a [comment](https://github.com/rust-lang/rust/issues/79735#issuecomment-745506187) from @**nikomatsakis** on issue [rust#79735](https://github.com/rust-lang/rust/issues/79735) which at least partly applies here too
+- regression 1.49: trait bound no longer inferred for associated type [rust#79904](https://github.com/rust-lang/rust/issues/79904)
+  - opened by @**Ryan Levick**
+  - `crater` run fails compiling a number of crates with different errors on trait bounds
+  - might be related to [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - Here's the [tracking issue](https://github.com/rust-lang/rust/issues/79501) for crater runs for 1.49
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-12-24.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-12-24.md
@@ -1,0 +1,273 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-12-24
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- We will be releasing 1.49 next Thursday, on December 31st
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Require users to confirm they know RUSTC_BOOTSTRAP is unsupported before using it" [compiler-team#350](https://github.com/rust-lang/compiler-team/issues/350)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+- Pending FCP requests (check your boxes!)
+  - "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+- Things in FCP (make sure you're good with it)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Tracking issue for map_ok and map_err method for Poll<Option<Result<T, E>>>" [rust#63514](https://github.com/rust-lang/rust/issues/63514)
+  - [T-libs] "Stabilize the Wake trait" [rust#74304](https://github.com/rust-lang/rust/pull/74304)
+  - [T-libs] "Mark `-1` as an available niche for file descriptors" [rust#74699](https://github.com/rust-lang/rust/pull/74699)
+  - [T-libs] "Stabilize or_insert_with_key" [rust#78083](https://github.com/rust-lang/rust/pull/78083)
+  - [T-lang] "Rename `overlapping_patterns` lint" [rust#78242](https://github.com/rust-lang/rust/pull/78242)
+  - [T-libs] "stabilize deque_range" [rust#79022](https://github.com/rust-lang/rust/pull/79022)
+  - [T-lang] "passes: prohibit invalid attrs on generic params" [rust#79073](https://github.com/rust-lang/rust/pull/79073)
+  - [T-libs] "Stabilize `core::slice::fill`" [rust#79213](https://github.com/rust-lang/rust/pull/79213)
+  - [T-libs] "Deprecate atomic compare_and_swap method" [rust#79261](https://github.com/rust-lang/rust/pull/79261)
+  - [T-lang] "Acknowledge that `[CONST; N]` is stable" [rust#79270](https://github.com/rust-lang/rust/pull/79270)
+  - [T-libs] "Stabilize all stable methods of `Ipv4Addr`, `Ipv6Addr` and `IpAddr` as const" [rust#79342](https://github.com/rust-lang/rust/pull/79342)
+  - [T-libs] "Move {f32,f64}::clamp to core." [rust#79473](https://github.com/rust-lang/rust/pull/79473)
+  - [T-libs] "Stabilize `unsafe_cell_get_mut`" [rust#79485](https://github.com/rust-lang/rust/pull/79485)
+  - [T-libs] "Implement From<char> for u64 and u128." [rust#79502](https://github.com/rust-lang/rust/pull/79502)
+
+### WG checkins
+
+@*WG-mir-opt* checkin by @**oli**:
+> Checkin text
+
+@*WG-polonius* checkin by @**lqd** @**nikomatsakis**:
+> A few things to report since last time (but this work is not reviewed yet):
+>
+> - we completed the refactoring to align with the rules we finalized last sprint (with another branch to update rustc)
+> - we completed computing subset errors in all the variants, which re-enables the fast "location insensitive" pre-pass
+> - we added more documentation to the book to explain the process, the "Naive" rules, and the data they're using
+> - preparatory work for the 1st sprint of 2021, both for planning the sprint, and in-progress PRs to review during the sprint (counting the above work, that's 4 PRs ready for when the sprint happens)
+
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Revert change to trait evaluation order" [rust#80132](https://github.com/rust-lang/rust/pull/80132)
+  - opened by @**Matthew Jasper** 
+  - approved by  @**nikomatsakis**
+  - resolves issue [rust#79902](https://github.com/rust-lang/rust/issues/79902)
+- "Don't allow `const` to begin a nonterminal" [rust#80135](https://github.com/rust-lang/rust/pull/80135)
+  - opened by  @**Camelid**
+  - approved by @**Vadim Petrochenkov**
+  - backports [rust#79908](https://github.com/rust-lang/rust/issues/79908), a fix for a `P-critical` regression 
+- "Prevent caching normalization results with a cycle" [rust#80246](https://github.com/rust-lang/rust/pull/80246)
+  - opened by @**Matthew Jasper**
+  - review assigned to @**nikomatsakis**, not yet approved
+  - fixes [rust#79714](https://github.com/rust-lang/rust/issues/79714)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "MIR-OPT: Pass to deduplicate blocks" [rust#77551](https://github.com/rust-lang/rust/pull/77551)
+  - Discussed last week
+  - opened by @**Simon Vandel Sillesen** 
+  - assigned to @**oli**
+  - The performance gain seems to be not very clear. Relevant comments [from here](https://github.com/rust-lang/rust/pull/77551#issuecomment-713417158).
+- "Fix rustc sysroot in systems using CAS" [rust#79253](https://github.com/rust-lang/rust/pull/79253)
+  - Assigned to @**simulacrum**
+  - "It seems like it could easily lead to confusion if there are (by accident or intentionally) different sysroots at argv0 and current_exe"
+  - @**simulacrum** thinks that the problem is real but is unsure if the solution is the right one
+- "BPF target support" [rust#79608](https://github.com/rust-lang/rust/pull/79608)
+  - Discussed last week
+  - opened by @**Alessandro Decina**, suggests a Tier 2 for this target
+  - assigned to @**simulacrum** 
+  - Adds targets `bpfel-unknown-none` and `bpfeb-unknown-none` (more info [here](https://github.com/alessandrod/bpf-linker))
+  - @_*simulacrum* suggests waiting to have a policy for that
+  - @**Josh Triplett** [is working on it](https://github.com/rust-lang/rust/pull/79608#issuecomment-744211807)
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [8 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [3 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [51 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [33 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [3 P-critical, 0 P-high, 1 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 8 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 31 P-high, 82 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Switching to opt-level=z on i686-windows-msvc triggers STATUS_ACCESS_VIOLATION" [rust#67497](https://github.com/rust-lang/rust/issues/67497)
+  - Discussed last week
+  - Opened by @**dignifiedquire** 
+  - Assigned to @**pnkfelix**
+  - [Rust 1.36.0 through 1.48.0](https://github.com/rust-lang/rust/issues/67497#issuecomment-733699197) all have broken builds on Windows i686-windows-msvc 
+- "missing_fragment_specifier hard error" [rust#76605](https://github.com/rust-lang/rust/issues/76605)
+  - Discussed last week
+  - opened by @**Pietro Albini** 
+  - assigned to @**Esteban Küber** 
+  - A deprecation warning since 2017 becomes hard error and breakes many packages (catched by the release team)
+  - @**simulacrum** suggests to create a patch for nightly also [to make it a hard warning](https://github.com/rust-lang/rust/issues/76605#issuecomment-742711664)
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482008)
+  - opened by @**Jeff Muizelaar**
+  - assigned to  @**pnkfelix** 
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+  - @_**pnkfelix**_ has patch in progress for LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943) (got feedback recently from @_**Nikita Popov**)
+- "No error reported when a generic parameter doesn't meet the requirement of an associated type" [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - opened by @**yshui** 
+  - assigned to  @**Matthew Jasper**
+  - [previously discussed](https://github.com/rust-lang/rust/issues/78893#issuecomment-726155995)
+  - [more comments](https://github.com/rust-lang/rust/issues/78893#issuecomment-730644250) from @**nikomatsakis**
+  - @**Camelid** bisected to [commit 08e2d46](https://github.com/rust-lang/rust/issues/78893#issuecomment-724192873) and PR [rust#73905](https://github.com/rust-lang/rust/pull/73905)
+- "Miscompilation of AVX2 code under --release" [rust#79865](https://github.com/rust-lang/rust/issues/79865)
+  - [Previously discussed](https://github.com/rust-lang/rust/issues/78893#issuecomment-726155995)
+  - opened by @**Tony Arcieri** 
+  - not yet assigned
+  - unsoundness that impacts cryptographic code
+  - reporter mentions a workaround ([pulling code out of a lamba](https://github.com/rust-lang/rust/issues/79865#issuecomment-742039745)) to fix the error 
+  - shortest [mcve so far](https://github.com/rust-lang/rust/issues/79865#issuecomment-742861255) provided by @**lqd**
+  - an even [shorter repro](https://github.com/rust-lang/rust/issues/79865#issuecomment-748537875) from @**Stu** 
+- "regression 1.49: macro_rules unexpected tokens" [rust#79908](https://github.com/rust-lang/rust/issues/79908)
+  - Discussed last week
+  - opened by @**simulacrum**
+  - assigned to @**Camelid**
+  - A crater test run find a regression. There are two crates involved (`fourier` and `tiger`), the latter is relevant to this regression
+  - we have an [mcve](https://github.com/rust-lang/rust/issues/79908#issuecomment-747085341)
+  - @_**Camelid** is working on a patch
+- "Unsoundness in type checking of trait impls. Differences in implied lifetime bounds are not considered." [rust#80176](https://github.com/rust-lang/rust/issues/80176)
+  - opened by @**Frank Steffahn** 
+  - here's a [repro](https://github.com/rust-lang/rust/issues/80176#issuecomment-748466836)
+  - seems related to [rust#25860](https://github.com/rust-lang/rust/issues/25860)
+- "Miscompilation when using wrapping_sub/wrapping_add on pointer." [rust#80309](https://github.com/rust-lang/rust/issues/80309)
+  - opened by @**Frank Steffahn**
+  - unsoundness leads to an `illegal instruction` error, but only when compiling for `release` (`debug` seems fine)
+  - here is a [minimal repro](https://github.com/rust-lang/rust/issues/80309#issuecomment-750290538)
+  - we have an [LLVM issue](https://bugs.llvm.org/show_bug.cgi?id=48577)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+Major event this week is landing PGO for rustc (on x86_64-unknown-linux-gnu). We
+expect other platforms to follow but further investigation will be needed,
+especially for cross-compiled platforms. We expect to add LLVM PGO as well.
+
+Triage done by **@simulacrum**.
+Revision range: [e1cce06e4ff5206daf397e1dcf91ed53653be171..c34c015fe2710caf53ba7ae9d1644f9ba65a6f74](https://perf.rust-lang.org/?start=e1cce06e4ff5206daf397e1dcf91ed53653be171&end=c34c015fe2710caf53ba7ae9d1644f9ba65a6f74&absolute=false&stat=instructions%3Au)
+
+3 Regressions, 5 Improvements
+
+### Regressions
+
+Rollup of 11 pull requests [#80105](https://github.com/rust-lang/rust/issues/80105)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a6491be5be9344a325b7e49b0114f3cf67ef199e&end=9b84d36a0b9ea3bf305f36f08d50aa42c26f96c2&stat=instructions:u) (up to 3.4% on `full` builds of `match-stress-enum-check`)
+- Due to implementing `if let` guards in [#79051](https://github.com/rust-lang/rust/issues/79051)
+
+Revert "cg_llvm: `fewer_names` in `uncached_llvm_type`" [#80122](https://github.com/rust-lang/rust/issues/80122)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=eb4fc71dc9024f15a0c9cc44bcc10c861e9d585e&end=1954756aa53d03e59e40669eaa47a15d8497c352&stat=instructions:u) (up to 424.2% on `incr-patched: println` builds of `regression-31157-debug`)
+- Hopefully temporary fix until LLVM patches are applied. Fairly unfortunate,
+  though, to lose this much performance.
+
+or_patterns: implement :pat edition-specific behavior [#80100](https://github.com/rust-lang/rust/issues/80100)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=0c11b93f5a8914a40f619b0a1663baafe029d427&end=29e32120c33d30ff526fc7f4d94ec9fce0dc10c9&stat=instructions:u) (up to 1.3% on `incr-unchanged` builds of `deep-vector-check`)
+- Most likely overeagerly queries edition of spans. Left ask for moving that to
+  be lazy.
+
+### Improvements
+
+Make BoundRegion have a kind of BoungRegionKind [#80163](https://github.com/rust-lang/rust/issues/80163)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=29e32120c33d30ff526fc7f4d94ec9fce0dc10c9&end=b1964e60b72c2d10e9fd4e801990f8af3f306ac0&stat=instructions:u) (up to -2.1% on `full` builds of `clap-rs-check`)
+- Looks like faster mostly due to a smaller argument size
+
+rustc_query_system: explicitly register reused dep nodes [#80177](https://github.com/rust-lang/rust/issues/80177)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=353f3a38460d3c2222d2ab29143f48595b1a32a9&end=bb1fbbf84455fbad9afd26c17e0f725019322655&stat=instructions:u) (up to -2.4% on `incr-unchanged` builds of `match-stress-enum-check`)
+- Almost entirely incremental-only change, as expected.
+
+Turn quadratic time on number of impl blocks into linear time [#78317](https://github.com/rust-lang/rust/issues/78317)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b0e5c7d1fee37f1890455b977495bfe262716701&end=c609b2eaf323186a1167ec1a9ffa69a7d4a5b1b9&stat=instructions:u) (up to -2.0% on `incr-unchanged` builds of `packed-simd-check`)
+
+rustc_query_system: reduce dependency graph memory usage [#79589](https://github.com/rust-lang/rust/issues/79589)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=3d10d3e49d9784ba3833ccf5d56d0a4d15bb36f6&end=49b315123e6adb35024437ef7ba408456771c062&stat=instructions:u) (up to -2.3% on `incr-unchanged` builds of `packed-simd-check`)
+
+Utilize PGO for rustc linux dist builds [#80262](https://github.com/rust-lang/rust/issues/80262)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=87eecd40e87cf7e77cee9cfdc79900c83baf6d8f&end=3ffea60dd5a2260004cc4f487401ae7c7db1aa0e&stat=instructions:u) (up to -12.2% on `full` builds of `externs-debug`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=87eecd40e87cf7e77cee9cfdc79900c83baf6d8f&end=3ffea60dd5a2260004cc4f487401ae7c7db1aa0e&stat=instructions:u) (up to 7.4% on `incr-unchanged` builds of `many-assoc-items-check`)
+- Instruction counts are not the main target of PGO, and wall times are
+  showing the expected 5-20% [wins](https://perf.rust-lang.org/compare.html?start=87eecd40e87cf7e77cee9cfdc79900c83baf6d8f&end=3ffea60dd5a2260004cc4f487401ae7c7db1aa0e&stat=wall-time).
+  Note that we expect to improve performance even further by applying PGO to
+  LLVM as well.
+
+### Nags requiring follow up
+
+- or_patterns: implement :pat edition-specific behavior [#80100](https://github.com/rust-lang/rust/issues/80100)
+    - Needs follow-up performance fixing patch. https://github.com/rust-lang/rust/pull/80100#issuecomment-750893149
+- stdarch is still a major contributor to libcore compile times.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Unsafe checking skips pointer dereferences in unused places" [rust#80059](https://github.com/rust-lang/rust/issues/80059)
+  - Opened by @**scottmcm**
+  - `P-medium` issue has been this way for over 3 years
+  - Nominated for further discussion after T-lang meeting of 2020-12-15 
+  - Linking a [comment](https://github.com/rust-lang/rust/issues/79735#issuecomment-745506187) from @**nikomatsakis** on issue [rust#79735](https://github.com/rust-lang/rust/issues/79735) which at least partly applies here too
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)

--- a/meetings-agenda/T-compiler Meeting Agenda 2020-12-31.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2020-12-31.md
@@ -1,0 +1,301 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2020-12-31
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Rust 1.49 has been released!!! :tada: :tada: :tada:
+- Make sure that all ideas for 2021 are in the [HackMD](https://hackmd.io/3eG6OZWHRbSMxoRxzwNhGQ?view); see [zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Rust.202021)
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+- Pending FCP requests (check your boxes!)
+  - "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+- Things in FCP (make sure you're good with it)
+  - "Make it easier to build the standard library" [compiler-team#394](https://github.com/rust-lang/compiler-team/issues/394)
+  - "Add a scheme to register functions from other crates with TyCtxt" [compiler-team#395](https://github.com/rust-lang/compiler-team/issues/395)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-infra, T-compiler] "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+  - [T-libs] "Tracking issue for map_ok and map_err method for Poll<Option<Result<T, E>>>" [rust#63514](https://github.com/rust-lang/rust/issues/63514)
+  - [T-libs] "Stabilize the Wake trait" [rust#74304](https://github.com/rust-lang/rust/pull/74304)
+  - [T-libs] "Mark `-1` as an available niche for file descriptors" [rust#74699](https://github.com/rust-lang/rust/pull/74699)
+  - [T-libs] "Stabilize or_insert_with_key" [rust#78083](https://github.com/rust-lang/rust/pull/78083)
+  - [T-lang] "Rename `overlapping_patterns` lint" [rust#78242](https://github.com/rust-lang/rust/pull/78242)
+  - [T-libs] "stabilize deque_range" [rust#79022](https://github.com/rust-lang/rust/pull/79022)
+  - [T-lang] "passes: prohibit invalid attrs on generic params" [rust#79073](https://github.com/rust-lang/rust/pull/79073)
+  - [T-libs] "Add `impl Div<NonZeroU{0}> for u{0}` which cannot panic" [rust#79134](https://github.com/rust-lang/rust/pull/79134)
+  - [T-lang] "stabilize `#![feature(min_const_generics)]` in 1.51" [rust#79135](https://github.com/rust-lang/rust/pull/79135)
+  - [T-libs] "Stabilize `core::slice::fill`" [rust#79213](https://github.com/rust-lang/rust/pull/79213)
+  - [T-libs] "BTreeMap: remove Ord bound where it's not needed" [rust#79245](https://github.com/rust-lang/rust/pull/79245)
+  - [T-libs] "Deprecate atomic compare_and_swap method" [rust#79261](https://github.com/rust-lang/rust/pull/79261)
+  - [T-lang] "Acknowledge that `[CONST; N]` is stable" [rust#79270](https://github.com/rust-lang/rust/pull/79270)
+  - [T-libs] "Stabilize all stable methods of `Ipv4Addr`, `Ipv6Addr` and `IpAddr` as const" [rust#79342](https://github.com/rust-lang/rust/pull/79342)
+  - [T-libs] "Move {f32,f64}::clamp to core." [rust#79473](https://github.com/rust-lang/rust/pull/79473)
+  - [T-libs] "Stabilize `unsafe_cell_get_mut`" [rust#79485](https://github.com/rust-lang/rust/pull/79485)
+  - [T-libs] "Implement From<char> for u64 and u128." [rust#79502](https://github.com/rust-lang/rust/pull/79502)
+
+### WG checkins
+
+@*WG-mir-opt* checkin by @**oli**:
+> * mir opts now participate in optimization fuel (#79117)
+> * some intrinsic calls are lowered to pure MIR statements/rvalues (#79049, #79922)
+> * the old copy-prop is finally gone (#77373)
+> * mir-dumps became less noisy around arrays and tuples (#79999)
+> * mir graphviz is now created by using an out-of-tree crate (#78399)
+> * various fixes of mir-inlining by @tmiasko (#79192, #78966, #78873, #78843, #78847, #78771, #78674, #78668, #78580)
+
+@*WG-polonius* checkin by @**lqd** @**nikomatsakis**:
+> A few things to report since last time (but this work is not reviewed yet):
+>
+> - we completed the refactoring to align with the rules we finalized last sprint (with another branch to update rustc)
+> - we completed computing subset errors in all the variants, which re-enables the fast "location insensitive" pre-pass
+> - we added more documentation to the book to explain the process, the "Naive" rules, and the data they're using
+> - preparatory work for the 1st sprint of 2021, both for planning the sprint, and in-progress PRs to review during the sprint (counting the above work, that's 4 PRs ready for when the sprint happens)
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- No beta nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "MIR-OPT: Pass to deduplicate blocks" [rust#77551](https://github.com/rust-lang/rust/pull/77551)
+  - Discussed last week
+  - opened by @**Simon Vandel Sillesen** 
+  - assigned to @**oli**
+  - The performance gain seems to be not very clear. Relevant comments [from here](https://github.com/rust-lang/rust/pull/77551#issuecomment-713417158).
+- "Fix rustc sysroot in systems using CAS" [rust#79253](https://github.com/rust-lang/rust/pull/79253)
+  - Assigned to @**simulacrum**
+  - "It seems like it could easily lead to confusion if there are (by accident or intentionally) different sysroots at argv0 and current_exe"
+  - @**simulacrum** thinks that the problem is real but is unsure if the solution is the right one
+  -  @**Joshua Nelson** [points out](https://github.com/rust-lang/rust/pull/79253#issuecomment-750706219) that there is already a `--sysroot` to override the system root (if that may help the issue reporter)
+- "BPF target support" [rust#79608](https://github.com/rust-lang/rust/pull/79608)
+  - Discussed last week
+  - opened by @**Alessandro Decina**, suggests a Tier 2 for this target
+  - assigned to @**simulacrum** 
+  - Adds targets `bpfel-unknown-none` and `bpfeb-unknown-none` (more info [here](https://github.com/alessandrod/bpf-linker))
+  - @_*simulacrum* suggests waiting to have a policy for that
+  - @**Josh Triplett** [is working on it](https://github.com/rust-lang/rust/pull/79608#issuecomment-744211807)
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [5 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [3 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [55 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [35 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 1 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 7 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 31 P-high, 81 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Switching to opt-level=z on i686-windows-msvc triggers STATUS_ACCESS_VIOLATION" [rust#67497](https://github.com/rust-lang/rust/issues/67497)
+  - Discussed last week
+  - Opened by @**dignifiedquire** 
+  - Assigned to @**pnkfelix**
+  - [Rust 1.36.0 through 1.48.0](https://github.com/rust-lang/rust/issues/67497#issuecomment-733699197) all have broken builds on Windows i686-windows-msvc 
+- "Upgrade to LLVM11 caused a codegen regression on Windows" [rust#78283](https://github.com/rust-lang/rust/issues/78283)
+  - [Previously discussed](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-11-12.20.2354818/near/216482008)
+  - opened by @**Jeff Muizelaar**
+  - assigned to  @**pnkfelix** 
+  - Firefox code that used to work on Rust 1.46 started to fail after upgrading to LLVM 11
+  - Affects only MSVC
+  - @**Nikita Popov** suggests could be related to [rust#74498](https://github.com/rust-lang/rust/issues/74498)
+  - @**Jeff Muizelaar** suggests to be related to LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943), provides a [minimal repro](https://github.com/rust-lang/rust/issues/78283#issuecomment-720156273)
+  - @_**pnkfelix**_ has patch in progress for LLVM bug [#46943](https://bugs.llvm.org/show_bug.cgi?id=46943) (got feedback recently from @_**Nikita Popov**)
+- "Miscompilation of AVX2 code under --release" [rust#79865](https://github.com/rust-lang/rust/issues/79865)
+  - [Previously discussed](https://github.com/rust-lang/rust/issues/78893#issuecomment-726155995)
+  - opened by @**Tony Arcieri** 
+  - not yet assigned
+  - unsoundness that impacts cryptographic code
+  - reporter mentions a workaround ([pulling code out of a lamba](https://github.com/rust-lang/rust/issues/79865#issuecomment-742039745)) to fix the error 
+  - shortest [mcve so far](https://github.com/rust-lang/rust/issues/79865#issuecomment-742861255) provided by @**lqd**
+  - an even [shorter repro](https://github.com/rust-lang/rust/issues/79865#issuecomment-748537875) from @**Stu** 
+- "Unsoundness in type checking of trait impls. Differences in implied lifetime bounds are not considered." [rust#80176](https://github.com/rust-lang/rust/issues/80176)
+  - opened by @**Frank Steffahn** 
+  - here's a [repro](https://github.com/rust-lang/rust/issues/80176#issuecomment-748466836)
+  - seems related to [rust#25860](https://github.com/rust-lang/rust/issues/25860)
+- "Miscompilation when using wrapping_sub/wrapping_add on pointer." [rust#80309](https://github.com/rust-lang/rust/issues/80309)
+  - opened by @**Frank Steffahn**
+  - unsoundness leads to an `illegal instruction` error, but only when compiling for `release` (`debug` seems fine)
+  - here is a [minimal repro](https://github.com/rust-lang/rust/issues/80309#issuecomment-750290538)
+  - we have an [LLVM issue](https://bugs.llvm.org/show_bug.cgi?id=48577) and [here](https://bugs.llvm.org/show_bug.cgi?id=44403)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "No error reported when a generic parameter doesn't meet the requirement of an associated type" [rust#78893](https://github.com/rust-lang/rust/issues/78893)
+  - Opened by @**yshui** 
+  - Assigned to @**Matthew Jasper** 
+  - @**Camelid** bisected to this PR [#73905](https://github.com/rust-lang/rust/pull/73905)
+  - Niko did [some analysis](https://github.com/rust-lang/rust/issues/78893#issuecomment-730646724) on the issue
+  - [Previously discussed](https://github.com/rust-lang/rust/issues/78893#issuecomment-726155995): reverting #73905 is not desirable
+  - @**simulacrum** [also comments](https://github.com/rust-lang/rust/issues/78893#issuecomment-751496676) this is likely to be a regression in stable once 1.49 is out, but not a release blocker
+  - but [if this gets into stable](https://github.com/rust-lang/rust/issues/78893#issuecomment-751538585), the eventual fix is going to be a breaking change
+   
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+### 2020-12-24
+
+Major event this week is landing PGO for rustc (on x86_64-unknown-linux-gnu). We
+expect other platforms to follow but further investigation will be needed,
+especially for cross-compiled platforms. We expect to add LLVM PGO as well.
+
+Triage done by **@simulacrum**.
+Revision range: [e1cce06e4ff5206daf397e1dcf91ed53653be171..c34c015fe2710caf53ba7ae9d1644f9ba65a6f74](https://perf.rust-lang.org/?start=e1cce06e4ff5206daf397e1dcf91ed53653be171&end=c34c015fe2710caf53ba7ae9d1644f9ba65a6f74&absolute=false&stat=instructions%3Au)
+
+3 Regressions, 5 Improvements
+
+#### Regressions
+
+Rollup of 11 pull requests [#80105](https://github.com/rust-lang/rust/issues/80105)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a6491be5be9344a325b7e49b0114f3cf67ef199e&end=9b84d36a0b9ea3bf305f36f08d50aa42c26f96c2&stat=instructions:u) (up to 3.4% on `full` builds of `match-stress-enum-check`)
+- Due to implementing `if let` guards in [#79051](https://github.com/rust-lang/rust/issues/79051)
+
+Revert "cg_llvm: `fewer_names` in `uncached_llvm_type`" [#80122](https://github.com/rust-lang/rust/issues/80122)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=eb4fc71dc9024f15a0c9cc44bcc10c861e9d585e&end=1954756aa53d03e59e40669eaa47a15d8497c352&stat=instructions:u) (up to 424.2% on `incr-patched: println` builds of `regression-31157-debug`)
+- Hopefully temporary fix until LLVM patches are applied. Fairly unfortunate,
+  though, to lose this much performance.
+
+or_patterns: implement :pat edition-specific behavior [#80100](https://github.com/rust-lang/rust/issues/80100)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=0c11b93f5a8914a40f619b0a1663baafe029d427&end=29e32120c33d30ff526fc7f4d94ec9fce0dc10c9&stat=instructions:u) (up to 1.3% on `incr-unchanged` builds of `deep-vector-check`)
+- Most likely overeagerly queries edition of spans. Left ask for moving that to
+  be lazy.
+
+#### Improvements
+
+Make BoundRegion have a kind of BoungRegionKind [#80163](https://github.com/rust-lang/rust/issues/80163)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=29e32120c33d30ff526fc7f4d94ec9fce0dc10c9&end=b1964e60b72c2d10e9fd4e801990f8af3f306ac0&stat=instructions:u) (up to -2.1% on `full` builds of `clap-rs-check`)
+- Looks like faster mostly due to a smaller argument size
+
+rustc_query_system: explicitly register reused dep nodes [#80177](https://github.com/rust-lang/rust/issues/80177)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=353f3a38460d3c2222d2ab29143f48595b1a32a9&end=bb1fbbf84455fbad9afd26c17e0f725019322655&stat=instructions:u) (up to -2.4% on `incr-unchanged` builds of `match-stress-enum-check`)
+- Almost entirely incremental-only change, as expected.
+
+Turn quadratic time on number of impl blocks into linear time [#78317](https://github.com/rust-lang/rust/issues/78317)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b0e5c7d1fee37f1890455b977495bfe262716701&end=c609b2eaf323186a1167ec1a9ffa69a7d4a5b1b9&stat=instructions:u) (up to -2.0% on `incr-unchanged` builds of `packed-simd-check`)
+
+rustc_query_system: reduce dependency graph memory usage [#79589](https://github.com/rust-lang/rust/issues/79589)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=3d10d3e49d9784ba3833ccf5d56d0a4d15bb36f6&end=49b315123e6adb35024437ef7ba408456771c062&stat=instructions:u) (up to -2.3% on `incr-unchanged` builds of `packed-simd-check`)
+
+Utilize PGO for rustc linux dist builds [#80262](https://github.com/rust-lang/rust/issues/80262)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=87eecd40e87cf7e77cee9cfdc79900c83baf6d8f&end=3ffea60dd5a2260004cc4f487401ae7c7db1aa0e&stat=instructions:u) (up to -12.2% on `full` builds of `externs-debug`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=87eecd40e87cf7e77cee9cfdc79900c83baf6d8f&end=3ffea60dd5a2260004cc4f487401ae7c7db1aa0e&stat=instructions:u) (up to 7.4% on `incr-unchanged` builds of `many-assoc-items-check`)
+- Instruction counts are not the main target of PGO, and wall times are
+  showing the expected 5-20% [wins](https://perf.rust-lang.org/compare.html?start=87eecd40e87cf7e77cee9cfdc79900c83baf6d8f&end=3ffea60dd5a2260004cc4f487401ae7c7db1aa0e&stat=wall-time).
+  Note that we expect to improve performance even further by applying PGO to
+  LLVM as well.
+
+#### Nags requiring follow up
+
+- or_patterns: implement :pat edition-specific behavior [#80100](https://github.com/rust-lang/rust/issues/80100)
+    - Needs follow-up performance fixing patch. https://github.com/rust-lang/rust/pull/80100#issuecomment-750893149
+- stdarch is still a major contributor to libcore compile times.
+
+### 2020-12-29
+
+This was a quiet week as many were on winter holidays. The regressions and improvements were all minor and mostly balanced each other out.
+
+Triage done by **@rylev**.
+Revision range: [c34c015fe2710caf53ba7ae9d1644f9ba65a6f74..e2a2592885539ca97bfb1232669e7519a0c0703b](https://perf.rust-lang.org/?start=c34c015fe2710caf53ba7ae9d1644f9ba65a6f74&end=e2a2592885539ca97bfb1232669e7519a0c0703b&absolute=false&stat=instructions%3Au)
+
+2 Regressions, 2 Improvements, 0 Mixed
+0 of them in rollups
+
+#### Regressions
+
+validate promoteds [#80235](https://github.com/rust-lang/rust/issues/80235)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=1832bdd7de93573464e1536e3ea17d5fd7d2888b&end=bb178237c5539c75e1b85ab78a8ab902b1f333d5&stat=instructions:u) (up to 4.8% on `full` builds of `ucd-check`)
+- Turn on const-value validation for promoteds.
+- In the PR there is a discussion if this change should instead only be a debug assertion. This should be discussed after a crater run happens. 
+
+BTreeMap: respect pointer provenance rules in split_off [#79347](https://github.com/rust-lang/rust/issues/79347)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=0edce6f4bbb4514482537f569f0b8ef48e71e0a0&end=2c308b9a2a9b9d531cafa3f11cb1000ee5362e63&stat=instructions:u) (up to 2.9% on `full` builds of `cranelift-codegen-opt`)
+- The minor perf regressions introduced here seemed to be gained back by [#79520](https://github.com/rust-lang/rust/issues/79520)
+
+#### Improvements
+
+Remove pointer comparison from slice equality [#80209](https://github.com/rust-lang/rust/issues/80209)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=d30dac2d839293f2c48e18ebfea1082819115d08&end=780b094d767b6720c11b1bf145dac2cf2643b89e&stat=instructions:u) (up to -3.1% on `incr-full` builds of `encoding-opt`)
+- Removed eagerly testing pointer equality in slices since most of the time slices won't be compared with themselves. This leads to an improvement in the code gen.
+
+BTreeMap: clean up access to MaybeUninit arrays [#79520](https://github.com/rust-lang/rust/issues/79520)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=30a42735a0ff678172f66f63aca746096a717293&end=89524d0f8e28080197a85e06d143b7d6f131b67e&stat=instructions:u) (up to -3.1% on `full` builds of `cranelift-codegen-opt`)
+- The minor perf gains seem to be regaining perfomance lost by [#79347](https://github.com/rust-lang/rust/issues/79347)
+
+#### Nags requiring follow up
+
+- stdarch is still a major contributor to libcore compile times.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "unstable fingerprints for optimized_mir" [#80336](https://github.com/rust-lang/rust/issues/80336)
+  - incr-comp issue opened by @**KalitaAlexey** 
+  - detected by using the `-Z incremental-verify-ich` flag, causing an ICE on working code pulled from git repositories (tested on Substrate framework and rust-analyzer)
+  - [Analysis](https://github.com/rust-lang/rust/issues/80336#issuecomment-751311417) by @**Aaron Hill**
+  - the keypoint being (underlined by @**Léo Lanteri Thauvin** ) "is it possible to weaponize this and make it an unsoundness issue?"
+  - difficult to minimize because "this is really difficult to observe in practice"
+  - @**matthiaskrgr** reproduced this on 1.50 nightly, 1.48.0, 1.50.0-beta.1 and way back to 1.46 (no unaffected version found yet, as bisecting without an MCVE is harder)
+  - Prioritized as `P-high`, we don't have yet a smaller mcve, we are wondering the possible implications of this issue.
+    
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-01-07.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-01-07.md
@@ -1,0 +1,172 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-01-07
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Welcome into 2021 :)
+- New MCPs (take a look, see if you like them!)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "Remove PredicateKind in favor of only Binder<PredicateAtom>" [compiler-team#397](https://github.com/rust-lang/compiler-team/issues/397)
+- Old MCPs (not seconded, take a look)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+- Pending FCP requests (check your boxes!)
+  - "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+- Things in FCP (make sure you're good with it)
+  - "Make it easier to build the standard library" [compiler-team#394](https://github.com/rust-lang/compiler-team/issues/394)
+  - "Add a scheme to register functions from other crates with TyCtxt" [compiler-team#395](https://github.com/rust-lang/compiler-team/issues/395)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - No new finished FCP (disposition merge) this time.
+
+### WG checkins
+
+@wg-polymorphization checkin by @**davidtwco**:
+> Happy new year everyone! There's no news from the polymorphization working group. Working group members have been focusing their efforts elsewhere in the compiler recently.
+
+@*WG-rfc-2229*  by @**nikomatsakis** and @**Matthew Jasper**:
+- `capture_disjoint_fields` kind of works now and is available on the nightly.
+- PRs for fixing some of the bugs and improving diagnostics are open and more fixes/improvements are currently in the works.
+- Parts of the migration (lint) analaysis for handling change in Drop ordering have been implemented, PR is open and will posting follow ups after that.
+- Need to discuss with T-lang about edge cases that we realized during the implementation phase of the RFC and an [issue](https://github.com/rust-lang/lang-team/issues/73) is open for scheduling a meeting.
+- [Perf results](https://perf.rust-lang.org/compare.html?start=0f6f2d681b39c5f95459cd09cb936b6ceb27cd82&end=aee064ad665521e03371fbb810437a813fbdd365) after hacking around some of the bugs and enabling the feature by default didn't seem bad. Incremental compile seems to be affected but that is speculated because of duplicate information currently in TypeckResults (requiring more information to hashed). Work is being done to get rid of the duplicate information.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- No beta nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- "Revert "Cleanup markdown span handling"" [rust#80381](https://github.com/rust-lang/rust/pull/80381)
+  - @**GuillaumeGomez** approves the backport
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on team this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [58 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [37 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 0 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 34 P-high, 82 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+
+- No `P-high` beta regressions at this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- "Panic with 'Missing tokens for nt ";"' when passing statement to proc macro from declarative macro" [rust#80760](https://github.com/rust-lang/rust/issues/80760)
+  - opened by @**Koxiaet** 
+  - looks like a regression on latest 1.51.0-nightly parsing the token `;` in a proc_macro
+  - @**Camelid** points to pr [79812](https://github.com/rust-lang/rust/pull/79812)
+  - no bisecting yet, but probably needs some attention
+  
+## Performance logs
+
+Happy New Year! A slow week to start off the new year, with by far the most exciting development being the large gains in the `ctfe` benchmark caused by changes in serialization and deserialization.
+
+Triage done by **@rylev**.
+Revision range: [e2a2592885539ca97bfb1232669e7519a0c0703b..f4b9d32ef53c0629732ee131b640920ae12d1edb](https://perf.rust-lang.org/?start=e2a2592885539ca97bfb1232669e7519a0c0703b&end=f4b9d32ef53c0629732ee131b640920ae12d1edb&absolute=false&stat=instructions%3Au)
+
+0 Regressions, 2 Improvements, 2 Mixed
+2 of them in rollups
+
+#### Improvements
+
+Implement edition-based macro :pat feature [#80459](https://github.com/rust-lang/rust/issues/80459)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b33e234155b33ab6bce280fb2445b62b68622b61&end=44e3daf5eee8263dfc3a2509e78ddd1f6f783a0e&stat=instructions:u) (up to -1.7% on `incr-unchanged` builds of `deep-vector-check`)
+- Fixes the perf regression from [#80100](https://github.com/rust-lang/rust/pull/80100#issuecomment-750893149)
+
+rustc_serialize: specialize opaque encoding and decoding of some u8 sequences [#80115](https://github.com/rust-lang/rust/issues/80115)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5986dd878f3e432025eb1946149e3241d3998b1b&end=929f66af9bf587383ed6010403e738e79dfac0d6&stat=instructions:u) (up to -85.1% on `incr-unchanged` builds of `ctfe-stress-4-check`)
+- In rustc-serialize, specialize encoding and decoding of some contiguous u8 sequences to use a more efficient implementation.
+
+#### Mixed
+
+Rollup of 9 pull requests [#80530](https://github.com/rust-lang/rust/issues/80530)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e2267046859c9ceb932abc983561d53a117089f6&end=9775ffef2a4c3a36cadb58b72ea60cefb92c86ae&stat=instructions:u) (up to 2.6% on `full` builds of `ripgrep-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=e2267046859c9ceb932abc983561d53a117089f6&end=9775ffef2a4c3a36cadb58b72ea60cefb92c86ae&stat=instructions:u) (up to -1.5% on `incr-patched: println` builds of `cargo-debug`)
+- Unsure which PRs were responsible for the performance impact, but we suspect [#80458](https://github.com/rust-lang/rust/pull/80458). 
+
+Rollup of 12 pull requests [#80708](https://github.com/rust-lang/rust/issues/80708)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9919ad6e9ed113557c68c430de2e0f434e4f5b6e&end=f412fb56b8d11c168e7ee49ee74e79c4ab2e5637&stat=instructions:u) (up to 5.9% on `incr-unchanged` builds of `deeply-nested-async-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=9919ad6e9ed113557c68c430de2e0f434e4f5b6e&end=f412fb56b8d11c168e7ee49ee74e79c4ab2e5637&stat=instructions:u) (up to -1.4% on `full` builds of `coercions-debug`)
+- The regression outweighs the improvement
+- Unsure which PR is the cause of the regression, but [#80637](https://github.com/rust-lang/rust/pull/80637) is our best guess.
+
+#### Nags requiring follow up
+
+- stdarch is still a major contributor to libcore compile times.
+- Investigate the two rollups that had perf impacts [#80530](https://github.com/rust-lang/rust/issues/80530) and [#80708](https://github.com/rust-lang/rust/pull/80708).
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Unsoundness in type checking of trait impls. Differences in implied lifetime bounds are not considered." [rust#80176](https://github.com/rust-lang/rust/issues/80176)
+  - opened by @**Frank Steffahn** 
+  - here's a [repro](https://github.com/rust-lang/rust/issues/80176#issuecomment-748466836)
+  - seems related to [rust#25860](https://github.com/rust-lang/rust/issues/25860)
+  - waiting for a discussion when [also Niko can be there](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-12-31.20.2354818/near/221297919)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-01-14.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-01-14.md
@@ -1,0 +1,183 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-01-14
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+- Pending FCP requests (check your boxes!)
+  - "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+- Things in FCP (make sure you're good with it)
+  - "Make it easier to build the standard library" [compiler-team#394](https://github.com/rust-lang/compiler-team/issues/394)
+  - "Add a scheme to register functions from other crates with TyCtxt" [compiler-team#395](https://github.com/rust-lang/compiler-team/issues/395)
+  - "Remove PredicateKind in favor of only Binder<PredicateAtom>" [compiler-team#397](https://github.com/rust-lang/compiler-team/issues/397)
+- Accepted MCPs
+  - "Make it easier to build the standard library" [compiler-team#394](https://github.com/rust-lang/compiler-team/issues/394)
+  - "Add a scheme to register functions from other crates with TyCtxt" [compiler-team#395](https://github.com/rust-lang/compiler-team/issues/395)
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Stabilize slice::strip_prefix and slice::strip_suffix" [rust#77853](https://github.com/rust-lang/rust/pull/77853)
+  - [T-libs] "Stabilize split_inclusive" [rust#77858](https://github.com/rust-lang/rust/pull/77858)
+
+### WG checkins
+
+@*WG-rls2.0* checkin by @**matklad** 
+> rls-2.0 also have been pretty quiet lately.
+This means that there are a lot of improvements all over the place, but nothing particularly earth-shattering happened.
+We did ship on-the-fly (during completion) auto-imports.
+We are also in the process of yet-another redesign of the core syntax tree datastructure: https://github.com/rust-analyzer/rust-analyzer/issues/6857.
+> The parser library-ification work is sadly on-hold :-[
+> Finally, to re-invigorate more ambitious undertakings, we will now hold a rust-analyzer steering meeting every six weeks.
+> The first one will happen next Monday, check the t-compiler calendar for details.
+
+@*WG-self-profile* checkin by @**Wesley Wiser**:
+> WG activity was light this cycle:
+> 
+> - @**andjo403** fixed a bug in the tooling where blocked queries weren't being properly counted when rustc was compiled with `parallel-compiler = true` ([measureme#148](https://github.com/rust-lang/measureme/pull/148))
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Make sure rust-call errors occur correctly for traits" [rust#79675](https://github.com/rust-lang/rust/pull/79675)
+  - Opened by @**Rune Tynan** 
+  - @**Esteban Küber** approves backport
+  - Fixes issue [#79669](https://github.com/rust-lang/rust/issues/79669), where an ICE was returned when checking an item that wasn't a function/closure
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [58 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [37 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 5 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 0 P-high, 7 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 37 P-high, 83 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- "Heap buffer overflow in `read_to_end_with_reservation()`" [rust#80894](https://github.com/rust-lang/rust/issues/80894)
+  - Opened by @**Yechan Bae** 
+  - unsoundness causing a heap overflow
+  - possible culprit on commit [ecbb896](https://github.com/rust-lang/rust/commit/ecbb896b9eb2acadefde57be493e4298c1aa04a3)
+  - @**Steven Fackler** prepared PR [#80895](https://github.com/rust-lang/rust/pull/80895)
+  - issue probably will be mentioned [in a CVE](https://github.com/RustSec/advisory-db/issues/539)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Cross-compiling Rust to s390x yields a faulty toolchain" [rust#80810](https://github.com/rust-lang/rust/issues/80810)
+  - Opened by [Jakob-Naucke](https://github.com/Jakob-Naucke)
+  - not yet assigned
+  - seems to affect specific s390x or to be related to endianess
+  - @**Santiago Pastorino** [suggests testing again](https://github.com/rust-lang/rust/issues/80810#issuecomment-758204892) against PR [#80732](https://github.com/rust-lang/rust/pull/80732) (ready for review)
+- "regression 1.50: Borrow checker reports function param as not living long enough" [rust#80949](https://github.com/rust-lang/rust/issues/80949)
+  - opened by @**rylev**, emerged in crater run for 1.50
+  - [Smallest MCVE found](https://github.com/rust-lang/rust/issues/80949#issuecomment-759432282) points to PR [#78373](https://github.com/rust-lang/rust/pull/78373)
+  - @**Matthew Jasper** mentions that pr #78373 [is possibly leading to a less precise borrowcheck](https://github.com/rust-lang/rust/issues/80949#issuecomment-760019484) on how long the borrow lasts
+- "regression 1.50: deny after forbid breaks build" [rust#80988](https://github.com/rust-lang/rust/issues/80988)
+  - Opened by @**rylev**, emerged in crater run for 1.50 
+  - possibly related to issue [#77713](https://github.com/rust-lang/rust/issues/77713)
+  - @**simulacrum** self assigns this issue and points to PR [#78864](https://github.com/rust-lang/rust/pull/78864) ~~and check that against the crates breaking in this issue~~ going to figure out if the regressions here seem expected and nominate for t-lang probably
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+[2021-01-12 Triage full report](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-01-12.md)
+
+Overall, a positive albeit quiet week. The largest change came from the incremental compilation working group which delivered large gains in performance caused by [changes](https://github.com/rust-lang/rust/issues/76896) in how inlining is handled in debug mode. Unfortunately, these changes may be reversed due to concerns.
+
+Triage done by **@rylev**.
+
+1 Regressions, 2 Improvements, 3 Mixed 2 of them in rollups
+
+#### Regressions
+
+Rollup of 9 pull requests [#80867](https://github.com/rust-lang/rust/issues/80867)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7a193921a024e910262ff90bfb028074fddf20d0&end=34628e5b533d35840b61c5db0665cf7633ed3c5a&stat=instructions:u) (up to 1.7% on `incr-full` builds of `syn-opt`)
+- Minor regressions in mostly incremental builds (both opt and debug).
+- It's hard to tell which PR was responsible but [#79968](https://github.com/rust-lang/rust/pull/79968/) seems to be the most likely. We will investigate.
+- There was a change in the `impl_trait_ref` which may give hints as to the root cause.
+
+#### Improvements
+
+- Rollup of 9 pull requests [#80928](https://github.com/rust-lang/rust/issues/80928)
+- Do not query the HIR directly in `opt_associated_item`. [#80889](https://github.com/rust-lang/rust/issues/80889)
+
+#### Mixed
+
+- Do not make local copies of inline fns in debug mode [#76896](https://github.com/rust-lang/rust/issues/76896)
+- ast: Remove some indirection layers from values in key-value attributes [#80441](https://github.com/rust-lang/rust/issues/80441)
+- Serialize incr comp structures to file via fixed-size buffer [#80463](https://github.com/rust-lang/rust/issues/80463)
+
+#### Nags requiring follow up
+
+- Follow up needs to happen on the regressions, especially on the rollup [#80928](https://github.com/rust-lang/rust/issues/80928) and [#80441](https://github.com/rust-lang/rust/issues/80441) where the performance regressed from an early perf run done while the PR was still open.
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-01-21.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-01-21.md
@@ -1,0 +1,200 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-01-21
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "MCP: move compiler/ crates to stable Rust" [compiler-team#358](https://github.com/rust-lang/compiler-team/issues/358)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+- Accepted MCPs
+  - "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+- Finalized FCPs (disposition merge)
+  - [T-compiler,T-infra,T-release] "Drop official support for Windows XP" [compiler-team#378](https://github.com/rust-lang/compiler-team/issues/378)
+  - [T-libs] "Tracking Issue for `panic_any`" [rust#78500](https://github.com/rust-lang/rust/issues/78500)
+
+### WG checkins
+
+@*WG-traits* checkin by @nikomatsakis and @Jack Huey:
+
+> Last week we held a meeting to discuss our next steps. 
+> We were looking specifically at "async fn in traits" and what it would take to support that within the compiler.
+> We identified a path of incremental support by enabling other features.
+> There are [meeting notes](https://hackmd.io/j8KTAWU2TzC-STlsB8ZSVQ) available here and a recording will be posted.
+> We've also been making progress towards refactoring and type library work;
+> the [2021-01-12 meeting](https://zulip-archive.rust-lang.org/144729wgtraits/40141meeting20210112.html)
+> contains a good summary. -nikomatsakis
+> We're also planning to try out the "sprint week" instead of the 6 week sprints we have been using so far. We haven't set the dates yet, though.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Make hitting the recursion limit in projection non-fatal" [rust#81055](https://github.com/rust-lang/rust/pull/81055)
+  - Opened by @**Matthew Jasper**
+  - Assigned to @**nikomatsakis** not yet r'ed
+  - This patch goes with merged PR [#80953](https://github.com/rust-lang/rust/issues/80953) (infinite loop bug in caching normalization of projections) making reaching the recursion limit not fatal.
+  - This should fix regression not caught in [the crater run](https://github.com/rust-lang/rust/issues/80953#issuecomment-759347129) and appeared in stable 1.49 and that breaks compiling production code
+  - related to PR [#80246](https://github.com/rust-lang/rust/pull/80246) already merged
+
+- "rustc_parse_format: Fix character indices in find_skips" [rust#81071](https://github.com/rust-lang/rust/pull/81071)
+  - opened by @**osa1** 
+  - fixes [#81006](https://github.com/rust-lang/rust/issues/81006), a `P-medium` issue, incorrect format string/argument mismatch triggering an ICE 
+  - r'ed by @**Esteban Küber**, [suggests beta backport](https://github.com/rust-lang/rust/pull/81071#issuecomment-761605595) to deploy the patch sooner and reduce user experiencing this error
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Make hitting the recursion limit in projection non-fatal" [rust#81055](https://github.com/rust-lang/rust/pull/81055)
+  - same as beta nomination 
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "MIR-OPT: Pass to deduplicate blocks" [rust#77551](https://github.com/rust-lang/rust/pull/77551)
+  - @**oli** has some thoughts about [merging this PR](https://github.com/rust-lang/rust/pull/77551#issuecomment-721142677) (the performance diff seems to be a net negative)
+  - [previous discussion](https://github.com/rust-lang/rust/pull/77551#issuecomment-752986652)
+  - @**oli** suggests to [put it into mir-opt-level=3 and merge](https://github.com/rust-lang/rust/pull/77551#issuecomment-753640105), then re-evaluate the spans and other performance improvements
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [60 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [38 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 3 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 0 P-high, 6 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 38 P-high, 84 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Cross-compiling Rust to s390x yields a faulty toolchain" [rust#80810](https://github.com/rust-lang/rust/issues/80810)
+  - Opened by [Jakob-Naucke](https://github.com/Jakob-Naucke)
+  - Assigned to @**pnkfelix**
+  - mentioned last week
+  - seems to affect specific s390x or to be related to endianess
+  - Need to checked against PR [#80732](https://github.com/rust-lang/rust/pull/80732) (ready for review)
+- "regression 1.50: Borrow checker reports function param as not living long enough" [rust#80949](https://github.com/rust-lang/rust/issues/80949)
+  - opened by @**rylev**, emerged in crater run for 1.50
+  - [Smallest MCVE found](https://github.com/rust-lang/rust/issues/80949#issuecomment-759432282) points to PR [#78373](https://github.com/rust-lang/rust/pull/78373)
+  - @**Matthew Jasper** comments that pr #78373 [caused MIR to have one fewer basic block](https://github.com/rust-lang/rust/issues/80949#issuecomment-760019484) which reduced borrowck precision
+  - @**Matthew Jasper** added [more details to the PR](the question of a revert for later, after we get more data about impact regression has on ecosystem)
+- "regression 1.50: deny after forbid breaks build" [rust#80988](https://github.com/rust-lang/rust/issues/80988)
+  - Opened by @**rylev**, emerged in crater run for 1.50 
+  - possibly related to issue [#77713](https://github.com/rust-lang/rust/issues/77713)
+  - @**simulacrum** self assigns this issue, points to PR [#78864](https://github.com/rust-lang/rust/pull/78864) and figures out [the root cause](https://github.com/rust-lang/rust/issues/80988#issuecomment-761622611)
+  - discussed in the [T-lang meeting](https://github.com/rust-lang/rust/issues/80988#issuecomment-763096218), the decision would be to close this
+  - @**pnkfelix** [comments](https://github.com/rust-lang/rust/issues/80988#issuecomment-763874759) that the specific issue discussed in the RFC is probably best dealt in issue [#81218](https://github.com/rust-lang/rust/issues/81218)
+- "beta regression: forbid(warnings) interacts poorly with common derives." [rust#81218](https://github.com/rust-lang/rust/issues/81218)
+    - see :point_up_2: but to address specifically `forbid` and `derive` interacting surprisingly
+
+## Performance logs
+
+[2021-01-20 Triage full log](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-01-20.md)
+
+A busy week with more performance gains than regressions. These changes included one very large [perf gain](https://github.com/rust-lang/rust/issues/79670) and one very large [perf regression](https://github.com/rust-lang/rust/issues/78407) in stress test benchmarks that seem to only produce mild perf changes in real world use cases. 
+
+Triage done by **@rylev**.
+
+3 Regressions, 5 Improvements, 4 Mixed
+2 of them in rollups
+
+#### Regressions
+
+Use tcx.symbol_name when determining clashing extern declarations. [#80009](https://github.com/rust-lang/rust/issues/80009)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=704e47f78b4c8801a3c76f235a5a152e1b60b300&end=7a9b552cb1621c9c57898d147228aab32b65a7c3&stat=instructions:u) (up to 1.3% on `incr-full` builds of `externs-check`)
+- Fix for [overeager warning in clashing extern declarations](https://github.com/rust-lang/rust/issues/79581).
+- Unsure how much performance can be gained back but an allocation is occuring that isn't strictly necessary. Perhaps removing it will help.
+- PR author was pinged about the regression [here](https://github.com/rust-lang/rust/pull/80009#issuecomment-763526902)
+
+Update cargo [#80974](https://github.com/rust-lang/rust/issues/80974)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=18ec4a9a74731ddc6a453ca29c0836f61dbcb8d4&end=e48eb37b9470a26748c916f7153569906f3c67bf&stat=instructions:u) (up to 5.2% on `incr-unchanged` builds of `token-stream-stress-opt`)
+- Purely an update of Cargo. Not sure why this is causing issues.
+
+implement ptr::write without dedicated intrinsic [#80290](https://github.com/rust-lang/rust/issues/80290)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=63a83c5f55801b17b77adf690db397d17c706c48&end=492b83c6971c390af7a42932869502224ef55ef7&stat=instructions:u) (up to 1.2% on `full` builds of `regex-debug`)
+- Small regex-debug full builds regression specifically in the `LLVM_module_codegen_emit_obj` query. This largely affects debug builds due to this previously being an instrinsic but now requiring LLVM to optimize it to its previously efficient form.
+- An idea for gaining the performance back can be found [here](https://github.com/rust-lang/rust/pull/80290#issuecomment-763583590)
+
+#### Improvements
+
+- Turn type inhabitedness into a query to fix `exhaustive_patterns` perf [#79670](https://github.com/rust-lang/rust/issues/79670)
+- Reintroduce hir::ExprKind::If [#79328](https://github.com/rust-lang/rust/issues/79328)
+- Use probe-stack=inline-asm in LLVM 11+ [#77885](https://github.com/rust-lang/rust/issues/77885)
+- Try to avoid locals when cloning into Box/Rc/Arc [#80824](https://github.com/rust-lang/rust/issues/80824)
+- BTreeMap: convert search functions to methods [#81159](https://github.com/rust-lang/rust/issues/81159)
+
+#### Mixed
+
+- Make CTFE able to check for UB... [#78407](https://github.com/rust-lang/rust/issues/78407)
+- Rollup of 10 pull requests [#80960](https://github.com/rust-lang/rust/issues/80960)
+- Rollup of 13 pull requests [#81113](https://github.com/rust-lang/rust/issues/81113)
+- Remove PredicateKind and instead only use Binder<PredicateAtom> [#80679](https://github.com/rust-lang/rust/issues/80679)
+
+#### Nags requiring follow up
+
+* Still need a follow up to one of last weeks [perf regressions](https://github.com/rust-lang/rust/pull/80441)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)
+  - [review by](https://github.com/rust-lang/rfcs/pull/3013#pullrequestreview-568757930) by @**Wesley Wiser** 
+  - RFC author implemented new suggestions

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-01-28.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-01-28.md
@@ -1,0 +1,224 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-01-28
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "refactor the unsafe checking to work on the THIR" [compiler-team#402](https://github.com/rust-lang/compiler-team/issues/402)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Stabilize `Seek::stream_position` (feature `seek_convenience`)" [rust#70904](https://github.com/rust-lang/rust/pull/70904)
+  - [T-compiler] "rustc: Stabilize `-Zrun-dsymutil` as `-Csplit-debuginfo`" [rust#79570](https://github.com/rust-lang/rust/pull/79570)
+  - [T-libs] "Stabilize `unsigned_abs`" [rust#80959](https://github.com/rust-lang/rust/pull/80959)
+
+### WG checkins
+
+@*WG-async-foundations*  by @**nikomatsakis** and @**tmandry**:
+* currently in a planning phase for the coming year, see [2021 roadmap topic](https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async-foundations/topic/2021.20roadmap)
+* have some pending RFCs (stream trait, warnings about types that ought not to be live over yield)
+* nikomatsakis is working on an [async vision document](https://hackmd.io/p6cmRZ9ZRQ-F1tlhGaN9rg) and interested in [getting feedback](https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async-foundations/topic/2021.20roadmap/near/224241416)
+
+@*WG-diagnostics* by @**Esteban Küber** and @**oli** :
+* @**Esteban Küber** and @**oli** (soon) have much more time for diagnostics
+* cross-await-borrow-failure explanation: #80614
+* move in method call in loop explanation:  #80324
+* [internal] document diagnostics infrastructure:  #80046
+* take negative impls into account for "trait item not found" errors: #79790
+* improve attribute spans for diagnostics on attributes: #79509
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Revert 78373 ("dont leak return value after panic in drop")" [rust#81257](https://github.com/rust-lang/rust/pull/81257)
+  - This revert [#78373](https://github.com/rust-lang/rust/pull/78373), as per [last week's discussion](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202021-01-21.20.2354818/near/223526167)
+  - Is being reviewed
+- "parser: Collect tokens for values in key-value attributes" [rust#81337](https://github.com/rust-lang/rust/pull/81337)
+  - opened by @**Vadim Petrochenkov** 
+  - approved by @**Aaron Hill** 
+  - Fixes [rust#81208](https://github.com/rust-lang/rust/issues/81208), a `P-medium` issue where a non-ASCII string in the `#[path]` attribute raised an ICE
+
+:back: :shrug: :hand:
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3Alibs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- "rustdoc: Fix visibility of trait and impl items" [rust#81288](https://github.com/rust-lang/rust/pull/81288)
+  - Opened by @**Camelid**
+  - r'ed and approved by @_**Joshua Nelson**
+  - Fixes part of [#81274](https://github.com/rust-lang/rust/issues/81274), where documentation does not show as `pub` the `next()` method from Iterator (and other Traits) 
+
+:back: :shrug: :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Make hitting the recursion limit in projection non-fatal" [rust#81055](https://github.com/rust-lang/rust/pull/81055)
+  - opened by @**Matthew Jasper**
+  - assigned to @**nikomatsakis** not yet approved
+  - Fixes [rust#80953](https://github.com/rust-lang/rust/issues/80953), a regression discovered the crater run for 1.50 that impacted 
+  - approved for beta backport, [stable backport was left open to discussion last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202021-01-21.20.2354818/near/223524147)
+
+:back: :shrug: :hand:
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3Alibs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Restore .editorconfig" [rust#81260](https://github.com/rust-lang/rust/pull/81260)
+    - opened by [vn971](https://github.com/vn971)
+    - Looks like the `.editorconfig` (a suggest file for text editors on how to handle code) was unintentionally removed. 
+    - @**simulacrum** inclined to merge if no concerns, what's the general opinion on adding it back?
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [64 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [39 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 5 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 3 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 40 P-high, 89 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3Alibs-impl)
+- "File implementation on Windows has unsound methods" [rust#81357](https://github.com/rust-lang/rust/issues/81357)
+  - an unsoundness on how Rust handles the Windows I/O API, should be probably marked as critical. we don't have a MVCE from a Windows user, but possibly it's been there since long time. 
+  - [libs meeting report](https://github.com/rust-lang/rust/issues/81357#issuecomment-768607504) by @**Ashley Mannix**: seems the consensus is ack one of the options suggested by the issue reporter (call `GetOverlappedResult` and if it returns error, call `abort()`)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Cross-compiling Rust to s390x yields a faulty toolchain" [rust#80810](https://github.com/rust-lang/rust/issues/80810)
+  - Opened by [Jakob-Naucke](https://github.com/Jakob-Naucke)
+  - discussed last week, @**pnkfelix** self-assigned
+  - seems to affect specifically s390x or to be related to endianess
+  - Issue not yet completely clear, could be checked against PR [#80732](https://github.com/rust-lang/rust/pull/80732) (not ready for merge yet)
+  - @**cuviper** comments that this issue [could also be unrelated to endianess](https://github.com/rust-lang/rust/issues/80810#issuecomment-761253970)
+- "regression 1.50: Borrow checker reports function param as not living long enough" [rust#80949](https://github.com/rust-lang/rust/issues/80949)
+  - opened by @**rylev**, emerged in crater run for 1.50
+  - [Smallest MCVE found](https://github.com/rust-lang/rust/issues/80949#issuecomment-759432282) points to PR [#78373](https://github.com/rust-lang/rust/pull/78373)
+  - @**Matthew Jasper** comments that pr #78373 [caused MIR to have one fewer basic block](https://github.com/rust-lang/rust/issues/80949#issuecomment-760019484) which reduced borrowck precision
+  - @**Matthew Jasper** added [additional details ](https://github.com/rust-lang/rust/issues/80949#issuecomment-760417066)
+  - @**pnkfelix** is working on PR [rust#81257](https://github.com/rust-lang/rust/pull/81257) to revert [rust#78373](https://github.com/rust-lang/rust/pull/78373) and fix this issue
+- "regression 1.50: deny after forbid breaks build" [rust#80988](https://github.com/rust-lang/rust/issues/80988)
+  - Opened by @**rylev**, emerged in crater run for 1.50 
+  - Assigned to @**pnkfelix**
+  - possibly related to issue [#77713](https://github.com/rust-lang/rust/issues/77713)
+  - @**simulacrum** points to PR [#78864](https://github.com/rust-lang/rust/pull/78864) and figures out [the root cause](https://github.com/rust-lang/rust/issues/80988#issuecomment-761622611)
+  - discussed in the [T-lang meeting](https://github.com/rust-lang/rust/issues/80988#issuecomment-763096218), the decision would be to close this
+  - @**pnkfelix** [comments](https://github.com/rust-lang/rust/issues/80988#issuecomment-763874759) that the specific issue discussed in the RFC is probably best dealt in issue [#81218](https://github.com/rust-lang/rust/issues/81218)
+  - ***entered in final-comment-period as disposition closed***
+- "beta regression: forbid(warnings) interacts poorly with common derives." [rust#81218](https://github.com/rust-lang/rust/issues/81218)
+    - Spawned from above issue [rust#80988](https://github.com/rust-lang/rust/issues/80988) ([discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202021-01-21.20.2354818/near/223527544)) to address specifically `forbid` and `derive` interacting surprisingly
+    - @**simulacrum** [added some comments](https://github.com/rust-lang/rust/issues/81218#issuecomment-766500893) after last week's discussion
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- "Breaking change in wasm32-unknown-unknown's ABI on nightly" [rust#81386](https://github.com/rust-lang/rust/issues/81386)
+    - opened by @**Alex Crichton** 
+    - he points to PR [rust#80594](https://github.com/rust-lang/rust/pull/80594) (cc: @**Vadim Petrochenkov**)
+    - @**bjorn3** has worked on PR [rust#81388](https://github.com/rust-lang/rust/pull/81388) for a possible fix, needs a review
+
+## Performance logs
+
+> [2020-01-26 Triage full logs](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-01-26.md)
+
+This week continues a trend of relatively large rollups, which often contain perf-sensitive PRs. We need to get better at marking PRs as rollup=never or otherwise not including them, but it is unclear how precisely to go about doing so. The tooling for testing individual PRs merged in rollups should also be improved to work better in the next few days, though.
+
+Other than that, this week saw several regressions, most of which were not easily explained. We are seeking feedback from PR authors and reviewers on whether the results are expected and if anything can be done.
+
+Triage done by **@rylevick** and **@simulacrum**.
+
+5 Regressions, 2 Improvements, 1 Mixed;
+3 of them in rollups
+
+#### Regressions
+
+Deprecate-in-future the constants superceded by RFC 2700 [#80958](https://github.com/rust-lang/rust/issues/80958)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=57a71ac0e17e4f7070b090ab7bdc5474d8e37ecc&end=339e19697a39a78f4d669c217b7d21109215de41&stat=instructions:u) (up to 2.4% on `incr-patched: Job` builds of `regex-check`)
+- Unsure why this might be causing performance regressions as this change does not touch much code and only produces lint warnings when the user opts into them.
+- The author of the PR [was asked why this might be the case](https://github.com/rust-lang/rust/pull/80958#issuecomment-767837811), and a nag noted.
+
+Rollup of 11 pull requests [#81240](https://github.com/rust-lang/rust/issues/81240)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=339e19697a39a78f4d669c217b7d21109215de41&end=a243ad280a4ac57c1b8427e30e31c5b505cf10de&stat=instructions:u) (up to 2.0% on `full` builds of `keccak-check`)
+- Revert kicked off [here](https://github.com/rust-lang/rust/pull/81420) to test a possible culprit in [#81178](https://github.com/rust-lang/rust/pull/81178).
+
+Generate metadata by iterating on DefId instead of traversing the HIR tree 1/N [#80919](https://github.com/rust-lang/rust/issues/80919)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=446cbc9db080c63c8742c418bcaa44c808f7e033&end=85e355ea9bd86ac6580a5d422a65dbf689845808&stat=instructions:u) (up to 1.0% on `incr-patched: println` builds of `style-servo-check`)
+- Contact the PR author to see why the perf regressions were not discussed in the initial PR (even though perf runs were done). Waiting on [their response](https://github.com/rust-lang/rust/pull/80919#issuecomment-767854932).
+
+Rollup of 14 pull requests [#81355](https://github.com/rust-lang/rust/issues/81355)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=1d0d76f8dd4f5f6ecbeab575b87edaf1c9f56bb8&end=d3163e96553ae8cb1fca0e62084b124e8b98310b&stat=instructions:u) (up to 12.6% on `full` builds of `deeply-nested-async-debug`)
+
+Prevent query cycles in the MIR inliner [#68828](https://github.com/rust-lang/rust/issues/68828)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7fba12bb1d3877870758a7a53e2fe766bb19bd60&end=f4eb5d9f719cd3c849befc8914ad8ce0ddcf34ed&stat=instructions:u) (up to 2.1% on `full` builds of `keccak-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=7fba12bb1d3877870758a7a53e2fe766bb19bd60&end=f4eb5d9f719cd3c849befc8914ad8ce0ddcf34ed&stat=instructions:u) (up to -1.8% on `full` builds of `ctfe-stress-4-check`)
+- Nag filed
+
+#### Improvements
+
+- Visit only terminators when removing unneeded drops [#81122](https://github.com/rust-lang/rust/issues/81122)
+- Rollup of 15 pull requests [#81304](https://github.com/rust-lang/rust/issues/81304)
+
+#### Mixed
+
+- mark raw_vec::ptr with inline [#79113](https://github.com/rust-lang/rust/issues/79113)
+
+#### Nags requiring follow up
+
+- Deprecate in future regression [#80958](https://github.com/rust-lang/rust/pull/80958#issuecomment-767837811)
+- Waiting on [response](https://github.com/rust-lang/rust/pull/80919#issuecomment-767854932) to inquiry.
+- Regression in prevent query cycles in the MIR inliner - expected? [#68828](https://github.com/rust-lang/rust/pull/68828#issuecomment-767872361)
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "split dwarf doesn't work with crate dependencies" [rust#81024](https://github.com/rust-lang/rust/issues/81024)
+  - Mentioning @**davidtwco** [message on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/split.20dwarf.20and.20dependencies)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3Alibs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)
+  - [review by](https://github.com/rust-lang/rfcs/pull/3013#pullrequestreview-568757930) by @**Wesley Wiser** 
+  - RFC author implemented new suggestions

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-02-04.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-02-04.md
@@ -1,0 +1,255 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-02-04
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow at <time:2021-02-05T12:00:00-03:00> Compiler Team Design Meeting: [perf.lo site review](https://github.com/rust-lang/compiler-team/issues/389)
+- Next Thursday **February, the 11th**: release of next stable 1.50 
+- 🎉 [David Wood and Jack Huey are now compiler team members](https://github.com/rust-lang/team/pull/525) 🎉
+- New MCPs (take a look, see if you like them!)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Add 32-bit and 64-bit stderr/stdout files for ui tests" [compiler-team#365](https://github.com/rust-lang/compiler-team/issues/365)
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "refactor the unsafe checking to work on the THIR" [compiler-team#402](https://github.com/rust-lang/compiler-team/issues/402)
+  - "Distribute rustc_codegen_cranelift as rustup component" [compiler-team#405](https://github.com/rust-lang/compiler-team/issues/405)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - [T-libs] "Tracking Issue for feature(int_bits_const): <integer>::BITS" [rust#76904](https://github.com/rust-lang/rust/issues/76904)
+  - [T-libs] "Implement io::Seek for io::Empty" [rust#78044](https://github.com/rust-lang/rust/pull/78044)
+  - [T-libs] "Stabilize Arc::{increment,decrement}_strong_count" [rust#79285](https://github.com/rust-lang/rust/pull/79285)
+  - [T-libs] "Stabilize `peekable_next_if`" [rust#80011](https://github.com/rust-lang/rust/pull/80011)
+  - [T-libs] "stabilise `cargo test -- --include-ignored`" [rust#80053](https://github.com/rust-lang/rust/pull/80053)
+  - [T-libs] "Implement missing `AsMut<str>` for `str`" [rust#80279](https://github.com/rust-lang/rust/pull/80279)
+  - [T-libs] "Stabilize by-value `[T; N]` iterator `core::array::IntoIter`" [rust#80470](https://github.com/rust-lang/rust/pull/80470)
+  - [T-libs] "Add Box::downcast() for dyn Any + Send + Sync" [rust#80945](https://github.com/rust-lang/rust/pull/80945)
+  - [T-libs] "Stabilize `core::slice::fill_with`" [rust#81048](https://github.com/rust-lang/rust/pull/81048)
+  - [T-libs] "Remove requirement that forces symmetric and transitive PartialEq impls to exist" [rust#81198](https://github.com/rust-lang/rust/pull/81198)
+### WG checkins
+
+- @*WG-rustc-dev-guide* by @**Santiago Pastorino**
+>- 🎉 New members! [@camelid](https://github.com/rust-lang/team/pull/504), [@igaray](https://github.com/rust-lang/team/pull/503) and [@rylev](https://github.com/rust-lang/team/issues/532) joined the WG 🎉
+>- We are starting to plan on working on a walkthrough section. That would be a section of the guide where we show Rust code and show what the compiler is doing and how is transforming the data.
+>- There are [41 merged PRs since our last check-in](https://github.com/rust-lang/rustc-dev-guide/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc+updated%3A%3E2020-12-10+) and [4 WIP PRs](https://github.com/rust-lang/rustc-dev-guide/pulls)
+>
+>### Most notable changes
+>
+>- Document how to stabilize a library feature [#1036](https://github.com/rust-lang/rustc-dev-guide/pull/1036)
+>- Note that `x.py check` now allows using any stage [#1025](https://github.com/rust-lang/rustc-dev-guide/pull/1025)
+>- Add a note about UI test entry limitation [#1019](https://github.com/rust-lang/rustc-dev-guide/pull/1019)
+>- Make instructions for configuring compiler for debug more explicit [#1005](https://github.com/rust-lang/rustc-dev-guide/pull/1005)
+>- Clarify that `check` uses a different stage than `build` [#999](https://github.com/rust-lang/rustc-dev-guide/pull/999)
+>- Update logging section and explain `RUSTC_LOG_COLOR` [#997](https://github.com/rust-lang/rustc-dev-guide/pull/997)
+>- [Fixes #778] Added and reorganized lecture links [#993](https://github.com/rust-lang/rustc-dev-guide/pull/993)
+>- Document `error-pattern` header [#989](https://github.com/rust-lang/rustc-dev-guide/pull/989)
+>
+>### Most notable WIPs
+>
+>- Add chapter on libs and metadata. [#1044](https://github.com/rust-lang/rustc-dev-guide/pull/1044)
+>- Document lang items [#978](https://github.com/rust-lang/rustc-dev-guide/pull/978)
+
+- @*wg-incr-comp* by @**Wesley Wiser**
+> We've restarted our bi-weekly meetings after skipping a few at the end of last year for the holidays.
+>
+> There's been a lot of work around the incremental/query system in rustc recently:
+>
+>   - @cjgillot has been working on moving HIR attributes into a side table instead of storing them directly on various HIR types with the goal of reducing incr-comp invalidations due to attributes changing. [#79519](https://github.com/rust-lang/rust/pull/79519)
+>   - @tgnottingham has been doing a lot of work to reduce memory usage, improve performance and improve code quality :tada: [#80957](https://github.com/rust-lang/rust/pull/80957), [#80602](https://github.com/rust-lang/rust/pull/80602), [#80463](https://github.com/rust-lang/rust/pull/80463), [#80177](https://github.com/rust-lang/rust/pull/80177) and [#79589](https://github.com/rust-lang/rust/pull/79589)
+>   - @mw has been experimenting with writing a hash table that uses the same binary representation both on disk and in-memory with goal of reducing serialization and deserialization costs for the `DefPathTable`. [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/241847-t-compiler.2Fwg-incr-comp/topic/Lazy.20DefPathTable.20decoding), [hash table implementation](https://github.com/michaelwoerister/odht)
+>
+> We've also spent some time discussing ideas for the upcoming compiler team sprint which we will continue doing.
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Remove incorrect `delay_span_bug`" [rust#81532](https://github.com/rust-lang/rust/pull/81532)
+    - opened by @**Esteban Küber**, not yet r'ed
+    - Removes invalid `delay_span_bug` that was introduced in [rust#70998](https://github.com/rust-lang/rust/pull/70998)
+    - Nominated for beta and stable
+    - @**pnkfelix** r+'ed
+- "introduce future-compatibility warning for forbidden lint groups" [rust#81556](https://github.com/rust-lang/rust/pull/81556)
+    - opened by @**nikomatsakis**
+    - @**pnkfelix** r+'ed
+    - `Explanation` section is missing in documentation, causing the [build errors](https://github.com/rust-lang/rust/pull/81556#issuecomment-770230801)
+    - Fixes two `P-high` regressions, [rust#80988](https://github.com/rust-lang/rust/issues/80988), [rust#81218](https://github.com/rust-lang/rust/issues/81218) caused by [rust#78864](https://github.com/rust-lang/rust/pull/78864)
+
+:back: / :shrug: / :hand:
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl)
+- No beta nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Remove incorrect `delay_span_bug`" [rust#81532](https://github.com/rust-lang/rust/pull/81532)
+    - See above in "Beta-nominations"
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No stable nominations for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [63 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [38 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 5 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 37 P-high, 88 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- "File implementation on Windows has unsound methods" [rust#81357](https://github.com/rust-lang/rust/issues/81357)
+  - an unsoundness on how Rust handles the Windows I/O API, should be probably marked as critical. we don't have a MVCE from a Windows user, but possibly it's been there since long time. 
+  - [libs meeting report](https://github.com/rust-lang/rust/issues/81357#issuecomment-768607504) by @**Ashley Mannix**: seems the consensus is ack one of the options suggested by the issue reporter (call `GetOverlappedResult` and if it returns error, call `abort()`)
+  - not yet assigned, @**Arlie Davis**  [volunteered last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202021-01-28.20.2354818/near/224342001) to have a look at it
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Cross-compiling Rust to s390x yields a faulty toolchain" [rust#80810](https://github.com/rust-lang/rust/issues/80810)
+  - Opened by [Jakob-Naucke](https://github.com/Jakob-Naucke)
+  - previously discussed, assigned to @**pnkfelix**
+  - Note: this issue is up for grab for anyone willing to follow it up
+  - seems to affect specifically s390x or to be related to endianess
+  - Issue not yet completely clear, could be checked against PR [#80732](https://github.com/rust-lang/rust/pull/80732) (not ready for merge yet)
+  - @**cuviper** comments that this issue [could also be unrelated to endianess](https://github.com/rust-lang/rust/issues/80810#issuecomment-761253970)
+- "regression 1.50: Duplicate symbol linker error" [rust#80951](https://github.com/rust-lang/rust/issues/80951)
+    - opened by @**rylev** 
+    - regression on crate [utxo-oracle](https://github.com/devrandom/utxo-oracle) that compiled on 1.49 (see [logs](https://crater-reports.s3.amazonaws.com/beta-1.50-1/beta-2021-01-01/gh/devrandom.utxo-oracle/log.txt))
+    - @**Frank Steffahn** adds that [doesn't look like a genuine regression](https://github.com/rust-lang/rust/issues/80951#issuecomment-768602173)
+    - @**apiraino** asks (out of curiosity): the crate imports a bitcoin library, the project does not seems very active and the [scope is unclear](https://github.com/devrandom/utxo-oracle/blob/master/src/main.rs) to me. Worth checking when was this crate added and why? Does it have specific code to be monitored between releases?
+- "regression 1.50: Borrow checker reports function param as not living long enough" [rust#80949](https://github.com/rust-lang/rust/issues/80949)
+  - opened by @**rylev**, emerged in crater run for 1.50
+  - [Smallest MCVE found](https://github.com/rust-lang/rust/issues/80949#issuecomment-759432282) points to PR [#78373](https://github.com/rust-lang/rust/pull/78373)
+  - @**Matthew Jasper** comments that pr #78373 [caused MIR to have one fewer basic block](https://github.com/rust-lang/rust/issues/80949#issuecomment-760019484) which reduced borrowck precision
+  - @**Matthew Jasper** added [additional details ](https://github.com/rust-lang/rust/issues/80949#issuecomment-760417066)
+  - @**pnkfelix** is working on PR [rust#81257](https://github.com/rust-lang/rust/pull/81257) to revert [rust#78373](https://github.com/rust-lang/rust/pull/78373) and fix this issue
+- "regression 1.50: deny after forbid breaks build" [rust#80988](https://github.com/rust-lang/rust/issues/80988)
+  - Opened by @**rylev**, emerged in crater run for 1.50 
+  - Assigned to @**pnkfelix**
+  - possibly related to issue [#77713](https://github.com/rust-lang/rust/issues/77713)
+  - @**simulacrum** points to PR [#78864](https://github.com/rust-lang/rust/pull/78864) and figures out [the root cause](https://github.com/rust-lang/rust/issues/80988#issuecomment-761622611)
+  - discussed in the [T-lang meeting](https://github.com/rust-lang/rust/issues/80988#issuecomment-763096218), the decision would be to close this
+  - @**pnkfelix** [comments](https://github.com/rust-lang/rust/issues/80988#issuecomment-763874759) that the specific issue discussed in the RFC is probably best dealt in issue [#81218](https://github.com/rust-lang/rust/issues/81218)
+  - ***final-comment-period is canceled***
+  - will be a future-incompatibility warning, @**nikomatsakis** is working on make it so
+- "beta regression: forbid(warnings) interacts poorly with common derives." [rust#81218](https://github.com/rust-lang/rust/issues/81218)
+    - Spawned from above issue [rust#80988](https://github.com/rust-lang/rust/issues/80988) ([discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202021-01-21.20.2354818/near/223527544)) to address specifically `forbid` and `derive` interacting surprisingly
+    - @**simulacrum** [added some comments](https://github.com/rust-lang/rust/issues/81218#issuecomment-766500893) after last week's discussion
+    - Assigned to @**simulacrum**
+    - same for [rust#80988](https://github.com/rust-lang/rust/issues/80988)  @**nikomatsakis** is working to make it a future-incompatibility warning
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned P-high nightly regressions
+
+## Performance logs
+
+> [2021-02-02 Triage Log](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-02-02.md)
+
+Another week dominated by rollups, most of which had relatively small changes with unclear causes embedded. Overall no major changes in performance this week.
+
+Triage done by **@simulacrum**.
+
+2 Regressions, 1 Improvements, 1 Mixed
+3 of them in rollups
+
+#### Regressions
+
+Rollup of 12 pull requests [#81625](https://github.com/rust-lang/rust/issues/81625)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=70b18bc2cbac4712020019f5bf57c00905373205&end=02b85d722050d61b40ae9746b3bac54ab55b1056&stat=instructions:u) (up to 3.3% on `incr-unchanged` builds of `match-stress-enum-check`)
+- Unclear responsible PR. Nothing in this rollup stands out, and self-profile
+  information does not reveal obvious causes.
+
+Add visitors for checking #[inline] [#80641](https://github.com/rust-lang/rust/issues/80641)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=02b85d722050d61b40ae9746b3bac54ab55b1056&end=d4e3570db4c007089035b833cc20c7fc2f8cb32f&stat=instructions:u) (up to 1.7% on `incr-unchanged` builds of `unicode_normalization-check`)
+- Primarily limited to incremental benchmarks; we are simply visiting more nodes
+  for this check, so it is unsurprising that we take a performance hit.
+
+#### Improvements
+
+- Rollup of 13 pull requests [#81461](https://github.com/rust-lang/rust/issues/81461)
+
+#### Mixed
+
+- Rollup of 10 pull requests [#81493](https://github.com/rust-lang/rust/issues/81493)
+
+#### Nags requiring follow up
+
+From last week:
+
+- Deprecate in future regression [#80958](https://github.com/rust-lang/rust/pull/80958#issuecomment-767837811)
+    - Some commentary in response but seems likely this will not be addressed
+      one way or another.
+- Waiting on [response](https://github.com/rust-lang/rust/pull/80919#issuecomment-767854932) to inquiry.
+    - Some investigation in [#81476](https://github.com/rust-lang/rust/issues/81476), potentially regression was down to a bugfix.
+- Regression in prevent query cycles in the MIR inliner - expected? [#68828](https://github.com/rust-lang/rust/pull/68828#issuecomment-767872361)
+    - No updates yet from  @**oli** on their investigation.
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Demote x86_64-rumprun-netbsd target" [rust#81514](https://github.com/rust-lang/rust/issues/81514)
+    - Demote due to inactivity of the rumprun project
+    - Nominated by @**nagisa**
+- "Adding diesel to the cargetest suite" [rust#81507](https://github.com/rust-lang/rust/issues/81507)
+    - opened by @**weiznich** 
+    - Came up in [rust#79560](https://github.com/rust-lang/rust/issues/79560#issuecomment-767542364)
+    - Last PR to add diesel to cargotest was closed due to a missing FCP policy for cargotest targets
+    - @**pnkfelix** [doesn't want this to be blocked until there's a proper policy](https://github.com/rust-lang/rust/pull/81507#issuecomment-771255829)
+    - @**simulacrum** [considers a temporary policy for this case, e.g. a "T-compiler and T-infra FCP"](https://github.com/rust-lang/rust/pull/81507#issuecomment-771256999)
+
+[libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)
+  - [review by](https://github.com/rust-lang/rfcs/pull/3013#pullrequestreview-568757930) by @**Wesley Wiser** 
+  - RFC author implemented suggestions, waiting for feedback
+
+

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-02-11.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-02-11.md
@@ -1,0 +1,211 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-02-11
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- 🎉 Today, release stable 1.50 🎉  [blog link](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html)
+-  @**rylev** and @**pnkfelix** met regarding perf triage and perf.rust-lang.org. @**pnkfelix** wants to suggest that for any PR that touches something under `compiler/`, have rustbot post comment suggesting that they consider a rust-timer run (and include the syntax for the invocation). Feedback?
+
+### MCP status
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+- Pending FCP requests (check your boxes!)
+  - "Demote x86_64-rumprun-netbsd target" [rust#81514](https://github.com/rust-lang/rust/issues/81514)
+- Things in FCP (make sure you're good with it)
+  - "Distribute rustc_codegen_cranelift as rustup component" [compiler-team#405](https://github.com/rust-lang/compiler-team/issues/405)
+- Accepted MCPs
+  - "Add a `NOOP_METHOD_CALL` lint for methods which should never be directly called" [compiler-team#375](https://github.com/rust-lang/compiler-team/issues/375)
+  - "refactor the unsafe checking to work on the THIR" [compiler-team#402](https://github.com/rust-lang/compiler-team/issues/402)
+- Finalized FCPs (disposition merge)
+  - "Tracking Issue for `partition_point`" [rust#73831](https://github.com/rust-lang/rust/issues/73831)
+  - "Tracking Issue for fmt::Arguments::as_str()" [rust#74442](https://github.com/rust-lang/rust/issues/74442)
+  - "Tracking Issue for feature(int_bits_const): <integer>::BITS" [rust#76904](https://github.com/rust-lang/rust/issues/76904)
+  - "Implement io::Seek for io::Empty" [rust#78044](https://github.com/rust-lang/rust/pull/78044)
+  - "Stabilize Arc::{increment,decrement}_strong_count" [rust#79285](https://github.com/rust-lang/rust/pull/79285)
+  - "Rename Iterator::fold_first to reduce and stabilize it" [rust#79805](https://github.com/rust-lang/rust/pull/79805)
+  - "Stabilize `peekable_next_if`" [rust#80011](https://github.com/rust-lang/rust/pull/80011)
+  - "stabilise `cargo test -- --include-ignored`" [rust#80053](https://github.com/rust-lang/rust/pull/80053)
+  - "Implement missing `AsMut<str>` for `str`" [rust#80279](https://github.com/rust-lang/rust/pull/80279)
+  - "Stabilize by-value `[T; N]` iterator `core::array::IntoIter`" [rust#80470](https://github.com/rust-lang/rust/pull/80470)
+  - "Add Box::downcast() for dyn Any + Send + Sync" [rust#80945](https://github.com/rust-lang/rust/pull/80945)
+  - "Stabilize remaining integer methods as `const fn`" [rust#80962](https://github.com/rust-lang/rust/pull/80962)
+  - "Stabilize `core::slice::fill_with`" [rust#81048](https://github.com/rust-lang/rust/pull/81048)
+  - "Remove requirement that forces symmetric and transitive PartialEq impls to exist" [rust#81198](https://github.com/rust-lang/rust/pull/81198)
+  - "libtest: allow multiple filters" [rust#81356](https://github.com/rust-lang/rust/pull/81356)
+
+### WG checkins
+
+@*WG-llvm* by @**nagisa** and @**Nikita Popov**:
+
+> There has been a bit of movement on the LLVM side:
+> * LLVM no longer assumes forward progress by default. This means that infinite loops, and more importantly, calls to functions with infinite loops, are no longer optimized away. This will fix [#28728](https://github.com/rust-lang/rust/issues/28728).
+>  * Known `noalias` related miscompiles have been fixed by the introduction of `@llvm.experimental.noalias.scope.decl` intrinsics. There might be more issues lurking here, but at least the previous blocker is resolved now. This will fix [#54878](https://github.com/rust-lang/rust/issues/54878).
+> * Incorrect nowrap flags in LSR have been fixed. This will fix [#74498](https://github.com/rust-lang/rust/issues/74498).
+> * fptoui.sat/fptosi.sat intrinsics for saturating float to int conversions have landed. However currently only X86 has optimized codegen. We may switch to these sometime in the future.
+> * MemorySSA-based MemCpyOpt is not enabled by default yet. We can test it under a flag, but due to current pipeline positioning it will have a compile-time cost.
+> * LLVM has switched to the new pass manager by default just after the LLVM 12 cut. This means that we should probably make a serious effort towards making the switch as well, as upstream now only does minimal testing of the legacy pass manager.
+> * There's a PR to [upgrade to LLVM 12](https://github.com/rust-lang/rust/pull/81451). Nikita managed to resolve the issues that came up. There seem to be performance implications in this upgrade (see the task for timing runs).
+
+@*T-compiler/WG-meta* by @**nikomatsakis** , @**davidtwco** and @**Santiago Pastorino** 
+> Checkin text
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "parser: Fix panic in 'const impl' recovery" [rust#81876](https://github.com/rust-lang/rust/pull/81876)
+  - opened by @**osa1**
+  - reviewed by @**Matthew Jasper** 
+  - fixes [rust#81806](https://github.com/rust-lang/rust/issues/81806), a `P-medium` ICE on an invalid 'const' keyword parsing 
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl)
+- No beta nominations for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [66 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [41 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 3 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 38 P-high, 88 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- "File implementation on Windows has unsound methods" [rust#81357](https://github.com/rust-lang/rust/issues/81357)
+  - assigned to @**Arlie Davis**
+  - Note: following @**pnkfelix** [suggestion](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202020-12-31.20.2354818/near/221297038), this issue has been downgraded to `P-high`
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "Cross-compiling Rust to s390x yields a faulty toolchain" [rust#80810](https://github.com/rust-lang/rust/issues/80810)
+  - Opened by [Jakob-Naucke](https://github.com/Jakob-Naucke)
+  - previously discussed, assigned to @**pnkfelix**
+  - Note: this issue is up for grab for anyone willing to follow it up
+  - seems to affect specifically s390x or to be related to endianess
+  - Issue not yet completely clear, could be checked against PR [#80732](https://github.com/rust-lang/rust/pull/80732) (not ready for merge yet)
+  - @**cuviper** comments that this issue [could also be unrelated to endianess](https://github.com/rust-lang/rust/issues/80810#issuecomment-761253970)
+- "regression 1.50: Duplicate symbol linker error" [rust#80951](https://github.com/rust-lang/rust/issues/80951)
+  - opened by @**rylev** 
+  - regression on crate [utxo-oracle](https://github.com/devrandom/utxo-oracle) that compiled on 1.49 (see [logs](https://crater-reports.s3.amazonaws.com/beta-1.50-1/beta-2021-01-01/gh/devrandom.utxo-oracle/log.txt))
+  - @**Frank Steffahn** adds that [doesn't look like a genuine regression](https://github.com/rust-lang/rust/issues/80951#issuecomment-768602173)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [2021-02-09 full triage logs](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-02-09.md)
+
+A week of more regressions than improvements with one fairly large regression in `incr-patched` benchmarks introduced in a rollup. Performance regressions introduced in rollups have been a source of headache lately and something the performance team is looking to improve in the future. 
+
+Triage done by **@rylev**.
+
+5 Regressions, 2 Improvements, 1 Mixed
+2 of them in rollups
+
+#### Regressions
+
+Rollup of 11 pull requests [#81660](https://github.com/rust-lang/rust/issues/81660)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f6cb45ad01a4518f615926f39801996622f46179&end=a3ed564c130ec3f19e933a9ea31faca5a717ce91&stat=instructions:u) (up to 33.1% on `incr-patched: println` builds of `cargo-check`)
+- A huge performance regression in a rollup which should not happen. This seems to be happening in `incr-patched` benchmarks in the `typeck` and `evaluate_obligation`.
+- This points towards to [#80629](https://github.com/rust-lang/rust/pull/80629) as being the most likely culprit.
+
+Add a new ABI to support cmse_nonsecure_call [#81346](https://github.com/rust-lang/rust/issues/81346)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e6a0f3cdf3801394a53ffa42683385d94b02c772&end=b593389edbaa9ea0c90f0ed419283842f534e50a&stat=instructions:u) (up to 1.9% on `full` builds of `deeply-nested-async-check`)
+- Adding support for an additional ABI shouldn't have performance implications on rustc. Perhaps this just happens to be noise, but it's hard to tell.
+
+Identify unreachable subpatterns more reliably [#80632](https://github.com/rust-lang/rust/issues/80632)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5a5f3a980c0d2afd55f2162300339471378e341f&end=36ecbc94eb6be90bc38b2d0fdd4bfac3f34d9923&stat=instructions:u) (up to 1.2% on `full` builds of `match-stress-enum-check`)
+- This is a regression in a benchmark specifically for pattern match which is impacted by this change. The [`check match`](https://perf.rust-lang.org/detailed-query.html?commit=36ecbc94eb6be90bc38b2d0fdd4bfac3f34d9923&base_commit=5a5f3a980c0d2afd55f2162300339471378e341f&benchmark=match-stress-enum-check&run_name=full) query was responsible for the regression.
+- Interestingly, a [performance run](https://perf.rust-lang.org/compare.html?start=fde692739576089729885b7f79aa2232cb9778c5&end=6e126cb311d93b2142d8eae09719d614926e04b7) was done on this change during review which did not show the regressions seen here.
+
+expand/resolve: Turn `#[derive]` into a regular macro attribute [#79078](https://github.com/rust-lang/rust/issues/79078)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=36ecbc94eb6be90bc38b2d0fdd4bfac3f34d9923&end=9778068cbc1e06cc3685422323ff38a2f397de26&stat=instructions:u) (up to 1.3% on `incr-unchanged` builds of `derive-check`)
+- This largely seems to be impacting `incr-unchanged` benchmarks particularly in the `expand_crate` and `late_resolve_crate` queries, and it's happening mostly in stress benchmarks. The only "real" code base impacted this is `style-servo-check` at 1.0% for `incr-unchanged`.
+
+Use ufcs in derive(Debug) [#81294](https://github.com/rust-lang/rust/issues/81294)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=6ad11e2e25919b75ebbc36d7910f2a1126a7e873&end=186f7ae5b04d31d8ccd1746ac63cdf1ab4bc2354&stat=instructions:u) (up to -3.3% on `incr-patched: println` builds of `cargo-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=6ad11e2e25919b75ebbc36d7910f2a1126a7e873&end=186f7ae5b04d31d8ccd1746ac63cdf1ab4bc2354&stat=instructions:u) (up to 3.3% on `full` builds of `style-servo-check`)
+- This was originally labeled as a "mixed" result, but this is largely a perf regression with only a few improvements. 
+- This is a correctness fix so it's possible that we'll need to eat any performance regressions.
+- There is a PR [open](https://github.com/rust-lang/rust/pull/81760) to try to address the fact that more MIR is produced, but this doesn't seem to have a positive impact on [perf](https://perf.rust-lang.org/compare.html?start=822ebfd2c43fbe466da8ae34ffe3ce6cba2e8336&end=d589fc7d554c7ecdab26eb7ae07fd6dc7e8280f7).
+
+#### Improvements
+
+- Rollup of 14 pull requests [#81678](https://github.com/rust-lang/rust/issues/81678)
+- Revert 78373 ("dont leak return value after panic in drop") [#81257](https://github.com/rust-lang/rust/issues/81257)
+
+#### Mixed
+
+- Fix derived PartialOrd operators  [#81384](https://github.com/rust-lang/rust/issues/81384)
+
+#### Nags requiring follow up
+
+- Waiting on more investigation in [#81476](https://github.com/rust-lang/rust/issues/81476).
+- Need to follow up on the regressions reported this week.
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "RFC: Checking conditional compilation at compile time" [rfcs#3013](https://github.com/rust-lang/rfcs/pull/3013)
+  - [review by](https://github.com/rust-lang/rfcs/pull/3013#pullrequestreview-568757930) by @**Wesley Wiser** 
+  - RFC author implemented suggestions, waiting for feedback

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-02-18.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-02-18.md
@@ -1,0 +1,197 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-02-18
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- We have no steering meeting tomorrow (Friday). We spent last week's planning meeting doing ad-hoc planning for the March sprint.
+- pnkfelix drafted a [blog post](https://github.com/rust-lang/blog.rust-lang.org/pull/782) announcing the March sprint. He hopes to publish tonight; if you want to chime in, throw a comment up on linked draft.
+
+### MCP/FCP status
+
+- New MCPs (take a look, see if you like them!)
+  - "Never Rollup When Changing the `compiler` Directory" [compiler-team#407](https://github.com/rust-lang/compiler-team/issues/407)
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Distribute rustc_codegen_cranelift as rustup component" [compiler-team#405](https://github.com/rust-lang/compiler-team/issues/405)
+  - "Demote x86_64-rumprun-netbsd target" [rust#81514](https://github.com/rust-lang/rust/issues/81514)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Add an impl of Error on `Arc<impl Error>`." [rust#80553](https://github.com/rust-lang/rust/pull/80553)
+  - "Allow leading | anywhere we allow or-patterns" [rust#81415](https://github.com/rust-lang/rust/issues/81415)
+
+### WG checkins
+
+@*WG-mir-opt* checkin by @**oli**:
+
+* Prevent query cycles in the MIR inliner https://github.com/rust-lang/rust/pull/68828
+    * This is done by finding recursion sites in unoptimized MIR right before the unoptimized MIR body is stolen from its query in order to get optimized. Hopefully this is the last large barrier in enabling MIR inlining by default.
+* Duplicate MIR of `const fn` (one optimized version for runtime and one unoptimized version for CTFE): https://github.com/rust-lang/rust/pull/78407
+    * This allows CTFE to detect more UB (since the UB didn't get optimized away) and generally looks like a good entry point for static analyses that want to consume MIR.
+* General trend: some intrinsics are lowered to dedicated MIR statements right after borrowck is done. This makes it easier to write optimizations around these intrinsics and makes it clear that some intrinsics cannot possibly unwind, because MIR statements cannot unwind.
+
+@*WG-polonius* checkin by @**lqd**:
+> a small update this time: 
+> - more work has been done on sharing results between the quick `LocationInsensitive` pre-pass and the full location-sensitive analysis that follows, to limit the costlier work done in the full analysis by using the information gathered in the pre-pass
+> - unfortunately no news on the future sprint yet, or reviews/progress on the already completed work for the sprint that we mentioned at the previous check-in
+
+## Beta-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- "Identify unreachable subpatterns more reliably" [rust#80632](https://github.com/rust-lang/rust/pull/80632)
+  - opened by @**Nadrieril** 
+  - reviewed by @**varkor** 
+  - Fixes [rust#80501](https://github.com/rust-lang/rust/issues/80501), a `P-medium` regression causing a spurious "unreachable code" error
+  - @**rylev** comments on [a 1% perf loss](https://github.com/rust-lang/rust/pull/80632#issuecomment-776591352) that the author seems not to be able to reproduce
+
+:back: / :shrug: / :hand:
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl)
+- No beta nominations for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+- "rustdoc: treat edition 2021 as unstable" [rust#82207](https://github.com/rust-lang/rust/pull/82207)
+  - This ensures that `--edition=2021` requires `-Z unstable-options` in rustdoc
+  - r'ed by @**Joshua Nelson** 
+
+:back: / :shrug: / :hand:
+
+## Stable-nominations
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- "Identify unreachable subpatterns more reliably" [rust#80632](https://github.com/rust-lang/rust/pull/80632)
+  - see beta nomination :point_up: 
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- "Implement String::remove_matches" [rust#71780](https://github.com/rust-lang/rust/pull/71780)
+  - Opened by @_**Josh Cotton** 
+  - Should close [rust#50206](https://github.com/rust-lang/rust/issues/50206), a 2018 feature request from @**Corey Farwell**: add the possibility to remove all matches for a pattern in a string
+  - Zulip discussion at [this link](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Implement.20String.3A.3Amatches.20.2371780)
+  - PR work stopped around July 2020, original PR author not having time anymore
+  - assigned to @**Ashley Mannix**, will have a look at it
+  - Notable comments and reviews:
+    - reviewed by [@_**kennytm**](https://github.com/rust-lang/rust/pull/71780#pullrequestreview-406679167) and (partially) also by [@_**David Tolnay**](https://github.com/rust-lang/rust/pull/71780#pullrequestreview-419824557)
+    - @_**Lukas Kalbertodt** [also left comments](https://github.com/rust-lang/rust/pull/71780#issuecomment-663841852)
+    - @_**BurntSushi** comments that [the pattern API would need a redesign](https://github.com/rust-lang/rust/pull/71780#issuecomment-664358236) to support this
+    - also [this comment](https://github.com/rust-lang/rust/pull/71780#issuecomment-688250368) by @boats
+ 
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [67 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [41 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 41 P-high, 89 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Starting with nightly-2021-01-13 (1.51) rustc fails to build archives on Windows 7" [rust#81051](https://github.com/rust-lang/rust/issues/81051)
+  - Issue first seemed to be only affect Win7 but it is actually an LLVM issue
+  - Win7 (x86_64-pc-windows-gnu) is still [Tier 1 platform](https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1): a side question about this issue could be if it should be demoted
+  - the problem disappears if reverting to [nightly-2021-01-12](https://github.com/rust-lang/rust/issues/81051#issuecomment-769520843) or up to LLVM [commit 6ec777c](https://github.com/rust-lang/llvm-project/commit/6ec777c) 
+  - @**moxian** [debugged the issue](https://github.com/rust-lang/rust/issues/81051#issuecomment-774638526) and provides significant data and points to rollup PR [#80960](https://github.com/rust-lang/rust/pull/80960)
+  - more debugging [at this comment](https://github.com/rust-lang/rust/issues/81051#issuecomment-779556314)
+  - @**cuviper** comments this bug looks similar to LLVM [#48378](https://bugs.llvm.org/show_bug.cgi?id=48378)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [2021-02-16 Full triage logs](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-02-16.md)
+
+A mostly quiet week, though with an excellent improvement in bootstrap times,
+shaving off a couple percent off the total and 10% off of rustc_middle due to
+changes in the code being compiled.
+
+Triage done by **@simulacrum**.
+
+1 Regressions, 2 Improvements, 1 Mixed
+
+#### Regressions
+
+Initialize BTree nodes directly in the heap [#81494](https://github.com/rust-lang/rust/issues/81494)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7e0241c63755ea28045d512b742f50b307874419&end=3c10a880eca60379343a6c6d19dd5bda38ead55d&stat=instructions:u) (up to 1.3% on `full` builds of `cargo-debug`)
+- Not really expected, but this is aiming for optimizing initialization of large
+  k/v pairs, so perhaps worth it. Left a nag.
+
+#### Improvements
+
+- [experiment] remove `#[inline]` from rustc_query_system::plumbing [#81892](https://github.com/rust-lang/rust/issues/81892)
+- directly expose copy and copy_nonoverlapping intrinsics [#81238](https://github.com/rust-lang/rust/issues/81238)
+
+#### Mixed
+
+- Check the result cache before the DepGraph when ensuring queries [#81855](https://github.com/rust-lang/rust/issues/81855)
+
+#### Nags requiring follow up
+
+Investigations pending:
+- https://github.com/rust-lang/rust/pull/81494#issuecomment-779938322
+- https://github.com/rust-lang/rust/pull/81855#issuecomment-779950478
+  - comment by [@cjgillot](https://github.com/cjgillot): "Follow-up PR #82197 recovers the expected perf gain."
+
+From last week:
+- Waiting on more investigation in [#81476](https://github.com/rust-lang/rust/issues/81476).
+- Need to follow up on the regressions reported this week.
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+  - opened by @**Alex Kornitzer**, reports that working code on x86_64-unknown-linux-gnu not compiling anymore after updating the MongoDB crate (compiled as dynamic library)
+  - @**Hameer Abbasi** did [some bisecting](https://github.com/rust-lang/rust/issues/82151#issuecomment-780520981) but the trail seems to go back to 2018 
+  - a minimal mcve [is found at this comment](https://github.com/rust-lang/rust/issues/82151#issuecomment-779368017)
+  - issue seems to warrant high priority but since it looks like to be there since long, we are not sure about the implications/impact
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-02-25.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-02-25.md
@@ -1,0 +1,168 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-02-25
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+### MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Move query implementation outside rustc_middle" [compiler-team#388](https://github.com/rust-lang/compiler-team/issues/388)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "Never Rollup When Changing the `compiler` Directory" [compiler-team#407](https://github.com/rust-lang/compiler-team/issues/407)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Add `-Z unpretty` flags for the AST and the THIR" [compiler-team#408](https://github.com/rust-lang/compiler-team/issues/408)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Add `NotSupported` to `std::io::ErrorKind`" [rust#78880](https://github.com/rust-lang/rust/pull/78880)
+  - "`impl PartialEq<Punct> for char`; symmetry for #78636" [rust#80595](https://github.com/rust-lang/rust/pull/80595)
+  - "Demote x86_64-rumprun-netbsd target" [rust#81514](https://github.com/rust-lang/rust/issues/81514)
+  - "Make char and u8 methods const" [rust#82078](https://github.com/rust-lang/rust/pull/82078)
+
+### WG checkins
+
+- @_*WG-rfc-2229*  by @**nikomatsakis** @**Matthew Jasper**:
+  > - Discussed milestones for edition release: https://github.com/rust-lang/project-rfc-2229/milestones 
+  > - `disjoint_capture_drop_reorder` lint partly implement to suppport migration around breaking changes across the edition boundry
+  > - T-Lang decided on migration syntax to be `catpure!(var)` within a closure to force a complete capture of `var` by the closure. 
+  > - Implemented better support for precise captures in move closures
+
+- @_*wg-polymorphization* by @**davidtwco**:
+  > There's no news from the polymorphization working group. Working group members have been focusing their efforts elsewhere in the compiler recently.
+
+## Backport nominations
+
+[T-compiler (stable)](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+[T-compiler (beta)](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler)
+- :beta: :stable: "Substitute erased lifetimes on bad placeholder type" [rust#82494](https://github.com/rust-lang/rust/pull/82494)
+  - opened by @**Esteban Küber** 
+  - not yet reviewed
+  - Fixes [rust#82455](https://github.com/rust-lang/rust/issues/82455) a `P-medium` a stable to stable regression that emitted an ICE after showing a compilation error on invalid code.
+
+[T-libs-impl (stable)](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl)
+[T-libs-impl (beta)](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc (beta)](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc)
+[T-rustdoc (stable)](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- :beta: "[intra-doc links] Don't check feature gates of items re-exported across crates" [rust#82295](https://github.com/rust-lang/rust/pull/82295)
+  - opened by @**Joshua Nelson** 
+  - approved by @_**GuillaumeGomez**  @_**Manish Goregaokar** @_**Camelid**
+  - fixes [rust#82284](https://github.com/rust-lang/rust/issues/82284), a `P-critical` regression that broke documentation for `serde` and other crates
+- :beta: "rustdoc: Remove duplicate "List of all items"" [rust#82484](https://github.com/rust-lang/rust/pull/82484)
+  - opened by @**Dániel Buga** 
+  - approved by @_**GuillaumeGomez**  @_**Manish Goregaokar** @_**Camelid** 
+  - closes [rust#82477](https://github.com/rust-lang/rust/issues/82477), rustdoc showed a title twice in the header 
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+  - "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+    - opened by @**The 8472|239181** (@**The 8472|330154**?) 
+    - @**simulacrum** [raises concerns about](https://github.com/rust-lang/rust/pull/81942#issuecomment-778685649) maintaining the complexity cost, suggests more eyeballs on this PR
+    - @**nagisa** [raise a concern](https://github.com/rust-lang/rust/pull/81942#issuecomment-782762020) that this could break tests sensible to the absence of a `-Ccodegen-units` flag
+    - CI seems to not pass consistently
+
+[libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3Alibs-impl)
+- No PRs waiting on `libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [64 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [38 of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 39 P-high, 88 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Starting with nightly-2021-01-13 (1.51) rustc fails to build archives on Windows 7" [rust#81051](https://github.com/rust-lang/rust/issues/81051)
+  - Assigned to @**cuviper**, comments this bug looks similar to LLVM [#48378](https://bugs.llvm.org/show_bug.cgi?id=48378)
+  - Win7 (x86_64-pc-windows-gnu) is still [Tier 1 platform](https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1): a side question about this issue could be if it should be demoted
+  - the problem disappears if reverting to [nightly-2021-01-12](https://github.com/rust-lang/rust/issues/81051#issuecomment-769520843) or up to LLVM [commit 6ec777c](https://github.com/rust-lang/llvm-project/commit/6ec777c)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+[2021-02-24 full Triage Log](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-02-24.md)
+
+Overall, a positive week for compiler performance with only one moderate regression. The change that introduced the regression leads to significantly improved [bootstrap speed](https://github.com/rust-lang/rust/pull/70951#issuecomment-766292996) of the compiler as well as easier maintainability.
+
+Triage done by **@rylev**.
+
+1 Regression, 5 Improvements, 0 Mixed
+0 of them in rollups
+
+#### Regressions
+
+- Move the query engine out of rustc_middle [#70951](https://github.com/rust-lang/rust/issues/70951)
+  - Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e7c23ab933ebc1f205c3b59f4ebc85d40f67d404&end=83b30a639d5abd1270ade35d9bd92271f5a5ba18&stat=instructions:u) (up to 4.9% on `full` builds of `deeply-nested-check`)
+  - While this does somewhat hurt compiler performance, it is a huge gain in bootstrap speed. The performance impact was deemed acceptable, but perhaps an investigation in if the remaining performance regressions can be eliminated, should be looked into.
+  - Added a nag to [the pull request](https://github.com/rust-lang/rust/pull/70951#issuecomment-785044935).
+
+#### Improvements
+
+- Only store a LocalDefId in some HIR nodes [#81611](https://github.com/rust-lang/rust/issues/81611)
+- Inline try_get_cached [#82197](https://github.com/rust-lang/rust/issues/82197)
+- Reduce size of InterpErrorInfo to 8 bytes [#82116](https://github.com/rust-lang/rust/issues/82116)
+- Make the `Query` enum a simple struct. [#80891](https://github.com/rust-lang/rust/issues/80891)
+- Improve assert_eq! and assert_ne! [#79100](https://github.com/rust-lang/rust/issues/79100)
+
+#### Nags requiring follow up
+
+- One nag for the only regression for the week.
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+  - [T-lang] "Invalid `field is never read: ` lint warning" [rust#81658](https://github.com/rust-lang/rust/issues/81658)
+  - "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+  - "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+    - opened by @**Alex Kornitzer**, reports that working code on x86_64-unknown-linux-gnu not compiling anymore after updating the MongoDB crate (compiled as dynamic library)
+    - @**Hameer Abbasi** did [some bisecting](https://github.com/rust-lang/rust/issues/82151#issuecomment-780520981) but the trail seems to go back to 2018 
+    - a minimal mcve [is found at this comment](https://github.com/rust-lang/rust/issues/82151#issuecomment-779368017)
+    - issue seems to warrant high priority but since it looks to be in the codebase since long, we are not sure about the implications/impact
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-03-04.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-03-04.md
@@ -1,0 +1,178 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-03-04
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - "Filter out query machinery from compiler backtraces by default" [compiler-team#410](https://github.com/rust-lang/compiler-team/issues/410)
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+- Pending FCP requests (check your boxes!)
+  - "Adding diesel to the cargotest suite" [rust#81507](https://github.com/rust-lang/rust/pull/81507)
+  - "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+- Things in FCP (make sure you're good with it)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Tracking Issue for ASCII methods on OsStr" [rust#70516](https://github.com/rust-lang/rust/issues/70516)
+  - "Tracking Issue for str_split_once" [rust#74773](https://github.com/rust-lang/rust/issues/74773)
+  - "Lint for unused borrows as part of `UNUSED_MUST_USE`" [rust#76894](https://github.com/rust-lang/rust/pull/76894)
+  - "[librustdoc] Only split lang string on `,`, ` `, and `\t`" [rust#78429](https://github.com/rust-lang/rust/pull/78429)
+  - "Stabilize `unsafe_op_in_unsafe_fn` lint" [rust#79208](https://github.com/rust-lang/rust/pull/79208)
+  - "Make rustdoc lints a tool lint instead of built-in" [rust#80527](https://github.com/rust-lang/rust/pull/80527)
+
+### WG checkins
+
+@*WG-rls2.0* by @**matklad** 
+We've finished our first 6 weeks "sprint" ([tracking issue](https://github.com/rust-analyzer/rust-analyzer/issues/7325#issuecomment-788222235)) with mixed results
+- rust-analyzer now supprts items declared inside function bodies
+- we are preparing to enable proc-macro suport by default. In particular, rust-analyzer suppors asynchronous execution of build scripts and loading of proc-macro.
+- we've switched macro-by-example parser to use a proper NFA, getting closer to parity with rustc at the cost of 2x worser expansion performance :(
+- "new mutable immutable syntax trees" work is still not finished, but it has progressed enough to rewrite one assist to confirm that the new API works and is significantly more ergonomic. 
+
+@*WG-self-profile* by @**Wesley Wiser**:
+> - We released `measureme@9.1` last week :tada: ([release notes](https://github.com/rust-lang/measureme/releases/tag/9.1.0))
+>   - The biggest feature is @eddyb's support for hardware performance counters
+>   - We've updated rustc to use the new version
+>   - This has unblocked [@eddyb's PR](https://github.com/rust-lang/rust/pull/78781) to use hardware performance counters for `-Zself-profile`
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Fix popping singleton paths in when generating E0433" [rust#82259](https://github.com/rust-lang/rust/pull/82259)
+  - opened by [osa1](https://github.com/osa1)
+  - fixes [#82156](https://github.com/rust-lang/rust/issues/82156), a `P-medium` ICE instead of emitting a syntax error when calling `super()`
+  - approved by @**Vadim Petrochenkov** 
+- :stable: "Fix popping singleton paths in when generating E0433" [rust#82259](https://github.com/rust-lang/rust/pull/82259)
+  - see above: safe for stable backport?
+- :beta: "libtest: Fix unwrap panic on duplicate TestDesc" [rust#82274](https://github.com/rust-lang/rust/pull/82274)
+  - opened by @**Anders Kaseorg** 
+  - approved by @**simulacrum**, [raises a question](https://github.com/rust-lang/rust/pull/82274#issuecomment-781635206) about this patch that is addressed in the follow-up PR [#82300](https://github.com/rust-lang/rust/pull/82300)
+- :beta: "Revert LLVM D81803 because it broke Windows 7" [rust#82605](https://github.com/rust-lang/rust/pull/82605)
+  - opened by @**cuviper**
+  - approved by   @**Nikita Popov** 
+  - fix a critical issue [#82605](https://github.com/rust-lang/rust/pull/82605) blocking build any archives on Windows 7 (issue [#81051](https://github.com/rust-lang/rust/issues/81051))
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- :beta: "[beta] Fix TcpListener::accept() on x86 Android on beta by disabling the use of accept4." [rust#82476](https://github.com/rust-lang/rust/pull/82476)
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+  - opened by @**The 8472|239181** (@**The 8472|330154**?) 
+  - @**simulacrum** [raises concerns about](https://github.com/rust-lang/rust/pull/81942#issuecomment-778685649) maintaining the complexity cost, suggests more eyeballs on this PR
+  - @**nagisa** [raise a concern](https://github.com/rust-lang/rust/pull/81942#issuecomment-782762020) that this could break tests sensible to the absence of a `-Ccodegen-units` flag
+  - CI seems to not pass consistently
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - opened by @**Ariadne Conill** 
+  - assigned to @**nagisa**, raises some concerns [on the behaviour consistency](https://github.com/rust-lang/rust/pull/82556#issuecomment-787088016) 
+  - assigned also to @**Vadim Petrochenkov**, [provides a great summary on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/2021-03-03.20meeting.20agenda/near/228681359), suggests to [enable dynamic linking on nightly](https://github.com/rust-lang/rust/pull/82556#issuecomment-787431717) to see what breaks
+  - [@richfelker](https://github.com/richfelker) (author and mantainer of musl) recommends [proper naming to avoid confusion](https://github.com/rust-lang/rust/pull/82556#issuecomment-788172193)
+  - discussion is still ongoing, revolves around clarifying the `--target` behaviour and what people expect when compiling for MUSL
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [65 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [40 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 39 P-high, 86 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- "Side effect handling in specialized zip implementation causes buffer overflow" [rust#82282](https://github.com/rust-lang/rust/issues/82282)
+  - unsound buffer overflow caused [by violating the safety requirement of `TrustedRandomAccess` trait](https://github.com/rust-lang/rust/issues/82282#issuecomment-781805170)
+  - @**Giacomo Stevanato** provides a patch [rust#82289](https://github.com/rust-lang/rust/pull/82289) to fix this, approved by @**Mara** 
+- "Zip may call __iterator_get_unchecked twice with the same index" [rust#82291](https://github.com/rust-lang/rust/issues/82291)
+  - related to the above issue, unsoundness could be exploited to get two mutable references to the same data and cause an use-after-free bug
+  - @**Giacomo Stevanato** provides another patch [#82292](https://github.com/rust-lang/rust/issues/82292), pending approval
+- "std::io::copy returns Bad File Descriptor with writer files in append mode in 1.50" [rust#82410](https://github.com/rust-lang/rust/issues/82410)
+  - happens when streaming one file into another and the writer is in append mode, only when using `BufWriter`/`BufReader`
+  - @**The 8472|239181** provides a patch [#82417](https://github.com/rust-lang/rust/pull/82417), pending review
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [Triage full logs](https://github.com/rust-lang/rustc-perf/blob/6e54a651ae4721eefd8b99341ad60a1b2d9f76c8/triage/2021-03-02.md)
+
+Quiet week, a couple regressions and several nice improvements.
+
+Triage done by **@simulacrum**.
+
+2 Regressions, 3 Improvements, 0 Mixed, 0 of them in rollups
+
+#### Regressions
+
+Use correct param_env in conservative_is_privately_uninhabited [#82159](https://github.com/rust-lang/rust/issues/82159)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a8486b64b0c87dabd045453b6c81500015d122d6&end=1fdadbf13aecd190b277ea2aa1b125d2ed986d55&stat=instructions:u) (up to 1.2% on `incr-unchanged` builds of `regression-31157-opt`)
+- Seems like a necessary bugfix.
+
+Detect match statement intended to be tail expression [#81458](https://github.com/rust-lang/rust/issues/81458)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=d95d30486180387a875b14633aea4e4dd8f960da&end=cecdb181ade91c0a5ffab9a148dba68fc7d00ee3&stat=instructions:u) (up to 5.6% on `incr-patched: println` builds of `unicode_normalization-check`)
+- Unexpected regresssion, left [nag](https://github.com/rust-lang/rust/pull/81458#issuecomment-789003548).
+
+#### Improvements
+
+- Prevent to compute Item attributes twice [#82265](https://github.com/rust-lang/rust/issues/82265)
+- Miscellaneous inlining improvements [#82559](https://github.com/rust-lang/rust/issues/82559)
+- Remove storage markers if they won't be used during code generation [#78360](https://github.com/rust-lang/rust/issues/78360)
+
+#### Nags requiring follow up
+
+Detect match statement intended to be tail expression [#81458](https://github.com/rust-lang/rust/issues/81458)
+- https://github.com/rust-lang/rust/pull/81458#issuecomment-789003548
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`fn() -> Out` is a valid type for unsized types `Out`, and it implements `FnOnce<(), Output = Out>`" [rust#82633](https://github.com/rust-lang/rust/issues/82633)
+  - opened by @**Frank Steffahn** 
+  - issue bisection seems to point to PR [#73905](https://github.com/rust-lang/rust/pull/73905)
+  - issue seems to [reproducible on stable since long](https://github.com/rust-lang/rust/issues/82633#issuecomment-789168223) (so not a regression) but to be unsound on nightly
+  - something to investigate a bit closer 
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-03-11.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-03-11.md
@@ -1,0 +1,192 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-03-11
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow, at 10 AM EST, is the T-compiler planning meeting for the upcoming cycle
+
+### MCPs/FCPs status
+
+- New MCPs (take a look, see if you like them!)
+  - "Lang Item for Transmutability" [compiler-team#411](https://github.com/rust-lang/compiler-team/issues/411)
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+- Pending FCP requests (check your boxes!)
+  - "Adding diesel to the cargotest suite" [rust#81507](https://github.com/rust-lang/rust/pull/81507)
+  - "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+- Things in FCP (make sure you're good with it)
+  - "Filter out query machinery from compiler backtraces by default" [compiler-team#410](https://github.com/rust-lang/compiler-team/issues/410)
+  - "MCP: Embed the `hir_id` of the _awaited expression_ into `DesugaringKind`" [compiler-team#413](https://github.com/rust-lang/compiler-team/issues/413)
+- Accepted MCPs
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+- Finalized FCPs (disposition merge)
+  - "Allow specifying alignment for functions" [rust#81234](https://github.com/rust-lang/rust/pull/81234)
+
+### WG checkins
+
+@*WG-async-foundations* by @**nikomatsakis** and @**tmandry**:
+> * Ongoing preparations to launch the ["async vision doc"](https://rust-lang.github.io/wg-async-foundations/vision.html) effort.
+> * [RFC #3014](https://github.com/rust-lang/rfcs/pull/3014) (`must_not_suspend_lint`) was accepted 18 days ago, will be merged soon.
+> * Other ongoing work can be found on the [project board](https://github.com/orgs/rust-lang/projects/2).
+
+@*WG-traits* by @**nikomatsakis** and @**Jack Huey**:
+> * Incremental progress on the binder refactor PR #76814
+> * Design work on how to move types out of `rustc_middle` into `rustc_type_ir`, particularly around `Encodable`/`Decodable`
+> * Work towards GATs stabilization
+>   - #82066
+>   - #82272
+> * Work towards `type_alias_impl_trait`/`min_type_alias_impl_trait` stabilization
+>   - #82558
+>   - #82898
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No backport nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- :beta: "std: Fix a bug on the wasm32-wasi target opening files" [rust#82804](https://github.com/rust-lang/rust/pull/82804)
+  - fixes [rust#82758](https://github.com/rust-lang/rust/issues/82758)
+  - P-high regression on target wasm32-wasi prevents from opening files
+  - see [P-high regressions](#P-high-regressions) in agenda :point_down:
+  - cc: @**Mara**
+- :stable: should also discuss a stable backport?
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - opened by @**Ariadne Conill**
+  - assigned to @**nagisa**, raises some concerns [on the behaviour consistency](https://github.com/rust-lang/rust/pull/82556#issuecomment-787088016)
+  - assigned also to @**Vadim Petrochenkov**, [provides a great summary on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/2021-03-03.20meeting.20agenda/near/228681359), suggests to [enable dynamic linking on nightly](https://github.com/rust-lang/rust/pull/82556#issuecomment-787431717) to see what breaks
+  - [@richfelker](https://github.com/richfelker) (author and mantainer of musl) recommends [proper naming to avoid confusion](https://github.com/rust-lang/rust/pull/82556#issuecomment-788172193)
+  - discussion is still ongoing, revolves around clarifying the `--target` behaviour and what people expect when compiling for MUSL
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [65 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [40 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [2 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 38 P-high, 90 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "char::encode_utf8 crash on nightly" [rust#82833](https://github.com/rust-lang/rust/issues/82833)
+  - Opened by @**David Hewitt**
+  - Assigned to @**Nikita Popov**
+  - Unsoundness on nightly when compiling with RUSTFLAGS="-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code"
+  - [comment shows](https://github.com/rust-lang/rust/issues/82833#issuecomment-791968727) that regressed in pr [rust#81451](https://github.com/rust-lang/rust/pull/81451)
+  - seems caused by an LLVM [upstream issue](https://github.com/rust-lang/rust/issues/82833#issuecomment-792301830)
+- "Slice length becomes random between nightly-2021-03-04 and nightly-2021-03-05" [rust#82859](https://github.com/rust-lang/rust/issues/82859)
+  - Assigned to @**Nikita Popov**
+  - On nightly `println!()` macro prints garbage when inlining functions
+  - Related to the above :point_up: (#82833) LLVM 12 upgrade unsoundness
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- "std::io::copy returns Bad File Descriptor with writer files in append mode in 1.50" [rust#82410](https://github.com/rust-lang/rust/issues/82410)
+  - Issue happens when streaming one file into another and the writer is in append mode, only when using BufWriter/BufReader
+  - @**The 8472|239181** provides a patch [rust#82417](https://github.com/rust-lang/rust/pull/82417), pending review
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- [t-libs-impl] "WASI: path_open regression in Rust 1.51 when using LTO" [rust#82758](https://github.com/rust-lang/rust/issues/82758)
+  - compiling for `--release` *and* with LTO enabled breaks loading files from the filesystem
+  - WASI is [Tier 2 target](https://doc.rust-lang.org/nightly/rustc/platform-support.html)
+  - Alex Crichton submitted a patch in [#82804](https://github.com/rust-lang/rust/pull/82804) (nominated for beta backport)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+[2021-03-10 Triage Log](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-03-10.md)
+
+A generally positive albeit quiet week though many of the perf improvements were gaining performance back from previous regressions. We'll need to continue to keep an eye on rollups as there were two that caused small performance changes.
+
+Triage done by **@rylev**.
+
+1 Regression, 4 Improvements, 1 Mixed
+2 of them in rollups
+
+#### Regressions
+
+Rollup of 8 pull requests [#82929](https://github.com/rust-lang/rust/issues/82929)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=4b9f5cc4c10a161047475cb9bbe02c4fda57fb07&end=3a5d45f68cadc8fff4fbb557780f92b403b19c19&stat=instructions:u) (up to 1.6% on `full` builds of `keccak-debug`)
+- A fairly consistent (albeit small) regression in the `typecheck` query across different benchmarks though none of the PRs in the rollup seem to touch that query. This might be noise, but it's hard to tell
+
+#### Improvements
+
+- Move check only relevant in error case out of critical path [#82738](https://github.com/rust-lang/rust/issues/82738)
+- Backport some LLVM compile-time improvements [#82783](https://github.com/rust-lang/rust/issues/82783)
+- Rollup of 10 pull requests [#82953](https://github.com/rust-lang/rust/issues/82953)
+- Update tracing to 0.1.25 [#82553](https://github.com/rust-lang/rust/issues/82553)
+
+#### Mixed
+
+Upgrade to LLVM 12 [#81451](https://github.com/rust-lang/rust/issues/81451)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=ec7f258d543e1ac7d0b94435972331e85da8c509&end=409920873cf8a95739a55dc5fe5adb05e1b4758e&stat=instructions:u) (up to -11.3% on `full` builds of `keccak-opt`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ec7f258d543e1ac7d0b94435972331e85da8c509&end=409920873cf8a95739a55dc5fe5adb05e1b4758e&stat=instructions:u) (up to 7.7% on `full` builds of `deeply-nested-opt`)
+- Some of the perf regression seen here was gained back in [#82783](https://github.com/rust-lang/rust/issues/82783).
+
+#### Nags requiring follow up
+
+No nags for this week and the nag from last week has been resolved by [#81458](https://github.com/rust-lang/rust/pull/81458).
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Invalid `field is never read: ` lint warning" [rust#81658](https://github.com/rust-lang/rust/issues/81658)
+  - Already discussed during [`T-lang` meeting](https://github.com/rust-lang/rust/issues/81658#issuecomment-794334545)
+  - Conclusion is to improve diagnostic
+  - However, related issue [rust#81626](https://github.com/rust-lang/rust/issues/81626) *is* a stable-to-beta regression
+  - Should we "just" revert [PR #81473](https://github.com/rust-lang/rust/pull/81473) on beta-alone, and in parallel improve the diagnostic on nightly?
+- "Make symbols stripping work on MacOS X" [rust#82037](https://github.com/rust-lang/rust/pull/82037)
+  - MacOS' linker can't strip binaries anymore, [Apple documentation](https://github.com/rust-lang/rust/issues/72110#issuecomment-641169818) recommend using a separate `strip` tool for that.
+  - This change allows the compiler to use that tool after a target has been compiled to strip symbols.
+  - Assigned to @**Esteban Küber** asks more eyeballs on this
+- "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+  - Opened by @**Alex Kornitzer**
+  - Unassigned and mentioned [two meetings ago](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.20meeting.5D.202021-02-25.20.2354818/near/227788998), scheduled to be discussed again today
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - Mentioned in [PR waiting on team](https://hackmd.io/3dTKNk1_RiK3NOZMfyOldw?view#PRs-S-waiting-on-team)
+- "`fn() -> Out` is a valid type for unsized types `Out`, and it implements `FnOnce<(), Output = Out>`" [rust#82633](https://github.com/rust-lang/rust/issues/82633)
+  - opened by @**Frank Steffahn**
+  - issue bisection seems to point to PR [#73905](https://github.com/rust-lang/rust/pull/73905)
+  - issue seems to [reproducible on stable since long](https://github.com/rust-lang/rust/issues/82633#issuecomment-789168223) (so not a regression) but to be unsound on nightly
+  - something to investigate a bit closer -> (needs an owner)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-03-18.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-03-18.md
@@ -1,0 +1,210 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-03-18
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow (Friday 18 March) we will have a retrospective on the March memshrink sprint. see [compiler-team#412](https://github.com/rust-lang/compiler-team/issues/412)
+- Next week 25.03 the new stable release 1.51 is out
+
+### MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issdues/419)
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  - "Lang Item for Transmutability" [compiler-team#411](https://github.com/rust-lang/compiler-team/issues/411)
+- Pending FCP requests (check your boxes!)
+  - "Adding diesel to the cargotest suite" [rust#81507](https://github.com/rust-lang/rust/pull/81507)
+  - "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+- Things in FCP (make sure you're good with it)
+  - "Filter out query machinery from compiler backtraces by default" [compiler-team#410](https://github.com/rust-lang/compiler-team/issues/410)
+  - "MCP: Embed the `hir_id` of the _awaited expression_ into `DesugaringKind`" [compiler-team#413](https://github.com/rust-lang/compiler-team/issues/413)
+  - "Switch JSON serialization from rustc_serialize to serde" [compiler-team#418](https://github.com/rust-lang/compiler-team/issues/418)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Emit errors/warns on some wrong uses of rustdoc attributes" [rust#80300](https://github.com/rust-lang/rust/pull/80300)
+  - "Implement Extend and FromIterator for OsString" [rust#82121](https://github.com/rust-lang/rust/pull/82121)
+  - "slice: Stabilize IterMut::as_slice." [rust#82771](https://github.com/rust-lang/rust/pull/82771)
+
+### WG checkins
+
+- @*WG-diagnostics* checking by @**Esteban Küber** and @**oli**:
+> Checkin text
+
+- @*WG-rustc-dev-guide* checkin by @**Santiago Pastorino** and @**Joshua Nelson**:
+>- Continuing to work on a walkthrough of the compiler
+>  - Added support for `-Z unpretty=ast` to the compiler [rust-lang/rust#82304](https://github.com/rust-lang/rust/pull/82304)
+>  - Added support for `-Z unpretty=thir` [rust-lang/rust#82860](https://github.com/rust-lang/rust/pull/82860)
+>  - Working on adding support for `-Z unpretty=hir` to playground [rust-playground#683](https://github.com/integer32llc/rust-playground/pull/683)
+>  - At some point we would like to add `-Z dump-metadata` or similar
+>
+>### Most notable changes
+>
+>- Add article on using WPA to profile rustc memory usage on Windows [#1074](https://github.com/rust-lang/rustc-dev-guide/pull/1074)
+>- Switch from Travis to GHA [#1073](https://github.com/rust-lang/rustc-dev-guide/pull/1073)
+>- Fix date-check comment formatting [#1066](https://github.com/rust-lang/rustc-dev-guide/pull/1066)
+>- Add Oxide paper to bibliography [#1056](https://github.com/rust-lang/rustc-dev-guide/pull/1056)
+>- Use more accurate estimate of generated LLVM IR with llvm-lines [#1049](https://github.com/rust-lang/rustc-dev-guide/pull/1049)
+>- Update docs from date triage for 2021-02 [#1048](https://github.com/rust-lang/rustc-dev-guide/pull/1048)
+>
+>### Most notable WIPs
+>
+>- Fix rust compiler meeting info [#1087](https://github.com/rust-lang/rustc-dev-guide/pull/1087)
+>- rewrite ty.md [#1057](https://github.com/rust-lang/rustc-dev-guide/pull/1057)
+>- improve glossary page [#1053](https://github.com/rust-lang/rustc-dev-guide/pull/1053)
+>- Add a section on keeping things up to date in the git section [#1031](https://github.com/rust-lang/rustc-dev-guide/pull/1031)
+>- Document lang items [#978](https://github.com/rust-lang/rustc-dev-guide/pull/978)
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No beta nominations for `T-compiler` this time.
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- :beta: "Fix io::copy specialization using copy_file_range when writer was opened with O_APPEND" [rust#82417](https://github.com/rust-lang/rust/pull/82417)
+  - opened by @**The 8472|239181**
+  - approved by @**Mara**
+  - Fixes [#82410](https://github.com/rust-lang/rust/issues/82410), `P-critical` regression when streaming one file into another and the writer is in append mode
+- :stable: "Fix io::copy specialization using copy_file_range when writer was opened with O_APPEND" [rust#82417](https://github.com/rust-lang/rust/pull/82417)
+  - issue is also nominated for beta backport
+- :beta: "std: Fix a bug on the wasm32-wasi target opening files" [rust#82804](https://github.com/rust-lang/rust/pull/82804)
+  - backport of a fix by @**Alex Crichton**
+  - fixes [#82758](https://github.com/rust-lang/rust/issues/82758), a P-high regression breaking loading files when compiling for `--release` and LTO enabled
+  - assigned to @**Mara**
+  - waiting for approval
+
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- :beta: "Fix "run" button position in error index" [rust#82979](https://github.com/rust-lang/rust/pull/82979)
+  - opened by @**GuillaumeGomez**
+  - approved to @**Nemo157**
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - opened by @**Ariadne Conill**
+  - assigned to @**nagisa**, raises some concerns [on the behaviour consistency](https://github.com/rust-lang/rust/pull/82556#issuecomment-787088016)
+  - assigned also to @**Vadim Petrochenkov**, [provides a great summary on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/2021-03-03.20meeting.20agenda/near/228681359), suggests to [enable dynamic linking on nightly](https://github.com/rust-lang/rust/pull/82556#issuecomment-787431717) to see what breaks
+  - [@richfelker](https://github.com/richfelker) (author and mantainer of musl) recommends [proper naming to avoid confusion](https://github.com/rust-lang/rust/pull/82556#issuecomment-788172193)
+  - @**Wesley Wiser** opened a [compiler-team#416](https://github.com/rust-lang/compiler-team/issues/416) meeting proposal
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [63 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [40 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 3 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 1 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 37 P-high, 89 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "`probe-stack=inline-asm` generates wrong DWARF information" [rust#83139](https://github.com/rust-lang/rust/issues/83139)
+  - issue is labelled as high/critical on [reporter's end](https://github.com/tikv/tikv/issues/9765), breaks compiling their cpu profiler
+  - reporter mentions root cause to be PR [#77885](https://github.com/rust-lang/rust/pull/77885)
+  - reporter also is testing [an LLVM patch](https://github.com/rust-lang/rust/issues/83139#issuecomment-801225600) from @**nagisa** which seemingly fixes the problem
+  - could this be a release blocker?
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "WASI: path_open regression in Rust 1.51 when using LTO" [rust#82758](https://github.com/rust-lang/rust/issues/82758)
+- "major performance regression between Rust 1.50 and beta when using target-cpu=native" [rust#83027](https://github.com/rust-lang/rust/issues/83027)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-03-18](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-03-16.md)
+
+Added two benchmarks over the past week to the perf suite - diesel and stm32f4,
+which are intended to add to the level of tracking for rustdoc and, for both, a
+focus on compiler trait machinery.
+
+Performance results for this week are mixed, but overall largely positive.
+
+Triage done by **@simulacrum**.
+
+3 Regressions, 3 Improvements, 4 Mixed
+
+#### Regressions
+
+Shorten `rustc_middle::ty::mod` [#82964](https://github.com/rust-lang/rust/issues/82964)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=066f01d81bfbed746f6b6cf27a0426d829e8e832&end=b3ac52646f7591a811fa9bf55995b24fd17ece08&stat=instructions:u) (up to 4.0% on `full` builds of `deeply-nested-check`)
+- Largely limited to diesel-doc builds, but a big regression there; left a nag
+  to followup. Likely caused by a change to inlining.
+
+Allow calling *const methods on *mut values [#82436](https://github.com/rust-lang/rust/issues/82436)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=4d76b4ca52a65d63ab83d82d6630f1df8ec05a93&end=f42888c15fd370b8bca4c5646ffc3aac3005dca8&stat=instructions:u) (up to 11.3% on `incr-full` builds of `packed-simd-check`)
+- Unfortunate and unexpected regression. Left a nag.
+
+Turn `-Z incremental-verify-ich` on by default [#83007](https://github.com/rust-lang/rust/issues/83007)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=56f74c52c1bb627ada01992787116054bf1e66e9&end=e7e1dc158c3de232750b568163f6941a184ee8be&stat=instructions:u) (up to 15.1% on `incr-unchanged` builds of `issue-46449-debug`)
+- Expected mitigation, essentially part of a soundness fix (though due to other
+  bugs in the compiler - this just adds asserts that catches those).
+
+#### Improvements
+
+- Eagerly construct bodies of THIR [#82495](https://github.com/rust-lang/rust/issues/82495)
+- Iterate on crate_inherent_impls for metadata. [#83082](https://github.com/rust-lang/rust/issues/83082)
+- Tweaks to stable hashing [#83064](https://github.com/rust-lang/rust/issues/83064)
+
+#### Mixed
+
+- Store HIR attributes in a side table [#79519](https://github.com/rust-lang/rust/issues/79519)
+- Enable MemorySSA in MemCpyOpt [#82806](https://github.com/rust-lang/rust/issues/82806)
+- Don't implement mem::replace with mem::swap. [#83022](https://github.com/rust-lang/rust/issues/83022)
+- Rebase and fixup #80493: Remove MIR assignments to ZST types [#83118](https://github.com/rust-lang/rust/issues/83118)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+  - mentioned in PR `S-waiting-on-team`
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- "Use getrandom for generating HashMap seed" [rust#80149](https://github.com/rust-lang/rust/pull/80149)
+  - Opened by @**Artyom Pavlov**
+  - assigned to @**Steven Fackler**, [raises a question](https://github.com/rust-lang/rust/pull/80149#issuecomment-776352953) about the policy for adding `getrandom` as new std dependency
+  - @**dhardy** describes how [the evaluation process could be](https://github.com/rust-lang/rust/pull/80149#issuecomment-776352953)
+  - @**Mara** labeled for T-libs-impl discussion
+- "Is there a gentler way to land the assert_matches macro?" [rust#82913](https://github.com/rust-lang/rust/issues/82913)
+  - opened by @**anp** [raises a question](https://github.com/rust-lang/rust/issues/82913#issue-825041783) about the level of breakage `assert_matches!()` introduces
+  - [Discussed in T-libs meeting](https://github.com/rust-lang/rust/issues/82913#issuecomment-801429887), outcome is to remove it from the `prelude` and re-add it in the next edition
+  - @**simulacrum** leaves this nominated to allow release team to chime in and comment
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-03-25.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-03-25.md
@@ -1,0 +1,205 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-03-25
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- :tada: Today the new stable release 1.51 is out :tada:
+
+- Tomorrow **March 26 10am EDT (14:00 UTC)** [compiler team meeting](https://github.com/rust-lang/rust/pull/82556#issuecomment-804087406) to decide on the behaviour of `musl-` targets compiling
+    - current background doc for design meeting: https://hackmd.io/YoAGSxUsRWumVvbRiHddrg
+
+### MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "Lint large assignments and locals" [compiler-team#420](https://github.com/rust-lang/compiler-team/issues/420)
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  - "Lang Item for Transmutability" [compiler-team#411](https://github.com/rust-lang/compiler-team/issues/411)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+- Pending FCP requests (check your boxes!)
+  - "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+- Things in FCP (make sure you're good with it)
+  - "Filter out query machinery from compiler backtraces by default" [compiler-team#410](https://github.com/rust-lang/compiler-team/issues/410)
+  - "MCP: Embed the `hir_id` of the _awaited expression_ into `DesugaringKind`" [compiler-team#413](https://github.com/rust-lang/compiler-team/issues/413)
+  - "Switch JSON serialization from rustc_serialize to serde" [compiler-team#418](https://github.com/rust-lang/compiler-team/issues/418)
+  - "Adding diesel to the cargotest suite" [rust#81507](https://github.com/rust-lang/rust/pull/81507)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "tracking issue for `debug_non_exhaustive` feature" [rust#67364](https://github.com/rust-lang/rust/issues/67364)
+  - "Add IEEE 754 compliant fmt/parse of -0, infinity, NaN" [rust#78618](https://github.com/rust-lang/rust/pull/78618)
+  - "Added #[repr(transparent)] to core::cmp::Reverse" [rust#81879](https://github.com/rust-lang/rust/pull/81879)
+  - "Deprecate `doc(include)`" [rust#82539](https://github.com/rust-lang/rust/pull/82539)
+  - "rustdoc: allow list syntax for #[doc(alias)] attributes" [rust#82846](https://github.com/rust-lang/rust/pull/82846)
+
+### WG checkins
+
+-  @*wg-incr-comp* checkin by @**pnkfelix** and @**Wesley Wiser**:
+> Most of wg-incr-comp members have been busy with other tasks. We have not had time to revisit any of the A-incr-comp labelled backlog.
+> We have had a lot of positive activity from @_**cjgillot** ([PRs](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Acjgillot)) and @_**mw** ([PRs](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Amw)), especially inflight improvements to how we handle disk/memory traffic for the incremental state ([PR #82780](https://github.com/rust-lang/rust/pull/82780), [PR #83214](https://github.com/rust-lang/rust/pull/83214))
+> @_**Aaron Hill** enabled incremental hash (ICH) validation ([PR #83007](https://github.com/rust-lang/rust/pull/83007)) which has uncovered many pre-existing bugs that they are now fixing.
+
+-  @*WG-llvm* by @**nagisa**: 
+
+> WG-llvm update: We bumped the LLVM version to a commit from a 12-series branch as well as the minimum LLVM version from 9 to 10. There has been a concentrated effort to clean up a number of regressions that we ended up hitting as well as to enable various features (e.g. noalias) that are fixed in LLVM 12.
+>
+> As there was a recent train roll-over and there are still some outstanding issues surfaced by LLVM12, fixes that we make over the next 6 weeks to the regressions caused by this upgrade should be often be backported.
+
+ * Example of note: [Issue #83335](https://github.com/rust-lang/rust/issues/83335), an AArch64 bare metal miscompile on LLVM12
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Lower condition of `if` expression before it's "then" block" [rust#82308](https://github.com/rust-lang/rust/pull/82308)
+  - PR from @**Esteban Küber** fixes [#82290](https://github.com/rust-lang/rust/issues/82290) and a duplicate [#82250](https://github.com/rust-lang/rust/issues/82250). A `P-medium`, [see brief explaination](https://github.com/rust-lang/rust/issues/82290#issuecomment-782482808)
+  - fairly [safe to backport](https://github.com/rust-lang/rust/pull/82308#issuecomment-782487249), was nightly only, a week ago started affecting beta
+  - reviewed by @**lcnr** 
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No beta nominations for `T-libs-impl` this time.
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - Issue will be discussed at compiler meeting on [March 26 10am EDT (14:00 UTC)](https://github.com/rust-lang/rust/pull/82556#issuecomment-804087406)
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- "Use getrandom for generating HashMap seed" [rust#80149](https://github.com/rust-lang/rust/pull/80149)
+  - Opened by @**Artyom Pavlov**
+  - assigned to @**Steven Fackler**, [raises a question](https://github.com/rust-lang/rust/pull/80149#issuecomment-776352953) about the policy for adding `getrandom` as new std dependency
+  - @**dhardy** describes how [the evaluation process could be](https://github.com/rust-lang/rust/pull/80149#issuecomment-776352953)
+  - labeled for T-libs-impl discussion
+
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [62 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [39 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 3 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 0 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 37 P-high, 90 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "`probe-stack=inline-asm` generates wrong DWARF information" [rust#83139](https://github.com/rust-lang/rust/issues/83139)
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-03-18.20.2354818/near/230877570), outcome was that @**pnkfelix** self assigns and revert PR [#77885](https://github.com/rust-lang/rust/pull/77885) (or part of it)
+  - probably can be now downgraded to `P-high` (as it's clearly not a release blocker)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Method resolution error" [rust#81211](https://github.com/rust-lang/rust/issues/81211)
+  - @**simulacrum** [comments](https://github.com/rust-lang/rust/issues/81211#issuecomment-802917170) being a minor breakage that can slip
+  - anything to add for this issue?
+- "WASI: path_open regression in Rust 1.51 when using LTO" [rust#82758](https://github.com/rust-lang/rust/issues/82758)
+  - Should be fixed by @**simulacrum** in commit [b9438e](https://github.com/Mark-Simulacrum/rust/commit/b9438e090570424d4f0813a94ce96be34351ae4d)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [2021-03-23 Triage Log](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-03-23.md)
+
+An overall busy but decent week for performance. While there were some performance regressions they were mostly small, and they were outnumbered by performance gains. Perhaps the most interesting news is not a compiler performance improvement but rather the introduction of no-alias optimizations at the LLVM level. This slightly hurts optimized build time performance in some cases, but it should make some workloads run faster after compilation.
+
+Triage done by **@rylev**.
+
+2 Regressions, 5 Improvements, 3 Mixed
+1 of them in rollups
+
+## Performance logs
+
+> [2021-03-23 Triage Log](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-03-23.md)
+
+An overall busy but decent week for performance. While there were some performance regressions they were mostly small, and they were outnumbered by performance gains. Perhaps the most interesting news is not a compiler performance improvement but rather the introduction of no-alias optimizations at the LLVM level. This slightly hurts optimized build time performance in some cases, but it should make some workloads run faster after compilation.
+
+Triage done by **@rylev**.
+
+2 Regressions, 5 Improvements, 3 Mixed
+1 of them in rollups
+
+#### Regressions
+
+Implement (but don't use) valtree and refactor in preparation of use [#82936](https://github.com/rust-lang/rust/issues/82936)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f5d8117c338a788bd24abec733fd143dfceb25a0&end=e655fb62216b6ba64a094b30f116d7988d19322d&stat=instructions:u) (up to 2.1% on `full` builds of `ctfe-stress-4-opt`)
+- Purely an addition of unused code (for a future feature). It is possible that this changed some inlining behavior, but the benchmark in question is susceptible to high variance though it seemed to impact full builds and not incremental builds.
+- The query impacted is `eval_to_allocation_raw` which is what ctfe stresses, so we'll [look into it](https://github.com/rust-lang/rust/pull/82936#issuecomment-805029518).
+
+Use TrustedRandomAccess for in-place iterators where possible [#79846](https://github.com/rust-lang/rust/issues/79846)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=97663b6690689379aa0493deb494dfe14627c46b&end=35385770ae1ea86a911cc44ac43f856831e44b26&stat=instructions:u) (up to 1.5% on `full` builds of `deep-vector-debug`)
+- This is a change in the standard library that seems to only impact one benchmark: `deep-vector-debug` full compilation. It looks to be impacting `typeck`, but I'm not sure why this would be. It's also possible that it's noise.
+- There's also a possibility that this has some strange interaction with the performance gained in [#83360](https://github.com/rust-lang/rust/issues/83360).
+
+#### Improvements
+
+- Add a check for ASCII characters in to_upper and to_lower [#81358](https://github.com/rust-lang/rust/issues/81358)
+- ast/hir: Rename field-related structures [#83188](https://github.com/rust-lang/rust/issues/83188)
+- Revert performance-sensitive change in #82436 [#83293](https://github.com/rust-lang/rust/issues/83293)
+- Rollup of 9 pull requests [#83360](https://github.com/rust-lang/rust/issues/83360)
+- Simplify encoder and decoder [#83273](https://github.com/rust-lang/rust/issues/83273)
+
+#### Mixed
+
+- feat: Update hashbrown to instantiate less llvm IR [#77566](https://github.com/rust-lang/rust/issues/77566)
+- Replace closures_captures and upvar_capture with closure_min_captures [#82951](https://github.com/rust-lang/rust/issues/82951)
+- Enable mutable noalias for LLVM >= 12 [#82834](https://github.com/rust-lang/rust/issues/82834)
+
+#### Nags requiring follow up
+
+- [Issue](https://github.com/rust-lang/rust/pull/82964#issuecomment-800663588) from last week needs to still be addressed.
+- This weeks follow-ups:
+    - https://github.com/rust-lang/rust/pull/77566#issuecomment-805033514
+    - https://github.com/rust-lang/rust/pull/82951#issuecomment-805038336
+    - https://github.com/rust-lang/rust/pull/82936#issuecomment-805029518
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+  - mentioned during last [meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-03-18.20.2354818/near/230879756)
+  - @**pnkfelix** has discussed it a bit with @**Alex Kornitzer**, still trying to figure out what the scope of it is, in terms of rustc's role
+  - @**Alex Kornitzer** [points out](https://github.com/rust-lang/rust/issues/82151#issuecomment-801310681) that the issue is related to how cargo changed behaviour
+
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - mentioned in `P-waiting-on-team`
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- "Use getrandom for generating HashMap seed" [rust#80149](https://github.com/rust-lang/rust/pull/80149)
+  - mentioned in `P-waiting-on-team`
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-04-01.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-04-01.md
@@ -1,0 +1,186 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-04-01
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- No Steering Meeting tomorrow (2021-04-02), as it is holiday in many countries.
+
+### MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+  - "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+- Old MCPs (not seconded, take a look)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Lang Item for Transmutability" [compiler-team#411](https://github.com/rust-lang/compiler-team/issues/411)
+  - "Switch JSON serialization from rustc_serialize to serde" [compiler-team#418](https://github.com/rust-lang/compiler-team/issues/418)
+  - "Lint large assignments and locals" [compiler-team#420](https://github.com/rust-lang/compiler-team/issues/420)
+  - "Adding diesel to the cargotest suite" [rust#81507](https://github.com/rust-lang/rust/pull/81507)
+  - "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+- Accepted MCPs
+  - "Filter out query machinery from compiler backtraces by default" [compiler-team#410](https://github.com/rust-lang/compiler-team/issues/410)
+  - "MCP: Embed the `hir_id` of the _awaited expression_ into `DesugaringKind`" [compiler-team#413](https://github.com/rust-lang/compiler-team/issues/413)
+- Finalized FCPs (disposition merge)
+  - "Implement indexing slices with pairs of core::ops::Bound<usize>" [rust#77704](https://github.com/rust-lang/rust/pull/77704)
+  - "Stabilize or_patterns (RFC 2535, 2530, 2175)" [rust#79278](https://github.com/rust-lang/rust/pull/79278)
+  - "Make NonNull::as_ref (and friends) return refs with unbound lifetimes" [rust#80771](https://github.com/rust-lang/rust/pull/80771)
+  - "Stabilize `assoc_char_funcs` and `assoc_char_consts`" [rust#82919](https://github.com/rust-lang/rust/pull/82919)
+  - "Stabilize `bufreader_seek_relative`" [rust#82992](https://github.com/rust-lang/rust/pull/82992)
+  - "Deprecate RustcEncodable and RustcDecodable." [rust#83160](https://github.com/rust-lang/rust/pull/83160)
+
+### WG checkins
+
+@*WG-mir-opt* checkin by @**oli**:
+> * Partook in the shrinkmem sprint
+> * mir-opt-level=2 is now automatically activated in release mode
+> * shaved off a few percentages of max-rss by adjusting MIR datastructures
+> * ran some experiments to pinpoint an MVP for MIR inlining
+
+@*WG-polonius* checkin by @**lqd**
+> Nothing especially newsworthy since the last check-in, only a little progress has been made since then.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Fix the `unsafe_block_in_unsafe_fn`s stabilized version" [rust#83736](https://github.com/rust-lang/rust/pull/83736)
+  - opened by @**Yuki Okushi|217081** 
+  - reviewed by @**Joshua Nelson** 
+  - fixes issue [#83735](https://github.com/rust-lang/rust/issues/83735), a wrong claim about `unsafe_block_in_unsafe_fn` being stabilized in 1.51.0
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- :beta: "Fix Self keyword doc URL conflict on case insensitive file systems (until definitely fixed on rustdoc)" [rust#83678](https://github.com/rust-lang/rust/pull/83678)
+  - opened by @**GuillaumeGomez** 
+  - approved by @**Joshua Nelson** 
+  - Fixes [#80504](https://github.com/rust-lang/rust/issues/80504) and prevents [#83154](https://github.com/rust-lang/rust/issues/83154) and related [rust-lang/rustup#2694](https://github.com/rust-lang/rustup/issues/2694)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - [actionables from the meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bdesign.20meeting.5D.202021-03-26.20musl.20linking.20compiler-team.23416)
+    - Written an [MCP](https://github.com/rust-lang/compiler-team/issues/422), verify whether we can give warnings, and have the team sign it off
+    - Finally a blog post to give a heads up and guidance [comment](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bdesign.20meeting.5D.202021-03-26.20musl.20linking.20compiler-team.23416/near/231979422)
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [62 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [39 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 3 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 0 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 38 P-high, 91 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- "Double free in Vec::from_iter specialization when drop panics" [rust#83618](https://github.com/rust-lang/rust/issues/83618)
+  - Opened by @**Yechan Bae**
+  -  @**The 8472|239181** submitted PR [#83629](https://github.com/rust-lang/rust/pull/83629)
+  - PR assigned for review to @**Mara**
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "WASI: path_open regression in Rust 1.51 when using LTO" [rust#82758](https://github.com/rust-lang/rust/issues/82758)
+  - fixed by @**simulacrum** in PR [#82804](https://github.com/rust-lang/rust/pull/82804), PR should be in 1.51 stable
+  - is there an actionable for this issue?
+- "`probe-stack=inline-asm` generates wrong DWARF information" [rust#83139](https://github.com/rust-lang/rust/issues/83139)
+  - partially mitigated by @**pnkfelix** in PR [#82412](https://github.com/rust-lang/rust/pull/83412), which reverts PR [#77885](https://github.com/rust-lang/rust/pull/77885)
+  - from the PR comment: after we resolve [#83139](https://github.com/rust-lang/rust/issues/83139) (potentially by backporting a fix to LLVM or by deciding that one cannot rely on the quality of our DWARF output in the manner described in #83139), we can change this back
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [2021-04-01 Triage Log](https://github.com/rust-lang/rustc-perf/blob/7af0553b65a918cf4b19fa289a85bd97abf3f43b/triage/2021-04-01.md)
+
+A somewhat negative weak for performance where regressions outweigh improvements. Sadly, a lot of the regressions don't seem very straight-forward to understand, and so more investigation will be necessary.
+
+Triage done by **@rylev**: 2 Regressions, 2 Improvements, 3 Mixed, 2 of them in rollups
+
+#### Regressions
+
+implement `feature(const_generics_defaults)` [#75384](https://github.com/rust-lang/rust/issues/75384)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=db492ecd5ba6bd82205612cebb9034710653f0c2&end=5b33de3340c7b36646af46303a30f7066b4bd7db&stat=instructions:u) (up to 1.1% on `incr-unchanged` builds of `ucd-check`)
+- A small regression in incremental compilation in one particular benchmark `ucd`. The query affected is `generate_crate_metadata` which tracks with the fact that incremental compilation is affected.
+- A quick scan of the changes doesn't reveal anything suspicious as encoding of metadata has changed only a little bit and should only be impacted when encoding something with default const generics.
+
+Use `EvaluatedToOkModuloRegions` whenever we erase regions [#83220](https://github.com/rust-lang/rust/issues/83220)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f5fe425c925ef36d5f4c18cfa44173fc42de31b8&end=07e0e2ec268c140e607e1ac7f49f145612d0f597&stat=instructions:u) (up to 1.8% on `full` builds of `hyper-2-check`)
+- A moderate regression in trait obligation evaluation which this code directly impacts. 
+- A performance run was performed, but the impact was deemed acceptable. The author and reviewer [were pinged](https://github.com/rust-lang/rust/pull/83220#issuecomment-811752366) about why the performance is acceptable.
+
+Refactor `Binder` to track bound vars [#76814](https://github.com/rust-lang/rust/issues/76814)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a5029ac0ab372aec515db2e718da6d7787f3d122&end=4fdac23f3171e2f8864d359a21da600dd3faafc9&stat=instructions:u) (up to 3.9% on `incr-unchanged` builds of `externs-check`)
+- Moderate regression in trait resolution queries which this code directly impacts. While a performance run was made, it was never discussed in the PR. The author and reviewer [were pinged](https://github.com/rust-lang/rust/pull/76814#issuecomment-811758311).
+
+#### Improvements
+
+- Rollup of 9 pull requests [#83432](https://github.com/rust-lang/rust/issues/83432)
+- Rollup of 8 pull requests [#83580](https://github.com/rust-lang/rust/issues/83580)
+
+#### Mixed
+
+- Remove assignments to ZST places instead of marking ZST return place as unused [#83177](https://github.com/rust-lang/rust/issues/83177)
+- Import small cold functions [#82980](https://github.com/rust-lang/rust/issues/82980)
+- Reduce the impact of Vec::reserve calls that do not cause any allocation [#83357](https://github.com/rust-lang/rust/issues/83357)
+
+#### Nags requiring follow up
+
+- The [issue](https://github.com/rust-lang/rust/pull/82964#issuecomment-800663588) from two weeks ago has stalled.
+- Follow-ups from this week:
+    - https://github.com/rust-lang/rust/pull/83220#issuecomment-811752366
+    - https://github.com/rust-lang/rust/pull/76814#issuecomment-811758311
+    - https://github.com/rust-lang/rust/pull/82980#issuecomment-811767001
+    - https://github.com/rust-lang/rust/pull/83357#issuecomment-811770400
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+  - (mentioned in [past meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-03-18.20.2354818/near/230879756))
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - (see item in S-waiting-on-team)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-04-08.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-04-08.md
@@ -1,0 +1,162 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-04-08
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow, at 10 AM EST, is the T-compiler planning meeting for the upcoming cycle
+
+- New MCPs (take a look, see if you like them!)
+  - "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+- Old MCPs (not seconded, take a look)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  - "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Lang Item for Transmutability" [compiler-team#411](https://github.com/rust-lang/compiler-team/issues/411)
+  - "Switch JSON serialization from rustc_serialize to serde" [compiler-team#418](https://github.com/rust-lang/compiler-team/issues/418)
+  - "Lint large assignments and locals" [compiler-team#420](https://github.com/rust-lang/compiler-team/issues/420)
+  - "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+- Accepted MCPs
+  - "Filter out query machinery from compiler backtraces by default" [compiler-team#410](https://github.com/rust-lang/compiler-team/issues/410)
+- Finalized FCPs (disposition merge)
+  - "Allow qualified paths in struct construction (both expressions and patterns)" [rust#80080](https://github.com/rust-lang/rust/pull/80080)
+  - "Stabilize cmp_min_max_by" [rust#81047](https://github.com/rust-lang/rust/pull/81047)
+  - "Adding diesel to the cargotest suite" [rust#81507](https://github.com/rust-lang/rust/pull/81507)
+  - "Stabilize `peekable_peek_mut`" [rust#81938](https://github.com/rust-lang/rust/pull/81938)
+  - "reduce threads spawned by ui-tests" [rust#81942](https://github.com/rust-lang/rust/pull/81942)
+  - "Add strong_count mutation methods to Rc" [rust#83476](https://github.com/rust-lang/rust/pull/83476)
+
+### WG checkins
+
+@*WG-rfc-2229* checkin by @**Matthew Jasper** and @**nikomatsakis**:
+> * Feature mostly works and is avaiable under #![feature(capture_disjoint_fields)]
+> * We have handled all edge cases we are aware of including patterns, FRU syntax, references in move closures, handling unsafe
+> * Migration lint for drop reordering is supported under #[deny(disjoint_capture_drop_reorder)] and is supported using rust fix.
+> * On going work to support migration for auto-traits, and diagnostics
+
+
+@*WG-polymorphization* checkin by @**davidtwco**:
+> There's nothing to report from the polymorphization working group.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No backport nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- :beta: "Fix Self keyword doc URL conflict on case insensitive file systems (until definitely fixed on rustdoc)" [rust#83678](https://github.com/rust-lang/rust/pull/83678)
+  - opened by @**GuillaumeGomez** 
+  - approved by @**Joshua Nelson**
+  - Fixes [#80504](https://github.com/rust-lang/rust/issues/80504) and prevents [#83154](https://github.com/rust-lang/rust/issues/83154) and related [rust-lang/rustup#2694](https://github.com/rust-lang/rustup/issues/2694)
+  - mentioned last week -> postponed backport decision after checking if patch actually fixes the issue (@**Joshua Nelson** [confirms PR fixes the issue](https://github.com/rust-lang/rustup/issues/2694#issuecomment-812918127))
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - [actionables from the meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bdesign.20meeting.5D.202021-03-26.20musl.20linking.20compiler-team.23416)
+    - Written an [MCP](https://github.com/rust-lang/compiler-team/issues/422), verify whether we can give warnings, and have the team sign it off
+    - Finally a blog post to give a heads up and guidance [comment](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bdesign.20meeting.5D.202021-03-26.20musl.20linking.20compiler-team.23416/near/231979422)
+    - [mentioned last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-04-01.20.2354818/near/232763387): give feedback to author before closing the issue and move on
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [63 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [39 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 1 P-high, 4 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 38 P-high, 88 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "`probe-stack=inline-asm` generates wrong DWARF information" [rust#83139](https://github.com/rust-lang/rust/issues/83139)
+  - partially mitigated by @**pnkfelix** in PR [#82412](https://github.com/rust-lang/rust/pull/83412), which reverts PR [#77885](https://github.com/rust-lang/rust/pull/77885)
+  - from the PR comment: after we resolve [#83139](https://github.com/rust-lang/rust/issues/83139) (potentially by backporting a fix to LLVM or by deciding that one cannot rely on the quality of our DWARF output in the manner described in #83139), we can change this back
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [2021-04-06 Full triage logs](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-04-06.md)
+
+A pretty major week for [memory usage improvements](https://perf.rust-lang.org/?start=4896450e7e0a522486b4d3a8d360ac4e1d2072a0&end=d32238532138485c80db4f2cd596372bce214e00&absolute=false&stat=max-rss), while wall time performance
+largely stayed neutral, with an average of ~20% gains on memory usage for
+release builds, and 5% on check builds, due to an update in the default allocator
+used (to a more recent jemalloc).
+
+Triage done by **@simulacrum**: 1 Regressions, 4 Improvements, 0 Mixed
+
+#### Regressions
+
+add OR_PATTERNS_BACK_COMPAT lint [#83468](https://github.com/rust-lang/rust/issues/83468)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a207871d5c22f89093085da89becbb636a45ef89&end=36bcf4069717b9dff90270d13b53a3b130329960&stat=instructions:u) (up to 1.2% on `incr-patched: println` builds of `coercions-debug`)
+- Relatively small hit on a number of benchmarks. Likely largely unavoidable.
+
+#### Improvements
+
+- Stream the dep-graph to a file instead of storing it in-memory [#82780](https://github.com/rust-lang/rust/pull/82780)
+- panic early when `TrustedLen` indicates a `length > usize::MAX` [#83726](https://github.com/rust-lang/rust/issues/83726)
+- Use tikv-jemallocator in rustc/rustdoc in addition to jemalloc-sys when enabled. [#83152](https://github.com/rust-lang/rust/issues/83152)
+
+#### Nags requiring follow up
+
+- The [issue](https://github.com/rust-lang/rust/pull/82964#issuecomment-800663588) from three weeks ago has stalled.
+  Likely this needs someone to mentor the author, or to take over the
+  investigation.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+  - (postponed from previous [meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-03-18.20.2354818/near/230879756))
+- "add dynamically-linked musl targets" [rust#82556](https://github.com/rust-lang/rust/pull/82556)
+  - (see item in S-waiting-on-team)
+- "Add default search path to `Target::search()`" [rust#83800](https://github.com/rust-lang/rust/pull/83800)
+  - `I-nominated` by @**nagisa**: [see comment](https://github.com/rust-lang/rust/pull/83800#issuecomment-813990895)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-04-15.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-04-15.md
@@ -1,0 +1,179 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-04-15
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Heads-up: meeting for [perf triage report construction](https://github.com/rust-lang/compiler-team/issues/400) is pushed to **April, 30th** at 10am EST (14:00 UTC) (originally scheduled for tomorrow April, 16th). 
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Debuggable Macro Expansions" [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386)
+  - "Staged queries" [compiler-team#391](https://github.com/rust-lang/compiler-team/issues/391)
+  - "Do not traverse the HIR to generate metadata" [compiler-team#392](https://github.com/rust-lang/compiler-team/issues/392)
+  - "Embed version numbers in backport nominations and regression labels" [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  - "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+  - "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+- Pending FCP requests (check your boxes!)
+  - "Add default search path to `Target::search()`" [rust#83800](https://github.com/rust-lang/rust/pull/83800)
+- Things in FCP (make sure you're good with it)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+- Accepted MCPs
+  - "Lang Item for Transmutability" [compiler-team#411](https://github.com/rust-lang/compiler-team/issues/411)
+  - "Switch JSON serialization from rustc_serialize to serde" [compiler-team#418](https://github.com/rust-lang/compiler-team/issues/418)
+  - "Lint large assignments and locals" [compiler-team#420](https://github.com/rust-lang/compiler-team/issues/420)
+- Closed MCPs for inactivity ([policy](https://forge.rust-lang.org/compiler/mcp.html#when-should-major-change-proposals-be-closed))
+  - Do not traverse the HIR to generate metadata [compiler-team#342](https://github.com/rust-lang/compiler-team/issues/392)
+  - Embed version numbers in backport nominations and regression labels [compiler-team#393](https://github.com/rust-lang/compiler-team/issues/393)
+  - Debuggable Macro Expansions [compiler-team#386](https://github.com/rust-lang/compiler-team/issues/386) 
+- Finalized FCPs (disposition merge)
+  - "Tracking Issue for `Duration::{zero, is_zero}` (`#![feature(duration_zero)]`)" [rust#73544](https://github.com/rust-lang/rust/issues/73544)
+  - "Tracking Issue for `Duration` saturating operations" [rust#76416](https://github.com/rust-lang/rust/issues/76416)
+  - "Tracking Issue for feature: "option_insert"" [rust#78271](https://github.com/rust-lang/rust/issues/78271)
+  - "Tracking Issue for `atomic_fetch_update`" [rust#78639](https://github.com/rust-lang/rust/issues/78639)
+  - "Tracking Issue for `#![feature(const_cell_into_inner)]`" [rust#78729](https://github.com/rust-lang/rust/issues/78729)
+  - "Tracking Issue for {BTreeMap,BTreeSet}::retain" [rust#79025](https://github.com/rust-lang/rust/issues/79025)
+  - "Tracking Issue for feature(nonzero_leading_trailing_zeros)" [rust#79143](https://github.com/rust-lang/rust/issues/79143)
+  - "Tracking issue: fNN::is_subnormal" [rust#79288](https://github.com/rust-lang/rust/issues/79288)
+  - "Stabilize `rustdoc::bare_urls` lint" [rust#81764](https://github.com/rust-lang/rust/pull/81764)
+  - "Turn old edition lint (anonymous-parameters) into warn-by-default on 2015" [rust#82918](https://github.com/rust-lang/rust/pull/82918)
+  - "Disallow octal format in Ipv4 string" [rust#83652](https://github.com/rust-lang/rust/pull/83652)
+  - "Remove `T: Debug` bound on UnsafeCell Debug impl" [rust#83707](https://github.com/rust-lang/rust/pull/83707)
+
+### WG checkins
+
+- @*WG-rls2.0* checkin by @**matklad**
+> * Conveniently, we just finished a six-week sprint
+    * old sprint: https://github.com/rust-analyzer/rust-analyzer/issues/7838
+    * new sprint: https://github.com/rust-analyzer/rust-analyzer/issues/8486
+> * We now support derive and function-like proc macros by default
+> * Supprot for attribute proc-macros is the last big bit until we have "feature parity" with rustc (
+  well, was before min-const-generics were stabilized :-)
+> * We switched to chalk's representation on types!
+> * We significantly reduced memory usage of rust-analyzer (finally!)
+
+> Overall, there's a feeling that rust-analyzer becomes less and less experimental, and more a dependable piece of Rust tooling. So, we want to focus on quality next: fixing glaring bugs, tidying up the internals, and, hopefully, moving forward with [RFC 2912](https://github.com/rust-lang/rfcs/blob/master/text/2912-rust-analyzer.md).
+
+> Sadly, there's still not much concrete progress on sharing more code between rustc and rust-analyzer, besides the chalk work.
+  
+
+- @*WG-self-profile* checkin by @**Wesley Wiser** and `michaelwoerister`
+> The working group has been quiet recently. Nothing to report. 
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "move new c abi abort behavior behind feature gate" [rust#84158](https://github.com/rust-lang/rust/pull/84158)
+  - pnkfelix nominated. They're not sure where the regression to beta is being tracked, if at all.
+  - the discussion on #**t-release>`"C"` unwind issue for release 1.52**  indicated that we would *either* backport this fix (PR #84158), or we would revert PR #76570 on beta. That is the choice before us.
+
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [63 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [39 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 1 P-high, 4 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 38 P-high, 86 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- "`probe-stack=inline-asm` generates wrong DWARF information" [rust#83139](https://github.com/rust-lang/rust/issues/83139)
+  - partially mitigated by @**pnkfelix** in PR [#82412](https://github.com/rust-lang/rust/pull/83412), which reverts PR [#77885](https://github.com/rust-lang/rust/pull/77885)
+  - backporting LLVM patch [D99579](https://reviews.llvm.org/D99579) as partial solution
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [2021-04-13 full triage logs](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-04-13.md)
+
+A very quiet week overall. Triage done by **@simulacrum**.
+
+1 Regressions, 0 Improvements, 0 Mixed, 0 of them in rollups
+
+#### Regressions
+
+Update stdarch submodule (to before it switched to const generics) [#83776](https://github.com/rust-lang/rust/issues/83776)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=1284da34da56a17ae368e4673920ec4120562cbd&end=d0695c9081b16077d0aed368bccaf437d77ff497&stat=instructions:u) (up to 6.3% on `incr-unchanged` builds of `deeply-nested-closures-debug`)
+- Mostly a regression for doc benchmarks, but also a 1.5% regression in memory
+  usage on check, debug, and opt builds across all benchmarks.
+
+#### Improvements
+
+- None
+
+#### Mixed
+
+- None
+
+#### Nags requiring follow up
+
+- The [issue](https://github.com/rust-lang/rust/pull/82964#issuecomment-800663588) from three weeks ago has stalled.
+  Likely this needs someone to mentor the author, or to take over the
+  investigation.
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`undefined reference to` linker error when using dylibs" [rust#82151](https://github.com/rust-lang/rust/issues/82151)
+  - (postponed from previous meetings)
+- "no_std: binary size blowup using Result::unwrap since 1.49.0" [rustc#83925](https://github.com/rust-lang/rust/issues/83925)
+  - size of final binary exceeding the limit for deployment on an embedded tier2 platform (`thumbv7em-none-eabi`)
+  - unsure how to treat this
+- "Disk usage 2-3x somewhere around 1.48" [rustc##84097](https://github.com/rust-lang/rust/issues/84097)
+  - Debian maintainer reports substancial increasing disk space when building rustc, across recent stable releases, build config is unchanged.
+  - issue reporter mentions that possibly debuginfo-related - the architectures using the least space have `debuginfo-level = 0 `due to [#45854](https://github.com/rust-lang/rust/issues/45854), generally the 32-bit.
+  - disk space metrics are not really measured on [perf.rlo](https://perf.rust-lang.org/dashboard.html)
+  - unsure how to treat this class of issues involving disk space usage
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-04-22.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-04-22.md
@@ -1,0 +1,166 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-04-22
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+Reminder: meeting [rustc steering: "guiding principles" doc](https://github.com/rust-lang/compiler-team/issues/424) tomorrow **April, 23rd at 10am EST (14:00 UTC)**
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  - "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+- Pending FCP requests (check your boxes!)
+  - "Add default search path to `Target::search()`" [rust#83800](https://github.com/rust-lang/rust/pull/83800)
+- Things in FCP (make sure you're good with it)
+  - "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  - "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  - "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+  - "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+  - "Split rustc_mir" [compiler-team#426](https://github.com/rust-lang/compiler-team/issues/426)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Tracking issue for RFC 2457, "Allow non-ASCII identifiers"" [rust#55467](https://github.com/rust-lang/rust/issues/55467)
+
+### WG checkins
+
+@*WG-async-foundations* checkin by @**nikomatsakis** and @**tmandry**
+> The major work has been the [async vision doc](https://rust-lang.github.io/wg-async-foundations/vision.html).
+> We now have 30 [status quo stories](https://rust-lang.github.io/wg-async-foundations/vision/status_quo.html), with more on the way.
+> We recently announced the start of the [shiny future brainstorming session](https://blog.rust-lang.org/2021/04/14/async-vision-doc-shiny-future.html).
+> If you're interested in participating, you might consider joining one of the [writing sessions](https://smallcultfollowing.com/babysteps/blog/2021/04/19/async-vision-doc-writing-sessions-vi/) that are taking place tomorrow, hosted by @**rylev** and @**nikomatsakis**.
+
+@*WG-traits*  checkin by @**nikomatsakis** and @**Jack Huey**
+> We've been concentrating on a number of initiatives:
+> 
+> * Creating a standalone library for Rust types: @**Jack Huey** recently landed #76814, which refactored binders so that they have a list of the things which they bind. This helps to align with Chalk's representation and permits us to represent things like `for<'a> fn(i32)`, where the `'a` in the binder doesn't actually appear in the type. Other notable PRs are on the way.
+> * Improving chalk: @**FireFighterDuck** landed rust-lang/chalk#698 that fixes coinductive handling in the recursive solver. Movement here has otherwise been slow.
+> * Async fn in traits: We created a [project board](https://github.com/rust-lang/wg-traits/projects/4) tracking the major blockers and milestones in this effort. 
+> * Closing various bugs: most notably, @**nikomatsakis** has been working with @**Aaron Hill** on #83913 and with @**Jack Huey** to resolve some problems that arose aftr #76814 landed.
+>
+> Office hours: We've also designed some regular blocks ("office hours") where @**nikomatsakis** and others are around and working on tasks. There is one general office hours and the other is designed for async fn in traits. Check the compiler team calendar for details.
+
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "move new c abi abort behavior behind feature gate" [#84158](https://github.com/rust-lang/rust/pull/84158)
+  - "PR [#76570](https://github.com/rust-lang/rust/pull/76570), which implements the "C-unwind" ABI, also changes the behavior of the "C" ABI, re-introducing the abort-on-unwind logic once more. However, while "C-unwind" is behind a feature flag, the abort-on-unwind logic is not."
+  - nomination postponed [from previous meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-04-15.20.2354818/near/234681707), @**simulacrum** suggests asking the project group to come back with a summary of the pros/cons and whys
+- :beta: "Update to LLVM 12.0.0 final" [rust#84230](https://github.com/rust-lang/rust/pull/84230)
+  - opened by @**cuviper**, already merged
+  - @**Nikita Popov** [comments](https://github.com/rust-lang/rust/pull/84230#issuecomment-821001707) we should wait for the backport of [https://reviews.llvm.org/D99469](https://reviews.llvm.org/D99469) (not landed upstream yet)
+  - @**nagisa** [comments](https://github.com/rust-lang/rust/pull/84230#issuecomment-821399329) that the patch to [add dwarf annotation for inline stack probe](https://reviews.llvm.org/rG1c268a8ff4e90a85d0e634350b1104080614cf2b) won't make it LLVM12 final so it will need to be manually backported to nightly/beta
+- :beta: "[beta] Bump LLVM to a upstream 12.0 release" [rust#84271](https://github.com/rust-lang/rust/pull/84271)
+  - opened by @**nagisa**
+  - Current beta branch utilizes a release candidate of LLVM 12.0. We want the upstream fixes (also those we know affecting Rust) before the next stable rust release (May, 6th).
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- :beta: "Fixes API soundness issue in join()" [rust#81728](https://github.com/rust-lang/rust/pull/81728)
+  - opened by @**Yechan Bae** , already merged
+  - nominated by @**cuviper** because of [CVE-2020-36323](https://github.com/rust-lang/rust/pull/81728#issuecomment-821351869)
+- :beta: "Fix double-drop in `Vec::from_iter(vec.into_iter())` specialization when items drop during panic" [rust#83629](https://github.com/rust-lang/rust/pull/83629)
+  - nominated by @**cuviper** because of [CVE-2020-31162](https://github.com/rust-lang/rust/pull/83629#issuecomment-821352426)
+  - r'ed by @**Mara**
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [69 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [45 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 6 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 3 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 40 P-high, 86 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "`probe-stack=inline-asm` generates wrong DWARF information" [rust#83139](https://github.com/rust-lang/rust/issues/83139)
+  - @**nagisa** handled backporting of [https://reviews.llvm.org/D99579](https://github.com/rust-lang/rust/issues/83139#issuecomment-815871790) in [PR #84270](https://github.com/rust-lang/rust/pull/84270)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Diagnostic when a trait is not in scope no longer tells you to add a use, instead tells you to box the receiver." [rust#84272](https://github.com/rust-lang/rust/issues/84272)
+  - A very useful diagnostic is lost, apparently regressed in [commit](https://github.com/rust-lang/rust/commit/16156fb2787f745e57504197bd7fe38b69c6cbea)
+  - perhaps happened in [PR #83667](https://github.com/rust-lang/rust/pull/83667)
+  - @**estebank** [suggests](https://github.com/rust-lang/rust/issues/84272#issuecomment-821909819) a fix but not sure if applicable in all cases
+
+## Performance logs
+
+> [2021-04-21 triage logs](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-04-21.md)
+
+Another quiet week with very small changes to compiler performance.
+
+Triage done by **@rylev**. 1 Regressions, 0 Improvements, 1 Mixed, 0 of them in rollups
+
+#### Regressions
+
+Fix lookahead with None-delimited group [#84130](https://github.com/rust-lang/rust/issues/84130)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7537b20626100e7e7fc8c4ad3079d38c05338121&end=16bf626a31cb5b121d0bca2baa969b4f67eb0dab&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `deep-vector-check`)
+- While this change fixes a bug, it does introduce moderate regressions in runtime performance on some benchmarks and a fairly large regression on the compilation of the rustc_parse crate itself.
+- We will [follow up](https://github.com/rust-lang/rust/pull/84130#issuecomment-823898920) on this particularly in the matter of `rustc_parse`'s compilation times regressing.
+
+#### Improvements
+
+- none
+
+#### Mixed
+
+Add some #[inline(always)] to arithmetic methods of integers [#84061](https://github.com/rust-lang/rust/issues/84061)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=392ba2ba1a7d6c542d2459fb8133bebf62a4a423&end=83ca4b7e600241850e61be48dee859f1604de50d&stat=instructions:u) (up to 1.7% on `full` builds of `regex-debug`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=392ba2ba1a7d6c542d2459fb8133bebf62a4a423&end=83ca4b7e600241850e61be48dee859f1604de50d&stat=instructions:u) (up to -1.3% on `incr-unchanged` builds of `cargo-check`)
+- This change inlines a bunch of code that might not have been previously. It's not really a surprise that codegen now is taking longer to churn through all those inline calls.
+- While this tradeoff on compile times for runtime performance is likely worth it, we are [checking in with the PR author and reviewer](https://github.com/rust-lang/rust/pull/84061#issuecomment-823908561) to make sure this is discussed.
+
+#### Nags requiring follow up
+
+- This week's follow ups:
+  - https://github.com/rust-lang/rust/pull/84130#issuecomment-823898920
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-04-29.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-04-29.md
@@ -1,0 +1,164 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-04-29
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+- Tomorrow (Friday April, 30th) rustc steering: [perf triage report construction](https://hackmd.io/@ryanlevick/Bk1Hidcbu) at 10:00 ET (14:00 UTC)
+- Next week **May, 6th** the new stable release 1.52 will be out
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  -  "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  -  "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  -  "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  -  "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  -  "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  -  "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+  -  "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+  -  "Split rustc_mir" [compiler-team#426](https://github.com/rust-lang/compiler-team/issues/426)
+  -  "Add default search path to `Target::search()`" [rust#83800](https://github.com/rust-lang/rust/pull/83800)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  -  "Tracking issue for x86 bittest intrinsics" [rust#59414](https://github.com/rust-lang/rust/issues/59414)
+  -  "Tracking issue for array::from_ref and array::from_mut" [rust#77101](https://github.com/rust-lang/rust/issues/77101)
+  -  "Tracking Issue for 'ordering helpers'" [rust#79885](https://github.com/rust-lang/rust/issues/79885)
+  -  "Tracking Issue for vec_extend_from_within" [rust#81656](https://github.com/rust-lang/rust/issues/81656)
+  -  "Update BARE_TRAIT_OBJECT and ELLIPSIS_INCLUSIVE_RANGE_PATTERNS to errors in Rust 2021" [rust#83213](https://github.com/rust-lang/rust/pull/83213)
+  -  "Stabilize `:pat_param` and remove `:pat2021`" [rust#83386](https://github.com/rust-lang/rust/pull/83386)
+  -  "Allow setting `target_family` to multiple values, and implement `target_family="wasm"`" [rust#84072](https://github.com/rust-lang/rust/pull/84072)
+  -  "Stabilize Duration::MAX" [rust#84120](https://github.com/rust-lang/rust/pull/84120)
+  -  "Cautiously add IntoIterator for arrays by value" [rust#84147](https://github.com/rust-lang/rust/pull/84147)
+
+### WG checkins
+
+@*WG-diagnostics* by @**Esteban Küber** and @**oli**:
+> Checkin text
+
+@*WG-rustc-dev-guide* by @**Santiago Pastorino** and @**Joshua Nelson**:
+
+> ### Most notable changes
+>- Add sample nix shell [#1113](https://github.com/rust-lang/rustc-dev-guide/pull/1113)
+>- Mention -Z unpretty=mir-cfg for debugging MIR [#1112](https://github.com/rust-lang/rustc-dev-guide/pull/1112)
+>- Mention CI build of LLVM in build instructions [#1104](https://github.com/rust-lang/rustc-dev-guide/pull/1104)
+>- Document test input normalization [#1098](https://github.com/rust-lang/rustc-dev-guide/pull/1098)
+>- Add quickstart for adding a new optimization [#1094](https://github.com/rust-lang/rustc-dev-guide/pull/1094)
+>- Add Polymorphisation paper [#1093](https://github.com/rust-lang/rustc-dev-guide/pull/1093)
+>- Suggest using `git range-diff` [#1092](https://github.com/rust-lang/rustc-dev-guide/pull/1092)
+
+> ### Most notable WIPs
+>- Update build instructions for rustdoc [#1117](https://github.com/rust-lang/rustc-dev-guide/pull/1117)
+>- Remove requests or suggestions about rebase and fixup contradictory to rust-highfive bot comment [#1111](https://github.com/rust-lang/rustc-dev-guide/pull/1111)
+>- Document inert vs active attributes [#1110](https://github.com/rust-lang/rustc-dev-guide/pull/1110)
+>- Explain the new valtree system for type level constants. [#1097](https://github.com/rust-lang/rustc-dev-guide/pull/1097)
+>- Add a section on keeping things up to date in the git section [#1031](https://github.com/rust-lang/rustc-dev-guide/pull/1031)
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No backport nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [70 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [46 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 2 P-high, 5 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 41 P-high, 86 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "HRTBs are unsound: HRTB on subtrait provides HTRB on supertrait with weaker implied bounds." [rust#84591](https://github.com/rust-lang/rust/issues/84591)
+  - higher ranked trait bound (HRTB) unsoundness on Rust stable
+- "Functions, closures, and HRTB-trait-objects can implement traits such that validity of associated types is never checked." [rust#84533](https://github.com/rust-lang/rust/issues/84533)
+  - related to previous issue #84591
+  - note: perhaps not be a regression, faulty code compiles even on 2018-01-01 nightly
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "rustdoc drops impl Foreign<Local> for Foreign" [rust#82465](https://github.com/rust-lang/rust/issues/82465)
+   - this should be handled by PR [#82496](https://github.com/rust-lang/rust/pull/82496) by @**GuillaumeGomez**
+   - The PR is blocked by some compiler error, [see stacktrace](https://github.com/rust-lang/rust/pull/82496#issuecomment-785396571)
+   - The PR has work done by @**GuillaumeGomez** and @**Joshua Nelson**  (also commented by @**Vadim Petrochenkov** [comments](https://github.com/rust-lang/rust/pull/82496#issuecomment-786951402)) but seems to a bit stuck
+   - Perhaps a second look at it?
+- "`probe-stack=inline-asm` generates wrong DWARF information" [rust#83139](https://github.com/rust-lang/rust/issues/83139)
+   - @nagisa handled backporting of https://reviews.llvm.org/D99579 in PR #84270
+   - and @**pnkfelix** with PR [#83412](https://github.com/rust-lang/rust/pull/83412)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Type annotations needed error on definition site" [rust#84398](https://github.com/rust-lang/rust/issues/84398)
+  - @**Jack Huey** submitted patch [#84559](https://github.com/rust-lang/rust/pull/84559) (unassigned, waiting for a review)
+
+## Performance logs
+
+> [2021-04-28 triage logs](https://github.com/rust-lang/rustc-perf/blob/fa2f5c61fd8f0490eeb4e41dbcd21cb39a461b44/triage/2021-04-28.md)
+
+It's always nice to have a week without any regressions and 2 small improvements 🎉🎉.
+
+Triage done by **@rylev**.
+
+0 Regressions, 2 Improvements, 0 Mixed, 0 of them in rollups
+
+#### Regressions
+
+#### Improvements
+
+- Use arrayvec 0.7, drop smallvec 0.6 [#84420](https://github.com/rust-lang/rust/issues/84420)
+- Update grab bag [#84498](https://github.com/rust-lang/rust/issues/84498)
+
+#### Mixed
+
+#### Nags requiring follow up
+
+* There has still been no follow up to [last week's issue](https://github.com/rust-lang/rust/pull/84130#issuecomment-823898920).
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "lldb tests only run on macos" [rust#81813](https://github.com/rust-lang/rust/issues/81813)
+  - nominated by @**pnkfelix** [see comment](https://github.com/rust-lang/rust/issues/81813#issuecomment-828786338) about debuginfo tests breakage
+
+- Special case: [highfive#278](https://github.com/rust-lang/highfive/pull/278)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-05-06.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-05-06.md
@@ -1,0 +1,172 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-05-06
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+- :tada: Today the new stable release 1.52 is out :tada:
+- Tomorrow **May, 7th 2021 10:00 ET** (14:00 UTC) monthly [Compiler Team planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html)
+
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  -  "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  -  "Eagerly construct bodies of THIR" [compiler-team#409](https://github.com/rust-lang/compiler-team/issues/409)
+  -  "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  -  "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  -  "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  -  "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  -  "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+  -  "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+  -  "Split rustc_mir" [compiler-team#426](https://github.com/rust-lang/compiler-team/issues/426)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  -  "Tracking Issue for {HashMap,BTreeMap}::into_{keys,values}" [rust#75294](https://github.com/rust-lang/rust/issues/75294)
+  -  "Add default search path to `Target::search()`" [rust#83800](https://github.com/rust-lang/rust/pull/83800)
+
+### WG checkins
+
+- @*wg-incr-comp* by @**pnkfelix** and @**Wesley Wiser**:
+
+> The incr-comp working group will be shifting to having its bi-weekly meetings [on zulip](https://rust-lang.zulipchat.com/#narrow/stream/241847-t-compiler.2Fwg-incr-comp/topic/change.20meeting.20time.20or.20other.20changes.20to.20drive.20engagement/near/235333445) instead of zoom.
+>
+> Since the last checkin (on [25 march 2021](https://hackmd.io/UZ8VFdqFT0mJtGRnm-Lwmw?view#WG-checkins)), thanks to efforts by cjgillot, we have started streaming the dep-graph to a file instead of storing it in-memory ([PR #82780](https://github.com/rust-lang/rust/pull/82780)).
+>
+- @*WG-llvm* checkin by @**nagisa**:
+> Since the LLVM 12's landing there have been a large number of issues. Many were fixed. We also enabled a some features we thought were fixed. So we still have plenty of problems that are still outstanding. We'll have to disable some of those features (mutable-noalias, inline-asm stack probes...) until we've more confidence they're fixed again
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Deduplicate ParamCandidates with the same value except for bound vars" [rust#84559](https://github.com/rust-lang/rust/pull/84559)
+  - Opened by @**Jack Huey**
+  - changes requested by @**nikomatsakis**
+  - Fixes a [p-high regression](https://github.com/rust-lang/rust/issues/84398) that slipped into beta 1.53
+- :beta: "Account for unsatisfied bounds in E0599" [rust#84808](https://github.com/rust-lang/rust/pull/84808)
+  - Opened by @**Esteban Küber**
+  - reviewed by @**Vadim Petrochenkov**, already merged
+  - Fixes a [P-high](https://github.com/rust-lang/rust/issues/84769)
+  - Nominated for 1.53 beta backport
+- :beta: "Do not ICE on invalid const param" [rust#84913](https://github.com/rust-lang/rust/pull/84913)
+  - Opened by @**Esteban Küber**
+  - reviewed by @**varkor**, already merged
+  - Fixes a [P-medium ICE](https://github.com/rust-lang/rust/issues/84831)
+  - Nominated for 1.53 beta backport
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Remove unstable `--pretty` flag" [rust#83491](https://github.com/rust-lang/rust/pull/83491)
+  - Should disambiguate and consolidate the usage of two apparently redundant flags (`--unpretty` and `--pretty`) into one
+  - Only known usage seems to be in the Rust Playground
+  - Reviewed by @**varkor**, suggests removing it from the Rust Playground before landing this (@**Jake Goulding** agrees on removing the flag)
+  - [@**Santiago Pastorino** suggests](https://github.com/rust-lang/rust/pull/83491#issuecomment-831894280) renaming/aliasing the flag to a `--dump-*` to better reflect its purpose
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- "Use try_reserve in Vec's io::Write" [rust#84612](https://github.com/rust-lang/rust/pull/84612)
+  - Opened by @**Kornel**
+  - Assigned for review to @**Mara**, waiting for consensus from T-libs
+  - Currently discussing the possible breakage this could cause (although fixing an incorrect behaviour)
+  - addressed the concern by [making it a warning](https://github.com/rust-lang/rust/pull/84612#issuecomment-833052459) and maybe `io::Error` in the future
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [73 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [51 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 2 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 42 P-high, 88 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "no_coverage feature-gated on function, not crate?" [rust#84836](https://github.com/rust-lang/rust/issues/84836)
+   - opened by @**simulacrum**
+   - @**Rich Kadel** pushed [a PR to address the concern](https://github.com/rust-lang/rust/pull/84871)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - opened by @**simulacrum** and nominated for discussion (see below)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Type annotations needed error on definition site" [rust#84398](https://github.com/rust-lang/rust/issues/84398)
+  - This should be fixed by PR [#84559](https://github.com/rust-lang/rust/pull/84559) (mentioned before in beta backports)
+- "On nightly rustc, E0599 emits a massive diagnostic to suggest wrapping the receiver in every combination of `{Box,Pin,Rc,Arc}::new({,&,&mut} expr)`" [rust#84769](https://github.com/rust-lang/rust/issues/84769)
+  - Addressed by @**Esteban Küber** in PR [#84808](https://github.com/rust-lang/rust/pull/84808)
+  - Will be also beta backported with PR [#84969](https://github.com/rust-lang/rust/pull/84969) (waiting for review, see previous beta nomination)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-05-04](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-05-04.md)
+
+Quiet week overall.
+
+Triage done by **@simulacrum**, 2 Regressions, 1 Improvements, 1 Mixed
+
+#### Regressions
+
+Revert PR 77885 everywhere [#84708](https://github.com/rust-lang/rust/issues/84708)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=18587b14d1d820d31151d5c0a633621a67149e78&end=478a07df05e3fe8df964291d8b25dd80b7e0e76b&stat=instructions:u) (up to 2.0% on `incr-unchanged` builds of `cargo-check`)
+
+Update BARE_TRAIT_OBJECT and ELLIPSIS_INCLUSIVE_RANGE_PATTERNS to errors in Rust 2021 [#83213](https://github.com/rust-lang/rust/issues/83213)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=c20c9219dae5ea56ce9bf1c211fafdc7da8700b9&end=7a0f1781d04662041db5deaef89598a8edd53717&stat=instructions:u) (up to 3.0% on `incr-unchanged` builds of `encoding-check`)
+
+#### Improvements
+
+- "const" initialized thread locals in rustc [#84833](https://github.com/rust-lang/rust/issues/84833)
+
+#### Mixed
+
+Move HIR parenting information out of hir_owner [#83114](https://github.com/rust-lang/rust/issues/83114)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5f304a5d7908d9dd55dda3baadd3cf564d907369&end=6e2a34474bb86911c5235476d2ea820e163629fe&stat=instructions:u) (up to -5.0% on `incr-patched: println` builds of `piston-image-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5f304a5d7908d9dd55dda3baadd3cf564d907369&end=6e2a34474bb86911c5235476d2ea820e163629fe&stat=instructions:u) (up to 2.2% on `incr-unchanged` builds of `unused-warnings-check`)
+
+#### Nags requiring follow up
+
+* None this week
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - opened by @**simulacrum**
+  - a `P-critical` nominated for discussion to be addressed before next stable
+  - [as per comment](https://github.com/rust-lang/rust/issues/84970#issue-877005793): there will be new ICEs emitted as a result of improved error detection in the incremental code, are there more user-friendly alternatives than emitting ICEs?
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-05-13.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-05-13.md
@@ -1,0 +1,156 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-05-13
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  -  "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  -  "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  -  "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+  -  "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+- Accepted MCPs
+  -  "MCP: More Cranelift-friendly portable SIMD intrinsics" [compiler-team#381](https://github.com/rust-lang/compiler-team/issues/381)
+  -  "Uplift the `invalid_atomic_ordering` lint from clippy to rustc" [compiler-team#390](https://github.com/rust-lang/compiler-team/issues/390)
+  -  "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+  -  "Split rustc_mir" [compiler-team#426](https://github.com/rust-lang/compiler-team/issues/426)
+- Finalized FCPs (disposition merge)
+  -  "rustdoc: Make "rust code block is empty" and "could not parse code block" warnings a lint (`INVALID_RUST_CODEBLOCKS`)" [rust#84587](https://github.com/rust-lang/rust/pull/84587)
+
+### WG checkins
+
+@*WG-mir-opt* by @**wesleywiser**:
+> Not much has been merged recently but there are a number of different projects in flight at the moment. A few highlights:
+> - Run RemoveZsts pass at mir-opt-level=1 [#83417](https://github.com/rust-lang/rust/pull/83417)
+> - Optimize calls to CopyNonOverlapping [#83785](https://github.com/rust-lang/rust/pull/83785)
+> - Mir-Opt for copying enums with large discrepancies [#85158](https://github.com/rust-lang/rust/pull/85158)
+> - Constant::eq skips spans [#85208](https://github.com/rust-lang/rust/pull/85208)
+
+@*WG-polymorphization by @**davidtwco**:
+> There's no update from the polymorphization working group. Working group members are focusing their efforts elsewhere currently.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Disallows `#![feature(no_coverage)]` on stable and beta (using standard crate-level gating)" [rust#84871](https://github.com/rust-lang/rust/pull/84871)
+  - opened by @**Rich Kadel**
+  - reviewed by @**nagisa** and @**tmandry**
+  - fixes P-critical [#84836](https://github.com/rust-lang/rust/issues/84836)
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No beta nominations for `T-libs-impl` this time.
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Remove unstable `--pretty` flag" [rust#83491](https://github.com/rust-lang/rust/pull/83491)
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-05-06.20.2354818/near/237667433)
+  - (@**pnkfelix** had some thoughts to be published on the PR)
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [74 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [50 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 43 P-high, 87 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - issue (and related ones) is being followed
+  - are there already candidate patches for a stable backport? (ref. [this comment](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/unstable.20fingerprints.20-.20actually.20in.201.2E52/near/238357575))
+  - anything else to discuss for this tracking issue?
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "On nightly rustc, E0599 emits a massive diagnostic to suggest wrapping the receiver in every combination of `{Box,Pin,Rc,Arc}::new({,&,&mut} expr)`" [rust#84769](https://github.com/rust-lang/rust/issues/84769)
+  - beta backport of patch [rust#84808](https://github.com/rust-lang/rust/issues/84808) has been approved
+  - issue be closed once lands in 1.53 beta
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Improve diagnostics of `evaluation of constant value failed` errors" [rust#85155](https://github.com/rust-lang/rust/issues/85155)
+  - opened by @**Mike Welsh**
+  - misleading diagnostic which could be annoying, potentially impacting other crates
+  - being tracked in issue [rust#https://github.com/rust-lang/rust/issues/73961](https://github.com/rust-lang/rust/issues/85155#issuecomment-838072043)
+  - regressed in [#83278](https://github.com/rust-lang/rust/pull/83278)
+  - (unsure if this issue warrants a P-high or lower)
+
+## Performance logs
+
+> [triage full logs for 2021-05-11](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-05-11.md)
+
+Not much change overall - both regressions and improvements were all minor, apart from the 2x compile-time improvement for libcore from PR [#83278](https://github.com/rust-lang/rust/issues/83278).
+
+We did see a pretty clear 2% improvement in memory usage ([max-rss](https://perf.rust-lang.org/?start=7a0f1781d04662041db5deaef89598a8edd53717&end=382f748f23979e37e3e012b090e5a0313463f182&absolute=false&stat=max-rss)), and that was again due to PR [#83278](https://github.com/rust-lang/rust/issues/83278).
+
+Triage done by **@pnkfelix**. 2 Regressions, 3 Improvements, 0 Mixed, 0 of them in rollups
+
+#### Regressions
+
+Integrate attributes as part of the crate hash [#83901](https://github.com/rust-lang/rust/issues/83901)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=770792ff8d1ec542e78e77876ac936f43ffb8e05&end=467253ff6a2aecd008d273286315ac14ff8ad937&stat=instructions:u) (up to 1.6% on `full` builds of `externs-check`)
+- There was a regression, seems roughly consistent with the results that we got from the perf run on the PR, so this regression was expected outcome.
+
+Bump stdarch submodule [#83278](https://github.com/rust-lang/rust/issues/83278)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ff34b919075f35a1787659e9c448a34b06bab8de&end=881c1ac408d93bb7adaa3a51dabab9266e82eee8&stat=instructions:u) (up to 3.3% on `full` builds of `keccak-debug`)
+- There are regressions, but as noted in [PR comments](https://github.com/rust-lang/rust/pull/83278#issuecomment-835570336), they were not as bad as anticipated. And also, we did continue to see the 2x win on compile-time for libcore.
+
+#### Improvements
+
+- Retain data in vectorized registers for longer [#84915](https://github.com/rust-lang/rust/issues/84915)
+- lazify backtrace formatting for delayed diagnostics [#84965](https://github.com/rust-lang/rust/issues/84965)
+- Optimize BufWriter [#79930](https://github.com/rust-lang/rust/issues/79930)
+
+#### Mixed
+
+- None
+
+#### Nags requiring follow up
+
+No new nags this week, and none leftover from last week.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-05-20.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-05-20.md
@@ -1,0 +1,224 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-05-20
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+  - "Introduce ty::WhereClause to align chalk and rustc dyn representation" [compiler-team#433](https://github.com/rust-lang/compiler-team/issues/433)
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  - "Rename -Cllvm-args to something backend agnostic" [compiler-team#421](https://github.com/rust-lang/compiler-team/issues/421)
+  - "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+  - "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+  - "Make `TypeFolder::fold_*` return `Result`" [compiler-team#432](https://github.com/rust-lang/compiler-team/issues/432)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Stabilize extended_key_value_attributes" [rust#83366](https://github.com/rust-lang/rust/pull/83366)
+  - "Stabilize "RangeFrom" patterns" [rust#83918](https://github.com/rust-lang/rust/pull/83918)
+  - "Uplift the invalid_atomic_ordering lint from clippy to rustc" [rust#84039](https://github.com/rust-lang/rust/pull/84039)
+  - "rustdoc: Make "rust code block is empty" and "could not parse code block" warnings a lint (`INVALID_RUST_CODEBLOCKS`)" [rust#84587](https://github.com/rust-lang/rust/pull/84587)
+  - "impl FromStr for proc_macro::Literal" [rust#84717](https://github.com/rust-lang/rust/pull/84717)
+  - "FCP poll for ErrorKind::OutOfMemory" [rust#84916](https://github.com/rust-lang/rust/issues/84916)
+
+### WG checkins
+
+@*WG-rfc-2229*  by @**nikomatsakis**  @**Matthew Jasper**:
+- Overall improvement to closure diagnostics: we now point to part of the source code responsible for the capture kind associated with the error message.
+  - Some screenshots of diagnostics here:https://github.com/rust-lang/lang-team/issues/50
+
+- We can now detect if the closure after enabling RFC 2229 will not meet Clone or any of the auto trait bounds and can provide migrations for it. These migrations are supported via rustfix as well.
+
+- We can annote drop implementations with `#[rustc_insignificant_dtor]` to avoid migrating in scenarios where drop order doesn't affect semantics of the program. We intend to use this attribute to annotate the stdlib to mark certain type as safe to be Drop reorded. eg: when a string gets dropped it would not affect the behavior of rest of the program.
+
+- We wrote an initial implementation for printing out the closure size before and after the feature. The implementation is somewhat incomplete, but was good enough for us to get some data on cargo and stdlib.
+Cargo and all depensices size data: [https://docs.google.com/spreadsheets/d/1Irsj5O7HPPfomWat2jPTPdx_KPlsyYo5kRuQpNNuwsQ/edit?usp=sharing](https://docs.google.com/spreadsheets/d/1Irsj5O7HPPfomWat2jPTPdx_KPlsyYo5kRuQpNNuwsQ/edit?usp=sharing)
+
+@*WG-rls2.0* by @**matklad**:
+> No updates for this meeting
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Ensure TLS destructors run before thread joins in SGX" [rust#84409](https://github.com/rust-lang/rust/pull/84409)
+  - opened by "mzohreva"
+  - r'ed by @**David Tolnay** and @**Jethro**, already merged
+  - A bit of context in this [comment](https://github.com/rust-lang/rust/pull/83416#discussion_r617282907)
+- :beta: "Update LLVM submodule" [rust#85236](https://github.com/rust-lang/rust/pull/85236)
+  - opened by @**Nikita Popov**
+  - approved by @**cuviper**
+  - merges recent changes from the upstream LLVM 12 branch, should also fix [rustc#84958](https://github.com/rust-lang/rust/issues/84958)
+- :beta: "Fix incorrect gating of nonterminals in key-value attributes" [rust#85445](https://github.com/rust-lang/rust/pull/85445)
+  - opened by @**Aaron Hill**
+  - approved by @**davidtwco**
+  - Fixes [rusc#85432](https://github.com/rust-lang/rust/issues/85432)
+- :beta: "have on_completion record subcycles" [rust#85186](https://github.com/rust-lang/rust/pull/85186)
+  - Fixes [rust#83538](https://github.com/rust-lang/rust/issues/83538), a P-high issue with the trait evaluation cache
+  - approved by @**Jack Huey**
+  - [comment](https://github.com/rust-lang/rust/pull/85186#issuecomment-840527579): perf comparison seems to indicate a tiny regression but the gain provided by this patch greatly make it worth
+  - nominated by @**nikomatsakis** because [these incremental failures are a big problem](https://github.com/rust-lang/rust/pull/85186#issuecomment-840715095)
+- :stable: "have on_completion record subcycles" [rust#85186](https://github.com/rust-lang/rust/pull/85186)
+  - (above isue nominated also for stable backport)
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- :beta: "remove InPlaceIterable marker from Peekable due to unsoundness" [rust#85340](https://github.com/rust-lang/rust/pull/85340)
+  - opened by @**The 8472|239181**
+  - approved  @**Jane Lusby**
+  - perf run shows overall neutral
+  - fixes a P-critical unsoundness (out of bounds access) [rust#85322](https://github.com/rust-lang/rust/issues/85322)
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- :beta: "rustdoc: Call `initSidebarItems` in root module of crate" [rust#85304](https://github.com/rust-lang/rust/pull/85304)
+  - opened by @**Stu**
+  - approved by @**jsha**
+  - Fixes [rust#85301](https://github.com/rust-lang/rust/issues/85301)
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+-  "Remove unstable `--pretty` flag" [rust#83491](https://github.com/rust-lang/rust/pull/83491)
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [75 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [49 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [3 P-critical, 1 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [3 P-critical, 45 P-high, 85 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - issue (and related ones) is being followed
+  - anything new to discuss for this tracking issue?
+- "Miscompilation on ARM-M with nightly-2021-04-23" [rust#85351](https://github.com/rust-lang/rust/issues/85351)
+  - regression from nightly `nightly-2021-04-23` (therefore `regression-from-stable-to-beta`) on 2 different Tier ARM targets (thumbv8m and thumbv7em)
+  - issue reporter mentions that it could affect other targets
+  - we don't have yet an mcve
+  - in this [comment](https://github.com/rust-lang/rust/issues/85351#issuecomment-842579818) "@yroux" mention is it indeed caused by LLVM 12 and will work on a patch
+- "Regression on nightly in AVX2 byte shift intrinsics" [rust#85446](https://github.com/rust-lang/rust/issues/85446)
+  - Unsoundness on byteshift on x86_64
+  - Seems part of the fallout from PR [rustc#83278](https://github.com/rust-lang/rust/issues/85446#issuecomment-843508538)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+-  "Rustc beta/nightly appears to ignore `unsafe` blocks inside closure in some cases" [rust#85435](https://github.com/rust-lang/rust/issues/85435)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-05-18](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-05-18.md)
+
+A lot of noise in the benchmark results this week. We are discussing ([zulip archive](https://zulip-archive.rust-lang.org/247081tcompilerperformance/06104coercionsdebugnoise.html), [live zulip](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/coercions-debug.20noise)) how best to update the benchmark set to eliminate the noisy cases that are bouncing around. Beyond that, some large improvements to a few individual benchmarks.
+
+The memory usage ([max-rss](https://perf.rust-lang.org/?start=2021-05-11&end=2021-05-18&absolute=true&stat=max-rss)) seemed largely flat. Except for an upward trend on `tuple-stess` that indicates 4% more memory from a week ago.
+
+Triage done by **@pnkfelix**.
+
+5 Regressions, 7 Improvements, 2 Mixed
+1 of them in rollups
+
+#### Regressions
+
+Reachable statics have reachable initializers [#84549](https://github.com/rust-lang/rust/issues/84549)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=747a5d2a5d6693f5e9426524b0dab34eb1587377&end=f8e1e9238077a829ce1ac0cc1f2c7e0eaa4e679d&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `ctfe-stress-4-opt`)
+- `ctfe-stress-4-debug` also saw a 1.2% regression in its `incr-unchanged` builds.
+- Other benchmarks were not significantly impacted.
+- The two regressions were [anticipated](https://github.com/rust-lang/rust/pull/84549#issuecomment-832760519) from a perf run on the PR itself.
+
+#### Improvements (summary)
+
+- have on_completion record subcycles [#85186](https://github.com/rust-lang/rust/issues/85186)
+- Store VariantIdx to distinguish enum variants [#85195](https://github.com/rust-lang/rust/issues/85195)
+- Do not allocate or unwind after fork [#81858](https://github.com/rust-lang/rust/issues/81858)
+
+#### Mixed
+
+BTree: no longer copy keys and values before dropping them [#84904](https://github.com/rust-lang/rust/issues/84904)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=ba8d7e2cb7cfc87070585c17cd0aa4ae7f091a08&end=5c029265465301fe9cb3960ce2a5da6c99b8dcf2&stat=instructions:u) (up to -1.2% on `incr-unchanged` builds of `ctfe-stress-4-check` and `ctfe-stress-4-opt` and `ctfe-stress-4-debug`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ba8d7e2cb7cfc87070585c17cd0aa4ae7f091a08&end=5c029265465301fe9cb3960ce2a5da6c99b8dcf2&stat=instructions:u) (up to 1.2% on `incr-patched: println` builds of `cargo-opt`)
+- These changes were [anticipated](https://github.com/rust-lang/rust/pull/84904#issuecomment-837892302) from a perf run on the PR itself.
+
+rustc_codegen_ssa: only create backend `BasicBlock`s as-needed. [#84993](https://github.com/rust-lang/rust/issues/84993)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=fe72845f7bb6a77b9e671e6a4f32fe714962cec4&end=a55748ffe94e71f841c7b1d752779b0db138b342&stat=instructions:u) (up to -4.3% on `full` builds of `syn-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=fe72845f7bb6a77b9e671e6a4f32fe714962cec4&end=a55748ffe94e71f841c7b1d752779b0db138b342&stat=instructions:u) (up to 1.8% on `full` builds of `deeply-nested-async-check`)
+- The improvement to `syn-opt` was [anticipated](https://github.com/rust-lang/rust/pull/84993#issuecomment-841687503) from perf runs on the PR itself.
+- The regression on `deeply-nested-async-check` was not predicted by that run.
+
+#### Suspicious Noise (summary)
+
+##### coercions
+
+- rustc_driver cleanup [#83610](https://github.com/rust-lang/rust/issues/83610)
+- Add auto traits and clone trait migrations for RFC2229 [#84730](https://github.com/rust-lang/rust/issues/84730)
+- Provide ExitStatusError [#82973](https://github.com/rust-lang/rust/issues/82973)
+- Fix `--remap-path-prefix` not correctly remapping `rust-src` component paths and unify handling of path mapping with virtualized paths [#83813](https://github.com/rust-lang/rust/issues/83813)
+- Rollup of 5 pull requests [#85231](https://github.com/rust-lang/rust/issues/85231)
+- Rollup of 8 pull requests [#85414](https://github.com/rust-lang/rust/issues/85414)
+
+##### html5ever
+
+- Add support for const operands and options to global_asm! [#84107](https://github.com/rust-lang/rust/issues/84107)
+- Update cc crate [#85190](https://github.com/rust-lang/rust/issues/85190)
+
+#### Nags requiring follow up
+
+- Double-check whether regression to `deeply-nested-async-check` from [#84993](https://github.com/rust-lang/rust/issues/84993) is noise or something real.
+- Look into the 4% `tuple-stress` regression. The first seems like gradual creep, plus a 3% jump that seems to be associated with [#84571](https://github.com/rust-lang/rust/pull/84571), "Parse unnamed fields of struct and union type." (Perhaps its inherent given the nature of that microbenchmark, but some other benchmarks also had their [memory usage impacted](https://perf.rust-lang.org/compare.html?start=44ec846f4ea68ffa6d06e7d68f078bd3cc59d4ec&end=9964284fed181676300aad693449f5b751e35ff2&stat=max-rss).
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "ICE: unwrap none error in compiler\rustc_mir\src\monomorphize\collector.rs" [rust#85447](https://github.com/rust-lang/rust/issues/85447)
+  - opened by "kocsis1david"
+  - ICE on nightly 2021-05-09 on target `x86_64-pc-windows-msvc`, latest working version was stable 1.51
+  - [bisection comment](https://github.com/rust-lang/rust/issues/85447#issuecomment-843614853) seems to point to [#81172](https://github.com/rust-lang/rust/pull/81172)
+  - comment: It seems that this only occurs if the crate-type is `lib`. Even if I remove a `pub`, it can compile successfully.
+  - @**Simon Sapin** did [some reduction and investigation](https://github.com/rust-lang/rust/issues/85447#issuecomment-843879967), asks for a bit more insights from someone more familiar with the compiler internals
+- "error: internal compiler error: unexpected panic: Failed to get crate data for crate21" [#85386](https://github.com/rust-lang/rust/issues/85386)
+  - opened by "T0mstone"
+  - ICE on stable 1.52.1, beta 1.53.0-beta.2 and nightly 1.54
+  - issue only occurs when compiling for `wasm32-unknown-unknown`
+  - A reduction is provided [in this comment](https://github.com/rust-lang/rust/issues/85386#issuecomment-842457820)
+  - [comment](https://github.com/rust-lang/rust/issues/85386#issuecomment-842487936): adding a call to `extern crate proc_macros` makes the issue disappear
+  - perhaps related to [#56935](https://github.com/rust-lang/rust/issues/56935)?
+  - Question: would it be useful to have someone closer to the target `wasm32-unknown-unknown` evaliate this issue? We're not sure of its impact (maybe a P-high?)
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-05-27.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-05-27.md
@@ -1,0 +1,170 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-05-27
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  -  "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  -  "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+  -  "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  -  "Make `TypeFolder::fold_*` return `Result`" [compiler-team#432](https://github.com/rust-lang/compiler-team/issues/432)
+  -  "Introduce ty::WhereClause to align chalk and rustc dyn representation" [compiler-team#433](https://github.com/rust-lang/compiler-team/issues/433)
+  -  "Force warnings on lints " [compiler-team#434](https://github.com/rust-lang/compiler-team/issues/434)
+- Accepted MCPs
+  -  "Update the existing musl targets to be dynamically linked." [compiler-team#422](https://github.com/rust-lang/compiler-team/issues/422)
+  -  "A --temps-dir option for specifying where the intermediate files are written" [compiler-team#423](https://github.com/rust-lang/compiler-team/issues/423)
+- Finalized FCPs (disposition merge)
+  -  "Add functions `Duration::try_from_secs_{f32, f64}`" [rust#82179](https://github.com/rust-lang/rust/pull/82179)
+  -  "Move UnwindSafe, RefUnwindSafe, AssertUnwindSafe to core" [rust#84662](https://github.com/rust-lang/rust/pull/84662)
+  -  "stabilize member constraints" [rust#84701](https://github.com/rust-lang/rust/pull/84701)
+  -  "stabilize `int_error_matching`" [rust#84910](https://github.com/rust-lang/rust/pull/84910)
+  -  "stabilize const_fn_unsize" [rust#85078](https://github.com/rust-lang/rust/pull/85078)
+
+### WG checkins
+
+@*WG-self-profile* checkin by @**Wesley Wiser** and michaelwoerister:
+> We've had a few small PRs to `measureme` but no major changes during this time.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "have on_completion record subcycles" [rust#85186](https://github.com/rust-lang/rust/pull/85186)
+  - Fixes [rust#83538](https://github.com/rust-lang/rust/issues/83538), a P-high issue with the trait evaluation cache
+  - approved by @**Jack Huey**
+  - [comment](https://github.com/rust-lang/rust/pull/85186#issuecomment-840527579): perf comparison seems to indicate a tiny regression but the gain provided by this patch greatly make it worth
+  - nominated by @**nikomatsakis** because [these incremental failures are a big problem](https://github.com/rust-lang/rust/pull/85186#issuecomment-840715095)
+- :beta: "readd capture disjoint fields gate" [rust#85564](https://github.com/rust-lang/rust/pull/85564)
+  - opened by @**pnkfelix**
+  - approved by @**nikomatsakis**
+  - adds again a feature gate from PR [rust##83521](https://github.com/rust-lang/rust/pull/83521) to allow a beta backport
+  - backport already discussed and approved? (see [this comment](https://github.com/rust-lang/rust/pull/85564#issuecomment-849045553))
+- :stable: "have on_completion record subcycles" [rust#85186](https://github.com/rust-lang/rust/pull/85186)
+  - (see previous description)
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No beta nominations for `T-libs-impl` this time.
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Remove unstable `--pretty` flag" [rust#83491](https://github.com/rust-lang/rust/pull/83491)
+  - discussed last week, Felix added some [comments](https://github.com/rust-lang/rust/pull/83491#issuecomment-842470356), any reaction?
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [78 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [51 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [6 P-critical, 0 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 46 P-high, 85 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "ICE when reifying function pointers to copy / copy_nonoverlapping using an if" [rust#84297](https://github.com/rust-lang/rust/issues/84297)
+   - also I-nominated (see below)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+   - [comment](https://github.com/rust-lang/rust/issues/84970#issuecomment-840602992) from @**pnkfelix** : downgrade issue to P-high?
+- "Miscompilation on ARM-M with nightly-2021-04-23" [rust#85351](https://github.com/rust-lang/rust/issues/85351)
+  - regression from nightly `nightly-2021-04-23` (therefore `regression-from-stable-to-beta`) on 2 different Tier ARM targets (thumbv8m and thumbv7em)
+  - issue reporter mentions that it could affect other targets
+  - @yroux [submitted a fix](https://github.com/rust-lang/rust/issues/85351#issuecomment-848813102) to LLVM [D103167](https://reviews.llvm.org/D103167), hopefully will be in LLVM 12.0.1
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-05-25](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+A somewhat quiet week. Some PRs had performance runs performed on them, but the changes were merged despite this. Also, we still have issues with certain benchmarks being noisy.
+
+Triage done by **@rylev**.
+
+2 Regressions, 2 Improvements, 1 Mixed
+0 of them in rollups
+
+#### Regressions
+
+Make building THIR a stealable query [#85273](https://github.com/rust-lang/rust/issues/85273)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=126561cb31e8ebe1e2dd9dfd0d3ca621308dc56f&end=d568d63b1f9f5fc47e4202e2a2a84142ff6202d8&stat=instructions:u) (up to 3.7% on `incr-full` builds of `tuple-stress-check`)
+- Work needed for other work to land. A performance run was performed, but still the change was allowed to land. I've asked [why](https://github.com/rust-lang/rust/pull/85273#issuecomment-848017988).
+
+Implement the new desugaring from `try_trait_v2` [#84767](https://github.com/rust-lang/rust/issues/84767)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=491cf5561efb1f5ff33c3234ccd0bc5cacbebe3e&end=4e3e6db011c5b482d2bef8ba02274657f93b5e0d&stat=instructions:u) (up to 2.9% on `full` builds of `cranelift-codegen-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=491cf5561efb1f5ff33c3234ccd0bc5cacbebe3e&end=4e3e6db011c5b482d2bef8ba02274657f93b5e0d&stat=instructions:u) (up to -1.8% on `full` builds of `deeply-nested-async-check`)
+- A much larger performance hit than when the performance suite was run while the pull request was open. This is largely a performance regression with only one non-volatile benchmark showing improvement.
+- Biggest change seems to be in the `mir_built` query which seems to make sense given that probably more mir will be produced by this change.
+- Follow-up happening [here](https://github.com/rust-lang/rust/pull/84767#issuecomment-848036325).
+
+#### Improvements
+
+- fix deallocation of immutable allocations [#85599](https://github.com/rust-lang/rust/issues/85599)
+- std: Attempt again to inline thread-local-init across crates [#84876](https://github.com/rust-lang/rust/issues/84876)
+
+#### Mixed
+
+Avoid zero-length memcpy in formatting [#85391](https://github.com/rust-lang/rust/issues/85391)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=df70463ea5d701489d6f53dc780a2c16294d6143&end=a426fc37f2269093ef1a4dbb3e31b3247980fccc&stat=instructions:u) (up to 3.8% on `incr-patched: println` builds of `cargo-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=df70463ea5d701489d6f53dc780a2c16294d6143&end=a426fc37f2269093ef1a4dbb3e31b3247980fccc&stat=instructions:u) (up to -1.8% on `full` builds of `deeply-nested-async-debug`)
+- This seems to have some interactions with LLVM codegen that cause certain benchmarks to fluctuate in performance. These largely cancel each other out.
+
+#### Nags requiring follow up
+
+- Follow-up:
+    [#84767](https://github.com/rust-lang/rust/pull/84767#issuecomment-848036325).
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "ICE when reifying function pointers to copy / copy_nonoverlapping using an if" [rust#84297](https://github.com/rust-lang/rust/issues/84297)
+  - unassigned
+  - nominated by @**simulacrum** (also for T-lang)
+  - @tmiasko [suggests](https://github.com/rust-lang/rust/issues/84297#issuecomment-830258189) to revert [#81238](https://github.com/rust-lang/rust/pull/81238) as short term solution
+- "Preserve, clarify, and extend debug information" [rust#83947](https://github.com/rust-lang/rust/pull/83947)
+  - nominated by @**pnkfelix**
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-06-03.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-06-03.md
@@ -1,0 +1,202 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-06-03
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Friday **June, 4th 2021 at 10:00 ET / 14:00 UTC** is planning meeting. Get your proposals in at [proposal site](https://github.com/rust-lang/compiler-team/issues/new?assignees=&labels=meeting-proposal&template=meeting-proposal.md&title=%28My+meeting+proposal%29)
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  -  "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  -  "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+  -  "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  -  "Make `TypeFolder::fold_*` return `Result`" [compiler-team#432](https://github.com/rust-lang/compiler-team/issues/432)
+  -  "Introduce ty::WhereClause to align chalk and rustc dyn representation" [compiler-team#433](https://github.com/rust-lang/compiler-team/issues/433)
+  -  "Force warnings on lints " [compiler-team#434](https://github.com/rust-lang/compiler-team/issues/434)
+- Finalized FCPs (disposition merge)
+  -  "Tracking issue for WebAssembly SIMD support" [rust#74372](https://github.com/rust-lang/rust/issues/74372)
+  -  "Tracking Issue for VecDeque binary search functions" [rust#78021](https://github.com/rust-lang/rust/issues/78021)
+  -  "Use try_reserve in Vec's io::Write" [rust#84612](https://github.com/rust-lang/rust/pull/84612)
+  -  "Show test type during prints" [rust#84863](https://github.com/rust-lang/rust/pull/84863)
+  -  "rustc: Allow safe #[target_feature] on wasm" [rust#84988](https://github.com/rust-lang/rust/pull/84988)
+
+### WG checkins
+
+@*WG-async-foundations* @**nikomatsakis**  @**tmandry** 
+> * Currently iterating on the async vision doc.
+> * Completed the brainstorming period.
+> * Working on a "harmonized shiny future".
+> * Little coding at present that @nikomatsakis is aware of, anyhow.
+
+@*WG-traits* by @**nikomatsakis**  @**Jack Huey** 
+> * Stabilized member constraints (https://github.com/rust-lang/rust/pull/84701).
+> * Working towards stabilized named impl Trait and generic associated types.
+> * Jack Huey has a PR that is aiming to normalize under binders (https://github.com/rust-lang/rust/pull/85499), which is pretty exciting.
+> * Still making small steps towards chalk-ty library, such as synchronizing rustc and chalk's folder traits.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Reachable statics have reachable initializers" [rust#84549](https://github.com/rust-lang/rust/pull/84549)
+  - opened by `@tmiasko`
+  - reviewed by @**varkor**
+  - patch is already merged, fixes [#84455](https://github.com/rust-lang/rust/issues/84455) a P-medium()
+- :beta: "Build crtbegin.o/crtend.o from source code" [rust#85395](https://github.com/rust-lang/rust/pull/85395)
+  - opened by @**12101111** 
+  - fixes [#85310](https://github.com/rust-lang/rust/issues/85310), [#47551](https://github.com/rust-lang/rust/issues/47551), [#84033](https://github.com/rust-lang/rust/issues/84033)
+  - already merged, reviewed by @**Vadim Petrochenkov**
+- :stable: "Build crtbegin.o/crtend.o from source code" [rust#85395](https://github.com/rust-lang/rust/pull/85395)
+  - (see beta nomination)
+  - possibly a dot release? (see [comment](https://github.com/rust-lang/rust/pull/85395#issuecomment-850870521))
+  - or revert [#82534](https://github.com/rust-lang/rust/pull/82534)
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [5 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [3 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [76 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [49 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [6 P-critical, 0 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [3 P-critical, 46 P-high, 86 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "ICE when reifying function pointers to copy / copy_nonoverlapping using an if" [rust#84297](https://github.com/rust-lang/rust/issues/84297)
+  - issue of interest for T-lang? 
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - issue is being followed
+- "Miscompilation on ARM-M with nightly-2021-04-23" [rust#85351](https://github.com/rust-lang/rust/issues/85351)
+  - issue reported and fixed on LLVM end [D103167](https://reviews.llvm.org/D103167)
+  - issue unassigned, does it need an owner?
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - opened by @**Frank Steffahn**
+  - reporter suggests possible fixes, on Zulip [some more thoughts](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/Issues.20.2385863.20and.20.2385873)
+  - is this issue of interest for T-lang? Also for T-libs?
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - opened by @**Frank Steffahn**, related to issue [#85863](https://github.com/rust-lang/rust/issues/85863)
+  - issue unassigned
+  - is this issue of interest for T-lang? Also for T-libs?
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - (see above) issue of interest also for T-libs-impl? 
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - (see above) issue of interest also for T-libs-impl? 
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-06](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-06-01.md)
+
+# 2021-06-01 Triage Log
+
+Busy week, with several reverted PRs due to performance regressions, but overall a positive week.
+
+Triage done by **@simulacrum**.
+
+3 Regressions, 3 Improvements, 5 Mixed
+
+#### Regressions
+
+Merge CrateDisambiguator into StableCrateId [#85804](https://github.com/rust-lang/rust/issues/85804)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=2023cc3aa1ea98530f3124ed07713e6f95fd26ab&end=59579907ab52ad2369735622185a26f158bf0f0f&stat=instructions:u) (up to 1.6% on `full` builds of `html5ever-opt`)
+- Seems to differ from the benchmark on PR, but held up over the rest of the
+  week on the graph. Suggested a revert on PR.
+
+#### Improvements
+
+- Don't hash `thir_body` [#85729](https://github.com/rust-lang/rust/issues/85729)
+- Optimize proc macro bridge [#85390](https://github.com/rust-lang/rust/issues/85390)
+
+#### Mixed
+
+Add `TrustedRandomAccess` specialization for `Vec::extend()` [#83770](https://github.com/rust-lang/rust/issues/83770)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9a700d2947f2d7f97a2c0dfca3117a8dcc255bdd&end=9111b8ae9793f18179a1336417618fc07a9cac85&stat=instructions:u) (up to 2.1% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=9a700d2947f2d7f97a2c0dfca3117a8dcc255bdd&end=9111b8ae9793f18179a1336417618fc07a9cac85&stat=instructions:u) (up to -1.6% on `incr-patched: println` builds of `cargo-debug`)
+- Reverted in the next result, seems to surprisingly in practice not be an improvement on
+  some of our larger benchmarks.
+
+Revert "Auto merge of #83770 - the8472:tra-extend, r=Mark-Simulacrum" [#85754](https://github.com/rust-lang/rust/issues/85754)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=9a72afa7dd5689da1844695086d1f89130956a88&end=bff138dbd95cec763f4def6b91bb465a26aaad9f&stat=instructions:u) (up to -2.1% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9a72afa7dd5689da1844695086d1f89130956a88&end=bff138dbd95cec763f4def6b91bb465a26aaad9f&stat=instructions:u) (up to 1.5% on `incr-patched: println` builds of `cargo-debug`)
+
+Simplification of query forcing [#85319](https://github.com/rust-lang/rust/issues/85319)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=d93b6a4598946a6a97e8f1b073b1cfc08d332a86&end=f60a67025607e74fbee31c2007f8791c2f352b6a&stat=instructions:u) (up to -3.2% on `full` builds of `unused-warnings-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=d93b6a4598946a6a97e8f1b073b1cfc08d332a86&end=f60a67025607e74fbee31c2007f8791c2f352b6a&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `stm32f4-check`)
+- Regressions seem to be limited to unused-warnings incremental.
+
+Reduce the amount of untracked state in TyCtxt [#85153](https://github.com/rust-lang/rust/issues/85153)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=d2091147b16a1e3e1f9a73b6ee29fbe941c8abce&end=41278062c8399ac02ed281e8b1648b99a36942e6&stat=instructions:u) (up to 1038.2% on `incr-unchanged` builds of `regex-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=d2091147b16a1e3e1f9a73b6ee29fbe941c8abce&end=41278062c8399ac02ed281e8b1648b99a36942e6&stat=instructions:u) (up to -1.3% on `full` builds of `cranelift-codegen-check`)
+- This was a pretty big regression, and wasn't detected on the PR run,
+  presumably due to work since the merge.
+
+Revert "Reduce the amount of untracked state in TyCtxt" [#85884](https://github.com/rust-lang/rust/issues/85884)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=80af6b091f6a4855be71bba1cd0c1ee9fd2a57a8&end=1160cf864f2a0014e3442367e1b96496bfbeadf4&stat=instructions:u) (up to -91.2% on `incr-unchanged` builds of `regex-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=80af6b091f6a4855be71bba1cd0c1ee9fd2a57a8&end=1160cf864f2a0014e3442367e1b96496bfbeadf4&stat=instructions:u) (up to 1.4% on `full` builds of `cranelift-codegen-check`)
+
+#### Nags requiring follow up
+
+* Expecting to revert [#85804](https://github.com/rust-lang/rust/pull/85804)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- Regression: undefined symbol __atomic_load_4 on risvc32imac-unknown-none-elf [#85736](https://github.com/rust-lang/rust/issues/85736)
+  - opened by github user `@xobs`
+  - regression on nightly-2021-03-18, affects target `riscv32imac-unknown-none`
+  - (spurious?) calls are generated to non-existing symbol `__atomic_load_4`
+  - workaround is to use target `riscv32i-unknown-none-elf`
+  - we have a [repro](https://github.com/rust-lang/rust/issues/85736#issuecomment-849881145)
+  - who can own this?
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-06-10.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-06-10.md
@@ -1,0 +1,224 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-06-10
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- :warning: next week June, 17th, release of Rust stable 1.53
+- pnkfelix seeking review with quick turnaround (in time for cutting 1.54-beta tomorrow) on [PR 85193](https://github.com/rust-lang/rust/pull/85193)
+ 
+### MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437)
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  - "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Allow changing the bug report url for the ice hook" [compiler-team#436](https://github.com/rust-lang/compiler-team/issues/436)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Tracking issue for WebAssembly SIMD support" [rust#74372](https://github.com/rust-lang/rust/issues/74372)
+  - "Tracking Issue for VecDeque binary search functions" [rust#78021](https://github.com/rust-lang/rust/issues/78021)
+  - "Use try_reserve and panic in Vec's io::Write" [rust#84612](https://github.com/rust-lang/rust/pull/84612)
+  - "Show test type during prints" [rust#84863](https://github.com/rust-lang/rust/pull/84863)
+  - "rustc: Allow safe #[target_feature] on wasm" [rust#84988](https://github.com/rust-lang/rust/pull/84988)
+
+### WG checkins
+
+- @*WG-diagnostics*  by @**Esteban Küber** and @**oli**
+> (both leads are on leave at the moment)
+
+- @*WG-rustc-dev-guide* by @**Santiago Pastorino** and @**Joshua Nelson**
+>### Most notable changes
+>
+>- explain Miri engine vs Miri-the-tool [#1134](https://github.com/rust-lang/rustc-dev-guide/pull/1134)
+>- Add more information about no_hash query modifier. [#1133](https://github.com/rust-lang/rustc-dev-guide/pull/1133)
+>- Describe the difference of rustc_lint vs rustc_lint_defs. [#1131](https://github.com/rust-lang/rustc-dev-guide/pull/1131)
+>- Document -Zunpretty=thir-tree [#1128](https://github.com/rust-lang/rustc-dev-guide/pull/1128)
+>- Update coverage docs [#1122](https://github.com/rust-lang/rustc-dev-guide/pull/1122)
+>
+>### Most notable WIPs
+>
+>- Update for merge of CrateDisambiguator into StableCrateId [#1135](https://github.com/rust-lang/rustc-dev-guide/pull/1135)
+>- Document lang items [#1119](https://github.com/rust-lang/rustc-dev-guide/pull/1119)
+>- Move "ctags" section into "Suggested Workflow" [#1115](https://github.com/rust-lang/rustc-dev-guide/pull/1115)
+>- Document inert vs active attributes [#1110](https://github.com/rust-lang/rustc-dev-guide/pull/1110)
+>- Explain the new valtree system for type level constants. [#1097](https://github.com/rust-lang/rustc-dev-guide/pull/1097)
+>- rewrite ty.md [#1057](https://github.com/rust-lang/rustc-dev-guide/pull/1057)
+>- improve glossary page [#1053](https://github.com/rust-lang/rustc-dev-guide/pull/1053)
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Reachable statics have reachable initializers" [rust#84549](https://github.com/rust-lang/rust/pull/84549)
+  - opened by @**tm|352985**
+  - reviewed by @**varkor**
+  - patch is already merged, fixes [#84455](https://github.com/rust-lang/rust/issues/84455), a `P-medium` ICE when crosscompiling
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-03.20.2354818/near/241395829)
+  - decision postponed (possibly decline the backport and let this patch land on next stable)
+- :beta: "Make copy/copy_nonoverlapping fn's again" [rust#86003](https://github.com/rust-lang/rust/pull/86003)
+  - opened and nominated for backport by @**pnkfelix** 
+  - addresses issue [#84297](https://github.com/rust-lang/rust/issues/84297), reverts PRs [#81167](https://github.com/rust-lang/rust/issues/81167) [#81238](https://github.com/rust-lang/rust/issues/81238), part of [#82967](https://github.com/rust-lang/rust/issues/82967), [#83091](https://github.com/rust-lang/rust/issues/83091) and parts of [#79684](https://github.com/rust-lang/rust/issues/79684).
+- :beta: "Disable the machine outliner by default" [rust#86020](https://github.com/rust-lang/rust/pull/86020)
+  - opened by @**nagisa** 
+  - assigned to @**Matthew Jasper**
+  - no r'ed yet
+  - Fixes [#85351](https://github.com/rust-lang/rust/issues/85351), a `P-critical` micompilation on ARM-M arch
+  - Fixing this involves a patch on LLVM, possibly [will make it into LLVM 12.0.1](https://github.com/rust-lang/rust/issues/85351#issuecomment-848813102)
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No beta nominations for `T-libs-impl` this time.
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [6 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [3 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [77 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [50 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [6 P-critical, 0 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [3 P-critical, 47 P-high, 87 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "ICE when reifying function pointers to copy / copy_nonoverlapping using an if" [rust#84297](https://github.com/rust-lang/rust/issues/84297)
+  - discussed in [this Zulip thread](https://zulip-archive.rust-lang.org/131828tcompiler/18251reifyingfunctionptrsforintrinsics84297.html) 
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - Steering meeting lays plan to disable incr-comp on 1.53 ([Zulip link from last week](https://zulip-archive.rust-lang.org/131828tcompiler/18251reifyingfunctionptrsforintrinsics84297.html)) 
+- "Miscompilation on ARM-M with nightly-2021-04-23" [rust#85351](https://github.com/rust-lang/rust/issues/85351)
+  - @**nagisa** authored patch [#86020](https://github.com/rust-lang/rust/pull/86020)
+  - [LLVM patch](https://github.com/rust-lang/rust/issues/85351#issuecomment-848813102) in the pipeline, too
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - mentioned [last week](https://github.com/rust-lang/rust/issues/85863#issuecomment-856958496)
+  - opened by @**Frank Steffahn**
+  - reporter suggests possible fixes, on Zulip [some more thoughts](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/Issues.20.2385863.20and.20.2385873)
+  - @**Josh Triplett** comments this issue will be discussed [in a follow-up T-lang meeting](https://github.com/rust-lang/rust/issues/85863#issuecomment-856958496)
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - same as above: issue will be discussed [in a follow-up T-lang meeting](https://github.com/rust-lang/rust/issues/85863#issuecomment-856958496)
+- "For 1.53, must fwd-port RUSTC_FORCE_INCREMENTAL from 1.52.1" [rust#86004](https://github.com/rust-lang/rust/issues/86004)
+  - Part of [#84970](https://github.com/rust-lang/rust/issues/84970) (Unstable fingerprints)
+  - Tracking issue for the forward-port to 1.53
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - see above
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - see above
+- "`lang_start` in std/src/rt.rs is unsound in presence of panic payload that panics on drop" [rust#86030](https://github.com/rust-lang/rust/issues/86030)
+  - Unsoundness issue, @**nagisa** opened PR [#86034](https://github.com/rust-lang/rust/pull/86034), waiting for review
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-06-08](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-06-08.md)
+
+Some good improvements, and a few regressions. No large changes.
+
+Triage done by **@simulacrum**.
+
+3 Regressions, 3 Improvements, 1 Mixed
+1 of them in rollups
+
+#### Regressions
+
+Always go through the expn_that_defined query. [#86002](https://github.com/rust-lang/rust/issues/86002)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ac3e680193a3e11e60b07840ffb1db12793de110&end=6c2dd251bbff03c7a3092d43fb5b637eca0810e3&stat=instructions:u) (up to 1.6% on `incr-patched: println` builds of `webrender-check`)
+- Necessary for correctness, regresions largely limited to incremental.
+
+Add variance-related information to lifetime error messages [#85343](https://github.com/rust-lang/rust/issues/85343)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5b638c1d3751b7ab31cac9739add516bdf39e10a&end=35fff69d043b1c0f5c29894e7f4b0da8b039c131&stat=instructions:u) (up to 4.3% on `full` builds of `wg-grammar-check`)
+- Seems to potentially be necessary, but difference from PR run suggests more
+  can possibly be done to avoid some of the losses noted on the final merge.
+
+Revert "Merge CrateDisambiguator into StableCrateId" [#85891](https://github.com/rust-lang/rust/issues/85891)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=022720bfccd46400e69def42f4647fe4059ad951&end=2312ff1a850db449b79fd3c4b215395cd2598c25&stat=instructions:u) (up to 4.9% on `full` builds of `html5ever-opt`)
+- Reverted due to performance concerns on the original PR ([#85804]), but does
+  not seem to have recovered performance. Suggested path is to re-land but with
+  measurements the original PR; potentially there are some performance
+  improvements that can be done there as well.
+
+[#85804]: https://github.com/rust-lang/rust/pull/85804
+
+#### Improvements
+
+- Remove CrateNum::ReservedForIncrCompCache [#85829](https://github.com/rust-lang/rust/issues/85829)
+- Only compute the trait map once [#85905](https://github.com/rust-lang/rust/issues/85905)
+- Miscellaneous inlining improvements [#85892](https://github.com/rust-lang/rust/issues/85892)
+
+#### Mixed
+
+Rollup of 13 pull requests [#85952](https://github.com/rust-lang/rust/issues/85952)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=016e9b5e33ef1407bffb575ec63d24241912556d&end=a93699f20a433797a4b84787b9652300dd7b2ad2&stat=instructions:u) (up to -4.8% on `full` builds of `html5ever-opt`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=016e9b5e33ef1407bffb575ec63d24241912556d&end=a93699f20a433797a4b84787b9652300dd7b2ad2&stat=instructions:u) (up to 2.9% on `incr-patched: println` builds of `cargo-opt`)
+- Predominantly an improvement, some incremental regressions; does not appear
+  worthwhile to investigate in depth the exact cause.
+
+#### Nags requiring follow up
+
+* Follow up on regression in [#85343](https://github.com/rust-lang/rust/pull/85343#issuecomment-856819536)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Generate links to definition in rustdoc source code pages" [rust#84176](https://github.com/rust-lang/rust/pull/84176)
+  - opened by @**GuillaumeGomez** 
+  - Adds hyperlinks to navigate code in rustdoc
+  - no known blockers
+  - feature is [nightly-only and disabled by default](https://github.com/rust-lang/rust/pull/84176#issuecomment-821026882)
+  - possibly a follow-up RFC to stabilize and enable it by default  
+  - PR has been reviewed by rustdoc team though final review won't happen soon; PR author asks if `T-compiler` can greenlight merge
+- "Emscripten wasm32 compilation broken" [rust#85821](https://github.com/rust-lang/rust/issues/85821)
+  - Compiling an Hello world with the new emscripten SDK version 2.0.10 trips into a removed stubbed function (`__gxx_personality_v0`) and dies.
+  - With emscripten SDK version 2.0.9 still works because the stub is there
+  - Nominated to find an owner: who has recently their hands in the wasm target (@__**Alex Crichton** ? maybe a WG?) 
+- "Re-add support for parsing (and pretty-printing) inner-attributes in match body" [rust#85193](https://github.com/rust-lang/rust/pull/85193)
+    - see announcements
+    - opened by @**pnkfelix**
+    - re-adds support for `match EXPR { #![inner] ARM_1 ARM_2 ... }` to sidestep breakage from [PR 83312 ](https://github.com/rust-lang/rust/pull/83312)
+    - lang team FCP in process; not end of world if review+landing doesn't happen before 1.54-beta is cut on Friday (tomorrow), but it is nice to avoid backports
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-06-17.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-06-17.md
@@ -1,0 +1,181 @@
+--
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-06-17
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- :tada: today release of Rust stable 1.53 :tada:
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  - "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437)
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - "Allow changing the bug report url for the ice hook" [compiler-team#436](https://github.com/rust-lang/compiler-team/issues/436)
+  - "Transfer on-disk hash table implementation (odht crate) to rust-lang org" [compiler-team#438](https://github.com/rust-lang/compiler-team/issues/438)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Tracking Issue for const `core::str::from_utf8_unchecked`" [rust#75196](https://github.com/rust-lang/rust/issues/75196)
+  - "Re-add support for parsing (and pretty-printing) inner-attributes in match body" [rust#85193](https://github.com/rust-lang/rust/pull/85193)
+  - "Stabilize `ops::ControlFlow` (just the type)" [rust#85608](https://github.com/rust-lang/rust/pull/85608)
+
+### WG checkins
+
+@*wg-incr-comp* by @**pnkfelix** and @**Wesley Wiser**:
+> While there has been activity recently around the ICEs in incremental compilation in 1.52 and 1.53, the group itself has not been very active. 
+
+@*WG-llvm* by @**nagisa** ([last update](https://hackmd.io/w9tJSQkHTZWYet3BUijtTA#WG-checkins)):
+> * Work on opaque pointer types has recently picked up. Don't think it will be ready for next release, but maybe the one after. We should probably get rid of our reliance on pointer element types in codegen_llvm at some point.
+> * A lot of mailing list discussion on pointer provenance wrt pointer<->int conversions (including implicit casts through memory) recently. It doesn't look like there's any consensus yet, but at least there is some movement.
+> * A support for demangling symbols that use new Rust mangling scheme.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Re-add support for parsing (and pretty-printing) inner-attributes in match body" [rust#85193](https://github.com/rust-lang/rust/pull/85193)
+  - nominated by @**Eric Huss**, PR didn't make it to the merge window 
+- :beta: "Revert "Allow specifying alignment for functions"" [rust#86300](https://github.com/rust-lang/rust/pull/86300)
+  - opened by @**pnkfelix** 
+  - @**simulacrum** [comments](https://github.com/rust-lang/rust/pull/86300#issuecomment-861065417) this PR is still a good candidate for backport since PR [#85976](https://github.com/rust-lang/rust/pull/85976) will land in 1.55
+- No stable nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No beta nominations for `T-libs-impl` this time.
+- No stable nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
+- No PRs waiting on `T-libs-impl` this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [2 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [80 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [53 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 1 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 3 P-high, 3 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 48 P-high, 86 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - milestone has been moved to 1.54
+  - reprio to `P-high`?
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - previously discussed
+  - @**Josh Triplett** comments this issue will be discussed [in a follow-up T-lang meeting](https://github.com/rust-lang/rust/issues/85863#issuecomment-856958496)
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - issue will be discussed [in a follow-up T-lang meeting](https://github.com/rust-lang/rust/issues/85863#issuecomment-856958496)
+- "For 1.53, must fwd-port RUSTC_FORCE_INCREMENTAL from 1.52.1" [rust#86004](https://github.com/rust-lang/rust/issues/86004)
+  - Part of [#84970](https://github.com/rust-lang/rust/issues/84970) (Unstable fingerprints)
+  - Tracking issue for the forward-port to 1.53
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+- No `P-critical` issues for `libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "rustdoc: Regression in display of `macro_rules!` matchers" [rust#86208](https://github.com/rust-lang/rust/issues/86208)
+  - looks under control from T-rustdoc (cc: @**Noah Lev** @**Joshua Nelson** )
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Apple platforms: Disabled frame pointer elimination causes perf issues and is not in line with what clang does" [rust#86196](https://github.com/rust-lang/rust/issues/86196)
+  - opened by @**Hans Kratz** 
+  - [mild perf regression](https://github.com/rust-lang/rust/issues/86196#issuecomment-860443448) on target Apple with disabled frame pointer elimination (clang default on macOS: `frame-pointer="no-leaf""`, in Rust nightly became `frame-pointer="all"`) along with an increase in binary size
+  - (assigned `P-high` but - if appropriate for a Tier 1 platform - maybe reprio to `P-critical`
+
+### P-high stable regression (which we don't usually discuss)
+
+- Compile error: static lifetime not satisfied but it is [#86172](https://github.com/rust-lang/rust/issues/86172)
+  - opened by @**Jack Rickard** 
+  - compact [mcve](https://github.com/rust-lang/rust/issues/86172#issuecomment-860236692)
+  - looks like fallout from an old merge [#73905](https://github.com/rust-lang/rust/pull/73905)
+  - assigned `P-high` to get visibility, does `P-medium` is a better fit (or maybe nominate?)
+
+
+## Performance logs
+
+[triage logs for 2021-06-16](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-06-16.md)
+
+The highlight of this week was a huge performance gains in some async focused benchmarks from only pretty-printing generator witness in verbose mode. This improved async heavy benchmarks by as much as 75%.
+
+Triage done by **@rylev**.
+
+1 Regressions, 2 Improvements, 0 Mixed
+0 of them in rollups
+
+#### Regressions
+
+Make copy/copy_nonoverlapping fn's again [#86003](https://github.com/rust-lang/rust/issues/86003)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=47d38752c65359e1f4558d7a06935982fb8b486f&end=eab201df7028ebb6812c0b1a01702ac6ecfcceed&stat=instructions:u) (up to 2.3% on `incr-patched: u8 3072` builds of `issue-46449-debug`)
+- Regressions happening mostly in LLVM codegen which makes sense given that this moves from intrinsics to function calls which should produce more LLVM IR. 
+- Follow up conversation starts [here](https://github.com/rust-lang/rust/pull/86003#issuecomment-862210554).
+
+#### Improvements
+
+- Update cargo [#86207](https://github.com/rust-lang/rust/issues/86207)
+- Pretty print generator witness only in `-Zverbose` mode [#86240](https://github.com/rust-lang/rust/issues/86240)
+
+#### Nags requiring follow up
+
+* Follow up from last week on regression in [#85343](https://github.com/rust-lang/rust/pull/85343#issuecomment-856819536)
+* Follow up to regression in [#86003](https://github.com/rust-lang/rust/pull/86003#issuecomment-862210554).
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Generate links to definition in rustdoc source code pages" [rust#84176](https://github.com/rust-lang/rust/pull/84176)
+  - opened by @**GuillaumeGomez**, adds hyperlinks to navigate code in rustdoc
+  - feature is [nightly-only and disabled by default](https://github.com/rust-lang/rust/pull/84176#issuecomment-821026882)
+  - [Last T-compiler discussion](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Badhoc.5D.202021-06-11.20unsound.20stdlib.20specialization.20and.201.2E53/near/242358093) was oriented to OK'ing the merge after the 1.53 release so we have more time to test/revert/etc.
+- "Re-add support for parsing (and pretty-printing) inner-attributes in match body" [rust#85193](https://github.com/rust-lang/rust/pull/85193)
+  - [discussed by T-lang](https://github.com/rust-lang/rust/pull/85193#issuecomment-852333730)
+  - @**pnkfelix** re-added [nomination for T-compiler](https://github.com/rust-lang/rust/pull/85193#issuecomment-858457241)
+- "Emscripten wasm32 compilation broken" [rust#85821](https://github.com/rust-lang/rust/issues/85821)
+  - Compiling an Hello world with the new emscripten SDK version 2.0.10 trips into a removed stubbed function (`__gxx_personality_v0`) and dies.
+  - With emscripten SDK version 2.0.9 still works because the stub is there
+  - Nominated to find an owner: who has recently their hands in the wasm target (@__**Alex Crichton** ? maybe a WG?)
+- "SPARC - passing argument from C++ to Rust issue" [rust#86163](https://github.com/rust-lang/rust/issues/86163)
+  - opened by @psumbera
+  - unsoundness on Tier 2 target `sparcv9-sun-solaris`
+  - @**nagisa** comments this seems to be a [SPARCv9 64-bit ABI definition issue](https://github.com/rust-lang/rust/issues/86163#issuecomment-857584194)
+  - We have [an MCVE](https://github.com/rust-lang/rust/issues/86163#issuecomment-859089923)
+  - Should we prioritize this as a `P-high` (or higher?) and try to follow-up accordingly? Who can own this?
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-06-24.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-06-24.md
@@ -1,0 +1,168 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-06-24
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- June 25th, at <time:2021-06-25T10:00:00-04:00> 1.52 Fingerprint retrospective [compiler-team#435](https://github.com/rust-lang/compiler-team/issues/435)
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  -  "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439)
+  -  "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441)
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403)
+  -  "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419)
+  -  "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+  -  "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437)
+- Pending FCP requests (check your boxes!)
+  -  "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+- Things in FCP (make sure you're good with it)
+  -  "Allow changing the bug report url for the ice hook" [compiler-team#436](https://github.com/rust-lang/compiler-team/issues/436)
+  -  "Transfer on-disk hash table implementation (odht crate) to rust-lang org" [compiler-team#438](https://github.com/rust-lang/compiler-team/issues/438)
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  -  "Ignore derived Clone and Debug implementations during dead code analysis" [rust#85200](https://github.com/rust-lang/rust/pull/85200)
+  -  "Stabilize span_open() and span_close()." [rust#86136](https://github.com/rust-lang/rust/pull/86136)
+
+### WG checkins
+
+@*WG-polymorphization* by @**davidtwco**
+> There's no update from the polymorphization working group. Everyone involved is working on other things.
+
+@*WG-mir-opt* by @**oli**
+> no update (oli is on leave)
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Disambiguate between SourceFiles from different crates even if they have the same path" [rust#86368](https://github.com/rust-lang/rust/pull/86368)
+- :beta: "rustfmt: load nested out-of-line mods correctly" [rust#86424](https://github.com/rust-lang/rust/pull/86424)
+  - opened by @**caleb**
+  - nominated by @**simulacrum**, [seems safe for beta backport](https://github.com/rust-lang/rust/pull/86424#issuecomment-867140034), stable backport maybe needs more testing
+  - fixes [rustfmt#4874](https://github.com/rust-lang/rustfmt/issues/4874) - rustfmt to no longer processed modules referenced in an inline mod
+- No stable nominations for `T-compiler` this time.
+
+[T-libs stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs) / [T-libs beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs)
+- No nominations for `T-libs` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Build aarch64-apple-ios-sim as part of the full macOS build" [rust#85782](https://github.com/rust-lang/rust/pull/85782)
+  - nominated by @**simulacrum** to indicate that MCP [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428) is waiting to be seconded
+
+[T-libs](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs)
+- "Show type for docs slice Chunks" [rust#77938](https://github.com/rust-lang/rust/pull/77938)
+  - seems safe to merge?
+  - mentioning T-libs to get their attention on this (cc: @**mara**)
+- "core: add unstable no_floating_point to disable float formatting code" [rust#86048](https://github.com/rust-lang/rust/pull/86048)
+  - A review from T-libs is in progress
+
+## Issues of Note
+
+### Short Summary
+
+- [5 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [4 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [81 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [54 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 0 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 3 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 49 P-high, 83 P-medium, 12 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "run-make-fulldeps/pgo-branch-weights fails on AArch64 Linux" [rust#78226](https://github.com/rust-lang/rust/issues/78226)
+  - only fails on aarch64 arm
+  - @**simulacrum** [comments](https://github.com/rust-lang/rust/issues/78226#issuecomment-866299280) that tests for this are disabled but a fix for 1.54 would be good
+- "add back support for inner attributes on non-block expressions?" [rust#84879](https://github.com/rust-lang/rust/issues/84879)
+  - addressed by PR [#85193](https://github.com/rust-lang/rust/pull/85193), can be closed as it is merged
+  - so, can be closed now?
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-17.20.2354818/near/243024615)
+  - @**Aaron Hill** comments about addressing the [sub-obligation](https://github.com/rust-lang/rust/issues/85360) and [the overflow](https://github.com/rust-lang/rust/issues/84963) issues, other than those all known issues are fixed
+  - @**estebank** [offered to have a look](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-17.20.2354818/near/243025573) 
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - updates about this one and the following one discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-17.20.2354818/near/243024615)
+  - @**pnkfelix** mentioned updating these issues
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - see previous one
+
+[T-libs](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs)
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - see above
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - see above
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Apple platforms: Disabled frame pointer elimination causes perf issues and is not in line with what clang does" [rust#86196](https://github.com/rust-lang/rust/issues/86196)
+  - opened by @**Hans Kratz** 
+  - [mild perf regression](https://github.com/rust-lang/rust/issues/86196#issuecomment-860443448) on target Apple with disabled frame pointer elimination (clang default on macOS: `frame-pointer="no-leaf""`, in Rust nightly became `frame-pointer="all"`) along with an increase in binary size
+  - needs an owner but not so a pressing issue (see [comment](https://github.com/rust-lang/rust/issues/86196#issuecomment-860443448): "while using `"frame-pointer"="non-leaf"` on Macos is generally a good idea since it has the potential to affect performance in rare cases it is not as urgent.")
+  
+## Performance logs
+
+> [triage logs for 2021-06-23](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+A few small regressions on smaller benchmarks (e.g., helloworld), likely centered around more IR being generated in a few cases.
+
+Triage done by **@simulacrum**. 2 Regressions, 1 Improvements, 0 Mixed, 1 of them in rollups
+
+#### Regressions
+
+Rollup of 6 pull requests [#86417](https://github.com/rust-lang/rust/issues/86417)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=149f4836dd6d9e789a26dca16dc034588866894e&end=a6bc43ea846ee568ef4e890d4ac2a4cc03475bfc&stat=instructions:u) (up to 2.0% on `incr-unchanged` builds of `helloworld-opt`)
+- Not really clear what the cause here is, but the regression is concentrated on
+  small benchmarks.
+
+Change entry point to 🛡️ against 💥 💥-payloads [#86034](https://github.com/rust-lang/rust/issues/86034)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=29cd70d40722930e66a8b726fe58a7bd1d64a22b&end=6b354a13820a444f834a33365ae4a8d97d7d27ce&stat=instructions:u) (up to 4.5% on `incr-full` builds of `helloworld-opt`)
+- Seems to be more code getting generated into binaries, leading to
+  regressions on the smaller benchmarks.
+
+#### Improvements
+
+- optimize Eq implementation for paths [#86179](https://github.com/rust-lang/rust/issues/86179)
+
+#### Nags requiring follow up
+
+Backlog:
+
+* Follow up on regression in [#85343](https://github.com/rust-lang/rust/pull/85343#issuecomment-856819536)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No `I-nominated` for `T-compiler` this time.
+
+[T-libs](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AI-nominated+-label%3AT-compiler+-label%3AT-lang+-label%3AT-rustdoc)
+- "Remove P: Unpin bound on impl Future for Pin" [rust#81363](https://github.com/rust-lang/rust/pull/81363)
+  - reviewed by @**RalfJ** 
+  - nominated by @**Jane Lusby**
+- "core: add unstable no_floating_point to disable float formatting code" [rust#86048](https://github.com/rust-lang/rust/pull/86048)
+  - see `S-waiting-on-team`
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-07-01.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-07-01.md
@@ -1,0 +1,222 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-07-01
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow <time:2021-07-02T10:00:00-04:00>, montly [Compiler Team Planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html)
+
+## MCPs/FCP
+
+- New MCPs (take a look, see if you like them!)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441)
+  - "Encode spans relative to the enclosing item" [compiler-team#443](https://github.com/rust-lang/compiler-team/issues/443)
+- Old MCPs (not seconded, take a look :point_right: **NEW**: testing age timestamps)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comment: 6 months ago)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: 5 months ago)
+  - "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419) (last comment: +3 months ago)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comment: 20 days ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+- Things in FCP (make sure you're good with it)
+  - "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428)
+  - "Merge rustc_codegen_gcc backend as compiler/rustc_codegen_gcc" [compiler-team#442](https://github.com/rust-lang/compiler-team/issues/442)
+- Accepted MCPs
+  - "Allow changing the bug report url for the ice hook" [compiler-team#436](https://github.com/rust-lang/compiler-team/issues/436)
+  - "Transfer on-disk hash table implementation (odht crate) to rust-lang org" [compiler-team#438](https://github.com/rust-lang/compiler-team/issues/438)
+- Finalized FCPs (disposition merge)
+  - "Tracking issue for `ops::Bound::cloned()`" [rust#61356](https://github.com/rust-lang/rust/issues/61356)
+  - "Support forwarding caller location through trait object method call" [rust#81360](https://github.com/rust-lang/rust/pull/81360)
+  - "Ignore derived Clone and Debug implementations during dead code analysis" [rust#85200](https://github.com/rust-lang/rust/pull/85200)
+  - "When using `process::Command` on Windows, environment variable names must be case-preserving but case-insensitive" [rust#85270](https://github.com/rust-lang/rust/pull/85270)
+  - "Redefine `ErrorKind::Other` and stop using it in std." [rust#85746](https://github.com/rust-lang/rust/pull/85746)
+  - "Stabilize span_open() and span_close()." [rust#86136](https://github.com/rust-lang/rust/pull/86136)
+
+### WG checkins
+
+@*wg-rfc-2229* by @nikomatsakis, @matthewjasper
+>- Feature is now enabled by default and lint is now part of the edition lint
+>- PR approved for -Zprofile-closures which dumps the closure size before and after the feature. This would generate a CSV which can be imported in the [first sheet here](https://docs.google.com/spreadsheets/d/1WUKERwkpJkYhQ-rt0aTQqg-7kcupC7pwKsgxk8v54qc/edit?usp=sharing)
+>- Based on profile of rustc we made an optimization to reduce the sizes of closures which seems to be effective. PR [#86701](https://github.com/rust-lang/rust/pull/86701) is open right now and has more details.
+
+@*WG-rls2.0* by @**matklad**:
+>Steering issues covered by this checkin: 
+>* https://github.com/rust-analyzer/rust-analyzer/issues/8486
+>* https://github.com/rust-analyzer/rust-analyzer/issues/8972
+
+>Hightlights:
+>* rust-analyzer now expands attribute-like proc macros.
+> * We started a conversation with the core team about moving rust-analyzer to the rust-lang project.
+  Theres little actual progress though, still waiting for the kickoff meeting to get scheduled. 
+>* We started groundwork to improve code completion quality: added reliable preformance tests, fixed three O(N^2) algorithms, added regression tests for irrelevant completion.
+>* We are making good progress on fixing all false errors: https://github.com/rust-analyzer/rust-analyzer/issues/8961
+  In general, rust-analyzer now supports most of Rust.
+>* We are tentatively thinking about designing the "final" API that the compiler exposes for the IDE:
+  https://github.com/rust-analyzer/rust-analyzer/issues/8713
+  
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No backport nominations for `T-compiler` this time.
+
+[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
+- No backport nominations for `T-libs-impl` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- :beta: "Revert "List trait impls before methods from deref in the sidebar ..."" [rust#86564](https://github.com/rust-lang/rust/pull/86564)
+  - opened by @**jsha** 
+  - beta-backport since it affects the sidebar display of methods in stdlib docs, substantial impact on people's doc-reading experience if it lands in stable.
+  - reverts commit [8a05892](https://github.com/rust-lang/rust/commit/8a058926ecd6d0988714f8f7a5a31293c533f8c6) and fixes [#85618](https://github.com/rust-lang/rust/issues/85618)
+  - r'ed by @**Joshua Nelson** 
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Build aarch64-apple-ios-sim as part of the full macOS build" [rust#85782](https://github.com/rust-lang/rust/pull/85782)
+  - MCP [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428) was seconded, anything else to do from `T-compiler`?
+
+[T-libs](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs)
+- "Show type for docs slice Chunks" [rust#77938](https://github.com/rust-lang/rust/pull/77938)
+  - being reviewed by T-libs
+- "Fix linker error" [rust#85953](https://github.com/rust-lang/rust/pull/85953)
+  - PR is being followed on [Zulip T-libs](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Using.20weak!.20in.20fs.3A.3Ahard_link)
+- "core: add unstable no_floating_point to disable float formatting code" [rust#86048](https://github.com/rust-lang/rust/pull/86048)
+  - (pr is being reviewed and discussed by T-libs)
+
+## Issues of Note
+
+### Short Summary
+
+- [5 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [4 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [81 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [53 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 0 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 3 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 49 P-high, 83 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "run-make-fulldeps/pgo-branch-weights fails on AArch64 Linux" [rust#78226](https://github.com/rust-lang/rust/issues/78226)
+  - only fails on aarch64 arm
+  - @**simulacrum** [comments](https://github.com/rust-lang/rust/issues/78226#issuecomment-866299280) that tests for this are disabled but a fix for 1.54 would be good
+  - being investigated by @**Jamie Cunliffe** [see comment](https://github.com/rust-lang/rust/issues/78226#issuecomment-868570487)
+- "add back support for inner attributes on non-block expressions?" [rust#84879](https://github.com/rust-lang/rust/issues/84879)
+  - will be closed after [rust#85193](https://github.com/rust-lang/rust/pull/85193) is beta backported (#85193 is merged and `beta-accepted`)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-24.20.2354818/near/243797032)
+  - @**Aaron Hill** comments about addressing the [sub-obligation](https://github.com/rust-lang/rust/issues/85360) and [the overflow](https://github.com/rust-lang/rust/issues/84963) issues, other than those all known issues are fixed
+  - @**estebank** [offered to have a look](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-17.20.2354818/near/243025573)
+  - general feeling is to re-enable incr-comp again in 1.54
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - @**cuviper** ([comment](https://github.com/rust-lang/rust/issues/85863#issuecomment-871797016)) opened pr [rust#86765](https://github.com/rust-lang/rust/pull/86765) and [rust#86766](https://github.com/rust-lang/rust/pull/86766) 
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - @**Frank Steffahn** authored pr [rust#85874](https://github.com/rust-lang/rust/pull/85874) that should close this issue
+
+[T-libs](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs)
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - see above (does T-libs need to be tagged?)
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - see above (does T-libs need to be tagged?)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-06-30](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-06-30.md)
+
+We only have partial results this week (more details below). From the results we have collected, we have one small regression and several improvements.
+Also, there was a broad [max-rss regression](https://perf.rust-lang.org/compare.html?start=29cd70d40722930e66a8b726fe58a7bd1d64a22b&end=6b354a13820a444f834a33365ae4a8d97d7d27ce&stat=max-rss) from 11 days ago and narrower [max-rss regression](https://perf.rust-lang.org/compare.html?start=406d4a9cc3b9601cf98a07c6c83e0227d64f5d48&end=4573a4a879a8e1f773944a8859e4dcd136138af8&stat=max-rss) from 9 days ago.
+
+This week we had some problems with missing benchmark results for some of the commits (we believe this is due to triagebot being out of service for a while). Thus, there is a gap from
+[5a7834050f3a0ebcd117b4ddf0bc1e8459594309](https://github.com/rust-lang/rust/commit/5a7834050f3a0ebcd117b4ddf0bc1e8459594309) to [7c3872e6bfd555d2ad753ac1f871db3bd7f2a547](https://github.com/rust-lang/rust/commit/7c3872e6bfd555d2ad753ac1f871db3bd7f2a547).
+
+The following PR's from that gap were omitted from this analysis.
+
+ * [#86467](https://github.com/rust-lang/rust/issues/86467) - ChrisDenton:win-env-clear, r=JohnTitor
+ * [#85427](https://github.com/rust-lang/rust/issues/85427) - ehuss:fix-use-placement, r=jackh726
+ * [#86279](https://github.com/rust-lang/rust/issues/86279) - JohnTitor:transparent-zero-size-fields, r=nikomatsakis
+ * [#86588](https://github.com/rust-lang/rust/issues/86588) - JohnTitor:rollup-ibgjbkf, r=JohnTitor
+ * [#86138](https://github.com/rust-lang/rust/issues/86138) - FabianWolff:issue-85871, r=nikomatsakis
+ * [#86573](https://github.com/rust-lang/rust/issues/86573) - Mark-Simulacrum:expat-bump, r=pietroalbini
+
+We have manually enqueued the missing commits for benchmarking on perf.rlo.
+
+Triage done by **@pnkfelix**.
+Revision range: [406d4a9cc3b9601cf98a07c6c83e0227d64f5d48..5a7834050f3a0ebcd117b4ddf0bc1e8459594309](https://perf.rust-lang.org/?start=406d4a9cc3b9601cf98a07c6c83e0227d64f5d48&end=5a7834050f3a0ebcd117b4ddf0bc1e8459594309&absolute=false&stat=instructions%3Au)
+Revision range: [7c3872e6bfd555d2ad753ac1f871db3bd7f2a547..7ede6e2a2359c1bb9032baffa4fdafe5633749e3](https://perf.rust-lang.org/?start=7c3872e6bfd555d2ad753ac1f871db3bd7f2a547&end=7ede6e2a2359c1bb9032baffa4fdafe5633749e3&absolute=false&stat=instructions%3Au)
+
+1 Regressions, 5 Improvements, 0 Mixed, 1 of them in rollups
+
+#### Regressions
+
+Disambiguate between SourceFiles from different crates even if they have the same path [#86368](https://github.com/rust-lang/rust/issues/86368)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=3487be11d5f3c9afc4d8e44438cdd2af1e98c859&end=80926fc409d671e7da13f08c90642b1e71f800d9&stat=instructions:u) (up to 1.2% on `incr-unchanged` builds of `ctfe-stress-4-check`)
+
+#### Improvements
+
+- Add MIR pass to lower call to `core::slice::len` into `Len` operand [#86383](https://github.com/rust-lang/rust/issues/86383)
+- Rollup of 11 pull requests [#86527](https://github.com/rust-lang/rust/issues/86527)
+- Derive `Copy` for `VarianceDiagInfo` [#86670](https://github.com/rust-lang/rust/issues/86670)
+- Add inflate to pgo [#86697](https://github.com/rust-lang/rust/issues/86697)
+- Change vtable memory representation to use tcx allocated allocations. [#86475](https://github.com/rust-lang/rust/issues/86475)
+
+#### Mixed
+
+- None
+
+#### Nags requiring follow up
+
+- Follow up on max-rss regression in [#86034](https://github.com/rust-lang/rust/pull/86034#issuecomment-871488586)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- Rework SESSION_GLOBALS API [#84961](https://github.com/rust-lang/rust/pull/84961) 
+  - Authored by @**GuillaumeGomez**
+  - Fixes [rust#84954](https://github.com/rust-lang/rust/issues/84954) (Don't allow overwriting `rustc_span::SESSION_GLOBALS`)
+  - Auto-assigned to Felix but `I-nominated` is more for a review request from T-compiler
+- ICE: unwrap none error in compiler\rustc_mir\src\monomorphize\collector.rs [#85447](https://github.com/rust-lang/rust/issues/85447)
+  - Opened by @kocsis1david
+  - Bisection pointing to pr [rust#81172](https://github.com/rust-lang/rust/pull/81172)
+  - issue reached stable (see [comment](https://github.com/rust-lang/rust/issues/85447#issuecomment-865882530))
+  - previously mentioned by T-compiler ([notes](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-05-20.20.2354818/near/239605615))
+  - @**Simon Sapin** asks for more directions on this, also opened [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/ICE.20with.20unresolved.20Pointee.3A.3AMetadata.20projection)
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610)
+  - perhaps related to one or more issues about the same theme (see mentioned issues, ex. [rust#86431](https://github.com/rust-lang/rust/issues/86431) was mentioned)
+  - a FIY for T-compiler and asking for an opinion: is there an actionable for these issues about binary size growing?
+- "Allow reifying intrinsics to `fn` pointers." [rust#86699](https://github.com/rust-lang/rust/pull/86699)
+  - opened by @**eddyb**, asking for a review ([comment](https://github.com/rust-lang/rust/pull/86699#issuecomment-870745885))
+-  "`match` an `std::cmp::Ordering` generates less optimized code in nightly" [rust#86511](https://github.com/rust-lang/rust/issues/86511)
+  - a comment mentions these issues [#86391](https://github.com/rust-lang/rust/issues/86391) and [#86354](https://github.com/rust-lang/rust/issues/86354)
+  - nominated to help finding someone giving some context 
+
+[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
+- No nominated issues for `T-libs-impl` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-rustdoc)
+- Generate links to definition in rustdoc source code pages [#84176](https://github.com/rust-lang/rust/pull/84176)
+  - Discussed at length [within T-rustdoc](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/go.20to.20definition.20feature), agreement is on merging as it is and keep it on nightly as long as necessary
+  - Perhaps a cursory review from T-compiler to have it merged from someone else than PR author (@**Joshua Nelson** might be able to review this week-end so better from next week)
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-07-08.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-07-08.md
@@ -1,0 +1,180 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-07-08
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Friday meeting: Tomorrow at <time:2021-07-09T10:00:00-04:00> we will be having part III of our series of meetings on the fingerprint bug write-up, compiler-team#435 ([doc](https://hackmd.io/DhKzaRUgTVGSmhW8Mj0c8A?view) under discussion).
+
+### MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comment: 6 months ago)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: 5 months ago)
+  -  "LLVM plugin support in Rust" [compiler-team#419](https://github.com/rust-lang/compiler-team/issues/419) (last comment: 3 months ago)
+  -  "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comment: about 26 days ago)
+  -  "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comment: about 5 days ago)
+  -  "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comment: about 5 days ago)
+  -  "Encode spans relative to the enclosing item" [compiler-team#443](https://github.com/rust-lang/compiler-team/issues/443) (last comment: about 5 days ago)
+- Pending FCP requests (check your boxes!)
+  -  "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+- Things in FCP (make sure you're good with it)
+  - None at this time
+- Accepted MCPs
+  -  "Promote `aarch64-apple-ios-sim` to Tier 2" [compiler-team#428](https://github.com/rust-lang/compiler-team/issues/428) 
+  -  "Merge rustc_codegen_gcc backend as compiler/rustc_codegen_gcc" [compiler-team#442](https://github.com/rust-lang/compiler-team/issues/442)
+- Finalized FCPs (disposition merge)
+  -  "Tracking Issue for feature(string_drain_as_str) - string::Drain::as_str()" [rust#76905](https://github.com/rust-lang/rust/issues/76905) 
+  -  "Tracking Issue for std::io::Seek::rewind()" [rust#85149](https://github.com/rust-lang/rust/issues/85149) 
+
+### WG checkins
+
+*WG-self-profile* checkin by @**mw** && @**Wesley Wiser**:
+> Just a few small things to report here:
+> - @**Aaron Hill** extended measureme's API to allow recording events in a more flexible way if needed.
+> - @**rylev** is working with @**mw** on adding incr. comp. related measurements, starting with query results hashing timings.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No beta nominations for `T-compiler` this time.
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- None at this time
+
+## Early Nominations
+
+- "Allow reifying intrinsics to `fn` pointers." [rust#86699](https://github.com/rust-lang/rust/pull/86699)
+  - opened by @**eddyb**, asking for a review ([comment](https://github.com/rust-lang/rust/pull/86699#issuecomment-870745885))
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [3 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [79 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [53 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 0 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 47 P-high, 83 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "run-make-fulldeps/pgo-branch-weights fails on AArch64 Linux" [rust#78226](https://github.com/rust-lang/rust/issues/78226)
+  - only fails on aarch64 arm
+  - @**simulacrum** [comments](https://github.com/rust-lang/rust/issues/78226#issuecomment-866299280) that tests for this are disabled but a fix for 1.54 would be good
+  - being investigated by @**Jamie Cunliffe** [see comment](https://github.com/rust-lang/rust/issues/78226#issuecomment-868570487) 
+  - @**simulacrum** [suggests](https://github.com/rust-lang/rust/issues/78226#issuecomment-875011175) looking at [#85891](https://github.com/rust-lang/rust/pull/85891)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-24.20.2354818/near/243797032)
+  - @**Aaron Hill** comments about addressing the [sub-obligation](https://github.com/rust-lang/rust/issues/85360) and [the overflow](https://github.com/rust-lang/rust/issues/84963) issues, other than those all known issues are fixed
+  - @**estebank** [offered to have a look](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-17.20.2354818/near/243025573)
+  - there are [still occurrences of incr-comp ICEs](https://github.com/rust-lang/rust/issues/84970#issuecomment-873539084) (though possibly related to other issues? see [comment](https://github.com/rust-lang/rust/issues/84970#issuecomment-873624124)) 
+  - general feeling is to re-enable incr-comp again in 1.54 
+- "iter::Fuse is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85863](https://github.com/rust-lang/rust/issues/85863)
+  - @**cuviper** ([comment](https://github.com/rust-lang/rust/issues/85863#issuecomment-871797016)) opened pr [rust#86765](https://github.com/rust-lang/rust/pull/86765) and [rust#86766](https://github.com/rust-lang/rust/pull/86766)
+  - also, discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-01.20.2354818/near/244577649) (issue needs an owner)
+- "TrustedRandomAccess optimization for Zip containing vec::IntoIter is unsound with how specialization currently behaves around HRTB fn pointers" [rust#85873](https://github.com/rust-lang/rust/issues/85873)
+  - @**Frank Steffahn** authored PR [rust#85874](https://github.com/rust-lang/rust/pull/85874) that should close this issue 
+  - added the work from PR [steffahn/rust#1](https://github.com/steffahn/rust/pull/1)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-07-06](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-07-06.md)
+
+A fairly mixed week with improvements and regressions mostly balancing themselves out. The highlight of this week is the new performance triage process which will now label PRs that introduce performance regressions with the `perf-regression` label. Authors and/or reviewers are expected to justify their performance regression either by a short summary of why the change is worth it despite the regression or by creating an issue to follow-up on the regression.
+
+Triage done by **@rylev**.
+2 Regressions, 3 Improvements, 2 Mixed, 1 of them in rollups
+
+#### Regressions
+
+Rollup of 8 pull requests [#86588](https://github.com/rust-lang/rust/issues/86588)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=f1e691da2e640bb45fe18f8a5bd8f7afa65ce21d&end=964a81eb37db6ee33b8fc107582618bf2befe02d&stat=instructions:u) (up to 1.9% on `full` builds of `deeply-nested-async-check`)
+- The regressions are worse in `deeply-nested-async`.
+- Most of the rollup is documentation or tooling changes. The only real changes in code were in [MIR pretty printing](https://github.com/rust-lang/rust/pull/86566) and [checking spans to see if Rust 2021 closure capturing should be used](https://github.com/rust-lang/rust/pull/86536). Both seem rather benign. However, given the performance regression is async code (which may take more advantage of closures), perhaps the closure capture change should be investigated first.
+- Follow-up comment: https://github.com/rust-lang/rust/pull/86588#issuecomment-874773229
+
+
+Improve debug symbol names to avoid ambiguity and work better with MSVC's debugger [#85269](https://github.com/rust-lang/rust/issues/85269)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=851c82e88ade86bfe3b4ee785d5e5ab1d954b61c&end=2545459bff0aae43288e2e17bff0d332c49a6353&stat=instructions:u) (up to 1.5% on `incr-unchanged` builds of `unify-linearly-debug`)
+- This might be the case of simply doing more work (including allocations) where there were comparatively few before.
+- Unfortunately a perf run was not run before merging (due to the somewhat complication nature of it landing). This is another example where we'll probably want to invest more in ensuring our performance triage process does not lose track of such changes.
+- @michaelwoerister already opened [#86431](https://github.com/rust-lang/rust/issues/86431) to investigate this area of the code. Given the regression isn't very bad, I suggest we let this change slide and try to address the performance of debug info generation wholistically.
+-Follow-up comment: https://github.com/rust-lang/rust/pull/85269#issuecomment-874776341
+
+
+#### Improvements
+
+- Derive `Copy` for `VarianceDiagInfo` [#86670](https://github.com/rust-lang/rust/issues/86670)
+- Add inflate to pgo [#86697](https://github.com/rust-lang/rust/issues/86697)
+- Fix const-generics ICE related to binding [#86795](https://github.com/rust-lang/rust/issues/86795)
+
+#### Mixed
+
+Include terminators in instance size estimate [#86777](https://github.com/rust-lang/rust/issues/86777)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=56dee7c49ecdec4c2c9eccc6ff966cf58847bda6&end=7a9ff746fe20a38a3adc0ac65e1789f6e4b099ad&stat=instructions:u) (up to 4.4% on `incr-unchanged` builds of `deeply-nested-async-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=56dee7c49ecdec4c2c9eccc6ff966cf58847bda6&end=7a9ff746fe20a38a3adc0ac65e1789f6e4b099ad&stat=instructions:u) (up to -1.9% on `full` builds of `ripgrep-opt`)
+- This was identified as potentially being performance sensitive since it leads to changes in CGU partitioning, but unfortunately, @bors has already been invoked on the PR. Arguably, we should have run a performance test anyway.
+- This seemed to impact the `deeply-nested-async` benchmark which has the tendency to be more sensitive to changes like this.
+- Follow-up comment: https://github.com/rust-lang/rust/pull/86777#issuecomment-874779995
+
+Inline Iterator as IntoIterator. [#84560](https://github.com/rust-lang/rust/issues/84560)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5249414809d40fe22eca0c36105a2f71b9006e04&end=6e9b3696d494a32d493585f96f0671123066cd58&stat=instructions:u) (up to 6.2% on `incr-patched: println` builds of `webrender-opt`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5249414809d40fe22eca0c36105a2f71b9006e04&end=6e9b3696d494a32d493585f96f0671123066cd58&stat=instructions:u) (up to -3.2% on `full` builds of `deeply-nested-opt`)
+- Performance run was run on the change which looks similar to results here. Given that this led to fairly significant regressions in some benchmarks, there should probably be some justification as to why the performance regressions are acceptable.
+- Follow-up comment: https://github.com/rust-lang/rust/pull/84560#issuecomment-874781386
+
+#### Nags requiring follow up
+
+- Now that we are adding labels to performance regressions, it should hopefully be easier to follow up.
+- Last week's follow up on max-rss regression in [#86034](https://github.com/rust-lang/rust/pull/86034#issuecomment-871488586) has not been addressed.
+
+## Nominated Issues
+
+T-rustdoc
+- Generate links to definition in rustdoc source code pages [#84176](https://github.com/rust-lang/rust/pull/84176)
+  - Authored by @**GuillaumeGomez**
+  - approved by T-rustdoc
+  - [mentioned in a past meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-17.20.2354818/near/243029071)
+  - needs a final look by T-compiler for merge (@**GuillaumeGomez** can't merge own PR)
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`match` an `std::cmp::Ordering` generates less optimized code in nightly" [rust#86511](https://github.com/rust-lang/rust/issues/86511)
+  - a comment mentions these issues [#86391](https://github.com/rust-lang/rust/issues/86391) and [#86354](https://github.com/rust-lang/rust/issues/86354)
+  - issue nominated for help in finding someone giving some context for an accurate priority to track the issue
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610)
+  - perhaps related to one or more issues about the same theme (see mentioned issues, ex. [rust#86431](https://github.com/rust-lang/rust/issues/86431) was mentioned)
+  - issue nominated as FIY for T-compiler. Can this be tracked in perf?
+
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-07-15.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-07-15.md
@@ -1,0 +1,180 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-07-15
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow July 16th at 10:00 ET steering meeting to discuss extensions to the review policy for Rust Compiler Pull Requests ([policy](https://github.com/rust-lang/compiler-team/issues/444))
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) 
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comment: 6 months ago)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: 5 months ago)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comment: about 34 days ago)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comment: about 13 days ago)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comment: about 13 days ago)
+  - "Encode spans relative to the enclosing item" [compiler-team#443](https://github.com/rust-lang/compiler-team/issues/443) (last comment: about 13 days ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+  - "Preserve, clarify, and extend debug information" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Tracking issue for `#![feature(maybe_uninit_extra,const_maybe_uninit_write)]`" [rust#63567](https://github.com/rust-lang/rust/issues/63567) 
+  - "Tracking Issue for `array_map`" [rust#75243](https://github.com/rust-lang/rust/issues/75243) 
+  - "Stabilize `impl From<[(K, V); N]> for HashMap` (and friends)" [rust#84111](https://github.com/rust-lang/rust/pull/84111) 
+  - "Stabilize bindings_after_at" [rust#85305](https://github.com/rust-lang/rust/pull/85305)
+
+### WG checkins
+
+@*WG-async-foundations* by @**nikomatsakis** and @**tmandry** :
+> Checkin text
+
+@*WG-traits* by @**nikomatsakis** and @**Jack Huey** 
+> We recently (last week) had an organizational meeting and reviewed various initiatives/projects that WG-traits is working on. These include: GATs, TAIT, rustc_type_ir, trait upcasting, salsa, Chalk, and fixing trait-related incremental bugs.
+> We decided to no longer have a single weekly meeting, in favor of more targeted "1:1" meetings (as needed for each initiative). We will still be having a steering/organizational meeting once a month. We haven't decided if that'll take the same timeslot as the weekly meeting or change.
+> Updates of individual initiatives:
+> **GATs**
+> We realized that in [#85499] (normalization under binders), we run into problems when we want to project but can't yet (i.e. `<T as Trait>::Foo<'a>`) and the associated type will *eventually* contain a bound var. So, for now, the plan is to fall back to no normalization when we don't have enough information to project. This still fixes the ICEs in [#62529], but results in some errors where we want to pass. Also split out [#86993] as a more minimal GATs-only change (which can be landed before, or skipped).
+> **TAIT**
+> We had a meeting and found that the implementation is still a bit wrong. There's a bit more work to do before stabilization of `min_type_alias_impl_trait`, including fixing a number of issues.
+> **rustc_type_ir**
+> There is an open PR [#86435] to begin moving major types (like `TyKind`) into `rustc_type_ir` and out of `rustc_middle`. Blocked on some lifetime variance (probably) issues that need to be looked into.
+> **trait upcasting**
+> There is an open PR [#86461] to refactor the vtable format and a bigger PR [#86264] that is being split out into smaller PRs.
+> **salsa, Chalk**
+> [chalk#708] got merged, which reworks the recursive solver to be prepare to use salsa for fixed-point iteration.
+> **incremental ICEs trait work**
+> There are [3 approaches](https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/subobligations.20and.20ICEs.20.2385868/near/245066992) open to solve the `evaluate_obligation` incremental issue, but each have a moderate perf impact. They need to be reviewed to pick the best solution.
+
+[#62529]: https://github.com/rust-lang/rust/issues/62529
+[#85499]: https://github.com/rust-lang/rust/pull/85499
+[#86264]: https://github.com/rust-lang/rust/pull/86264
+[#86435]: https://github.com/rust-lang/rust/pull/86435
+[#86461]: https://github.com/rust-lang/rust/pull/86461
+[#86993]: https://github.com/rust-lang/rust/pull/86993
+[chalk#708]: https://github.com/rust-lang/chalk/pull/708
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Don't use gc-sections with profile-generate." [rust#87004](https://github.com/rust-lang/rust/pull/87004) 
+  - opened by @**Jamie Cunliffe** 
+  - nomination proposed by @**simulacrum** as this should fix [rust#78226](https://github.com/rust-lang/rust/issues/78226), preferably to be shipped in 1.54 a `P-critical` regression on AArch64 target
+  - Some PGO tests are failing on Windows (see [comment](https://github.com/rust-lang/rust/pull/87004#issuecomment-879157185))
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Encode spans relative to the enclosing item" [rust#84373](https://github.com/rust-lang/rust/pull/84373) 
+  - opened by @**cjgillot** 
+  - @**Vadim Petrochenkov** called on team review as it may be interesting to be merged to move forward [rust#35148](https://github.com/rust-lang/rust/issues/35148#issuecomment-879839839)
+- "Wrap libraries in linker groups, allowing backwards/circular references" [rust#85805](https://github.com/rust-lang/rust/pull/85805) 
+  - opened by @**Josh Triplett** 
+  - reviewed by @**bjorn3** 
+  - @**Vadim Petrochenkov** self-assigned for review, expressed idea to reconsider this PR [in 6-12 months](https://github.com/rust-lang/rust/pull/85805#issuecomment-868825690)
+
+## Issues of Note
+
+### Short Summary
+
+- [4 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [3 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [80 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [54 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 0 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 3 P-high, 2 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 45 P-high, 83 P-medium, 11 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "run-make-fulldeps/pgo-branch-weights fails on AArch64 Linux" [rust#78226](https://github.com/rust-lang/rust/issues/78226) 
+  - only fails on aarch64 arm
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-08.20.2354818/near/245320262)
+  - @**simulacrum** [comments](https://github.com/rust-lang/rust/issues/78226#issuecomment-866299280) that tests for this are disabled but a fix for 1.54 would be good
+  - being investigated by @**Jamie Cunliffe** [see comment](https://github.com/rust-lang/rust/issues/78226#issuecomment-868570487) 
+  - @**simulacrum**has beta-nominated [rust#87004](https://github.com/rust-lang/rust/pull/87004) to fix this
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-08.20.2354818/near/245321885)
+  - general feeling is to re-enable incr-comp again in 1.54
+  - @**Aaron Hill** is working on some performance improvements to handling of projection predicates
+  - @**nagisa** reported that errors are looking useful enough
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-07-13](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-07-13.md)
+
+Mostly quiet week; improvements outweighed regressions.
+
+Triage done by **@simulacrum**.
+Revision range: [9a27044f42ace9eb652781b53f598e25d4e7e918..5aff6dd07a562a2cba3c57fc3460a72acb6bef46](https://perf.rust-lang.org/?start=9a27044f42ace9eb652781b53f598e25d4e7e918&end=5aff6dd07a562a2cba3c57fc3460a72acb6bef46&absolute=false&stat=instructions%3Au)
+
+1 Regressions, 4 Improvements, 0 Mixed; 0 of them in rollups
+
+#### Regressions
+
+Support forwarding caller location through trait object method call [#81360](https://github.com/rust-lang/rust/issues/81360)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a84d1b21aea9863f0fc5f436b4982d145dade646&end=3982eb35cabe3a99194d768d34a92347967c3fa2&stat=instructions:u) (up to 1.5% on `incr-full` builds of `unused-warnings-check`)
+- Largely due to increased number of calls to the newly-made query
+  should_inherit_track_caller. Mostly higher regressions on smaller benchmarks.
+
+#### Improvements
+
+- Reland "Merge CrateDisambiguator into StableCrateId" [#86143](https://github.com/rust-lang/rust/issues/86143)
+- Stop generating `alloca`s & `memcmp` for simple short array equality [#85828](https://github.com/rust-lang/rust/issues/85828)
+- Add support for raw-dylib with stdcall, fastcall functions [#86419](https://github.com/rust-lang/rust/issues/86419)
+- Use clang 12.0.1 on dist-x86_64/i686-linux [#87019](https://github.com/rust-lang/rust/issues/87019)
+
+#### Nags requiring follow up
+
+- There are a number of [untriaged regressions](https://github.com/rust-lang/rust/issues?q=is%3Amerged+label%3Aperf-regression+-label%3Aperf-regression-triaged); as of this writing:
+  - Include terminators in instance size estimate [#86777](https://github.com/rust-lang/rust/issues/86777)
+  - Rollup of 8 pull requests [#86588](https://github.com/rust-lang/rust/issues/86588)
+  - Change entry point to 🛡️ against 💥 💥-payloads [#86034](https://github.com/rust-lang/rust/issues/86034)
+  - Inline Iterator as IntoIterator. [#84560](https://github.com/rust-lang/rust/issues/84560)
+
+## Nominated Issues
+
+T-rustdoc
+- Generate links to definition in rustdoc source code pages [#84176](https://github.com/rust-lang/rust/pull/84176)
+  - Authored by @**GuillaumeGomez**
+  - approved by T-rustdoc, reviewed by @**Joshua Nelson** 
+  - [mentioned last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-08.20.2354818/near/245326203)
+  - needs a final look by T-compiler for merge (@**GuillaumeGomez** can't merge own PR)
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "`match` an `std::cmp::Ordering` generates less optimized code in nightly" [rust#86511](https://github.com/rust-lang/rust/issues/86511)
+  - comment mentions these issues [#86391](https://github.com/rust-lang/rust/issues/86391) and [#86354](https://github.com/rust-lang/rust/issues/86354)
+  - issue nominated for help in finding someone giving some context for an accurate priority to track the issue
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610)
+  - perhaps related to one or more issues about the same theme (see mentioned issues, ex. [rust#86431](https://github.com/rust-lang/rust/issues/86431) was mentioned)
+  - issue nominated as FIY for T-compiler. Can this be tracked in perf?
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-07-22.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-07-22.md
@@ -1,0 +1,232 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-07-22
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- :loudspeaker: Next week, July, 29th release Rust stable 1.54 :loudspeaker: 
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comment: 6 months ago)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: 5 months ago)
+  -  "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comment: about 41 days ago)
+  -  "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comment: about 20 days ago)
+  -  "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comment: about 20 days ago)
+  -  "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comment: about 6 days ago)
+- Pending FCP requests (check your boxes!)
+  -  "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+  -  "Preserve, clarify, and extend debug information" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+- Things in FCP (make sure you're good with it)
+  -  "Encode spans relative to the enclosing item" [compiler-team#443](https://github.com/rust-lang/compiler-team/issues/443) 
+  -  "Don't abort compilation after giving a lint error" [compiler-team#447](https://github.com/rust-lang/compiler-team/issues/447) 
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  -  "Tracking Issue for IntoInnerError::into_parts etc. (io_into_inner_error_parts)" [rust#79704](https://github.com/rust-lang/rust/issues/79704) 
+  -  "Remove P: Unpin bound on impl Future for Pin" [rust#81363](https://github.com/rust-lang/rust/pull/81363) 
+  -  "Allow leading pipe in `matches!()` patterns." [rust#85272](https://github.com/rust-lang/rust/pull/85272) 
+  -  "Stabilize `const_fn_transmute`, `const_fn_union`" [rust#85769](https://github.com/rust-lang/rust/pull/85769) 
+  -  "Partially stabilize `const_slice_first_last`" [rust#86593](https://github.com/rust-lang/rust/pull/86593) 
+  -  "Document iteration order of `retain` functions" [rust#86790](https://github.com/rust-lang/rust/pull/86790)
+
+### WG checkins
+
+@*WG-diagnostics* from @**Esteban Küber** and @**oli** 
+> 
+> Since our last checking a lot of PRs with improvements have been merged. We've made many subtle changes to wording, amount and accuracy of information and presence structured suggestions in a variety of diagnostics. All of them fall into one of the following categories:
+> - More accurate spans for predicate obligations (associated types and trait bounds, ongoing area of concern)
+> - We now account better for implicit `'static` lifetimes introduced by type params and assoc types
+> - We now include `for<'lt>` in pretty printing output
+> - We had some efforts to close the distance between nll and old regionck output
+> - Improvements to MIR, TAIT and const diagnostics, as part of ongoing efforts
+> - Tweaks to lint triggering and output
+> - We now include first macro level, this particularly makes errors involving `derive` macros easier to understand
+> - Various parser and error recovery improvements
+> - Various ICE fixes by improving support or use of `delay_span_bug`
+> - Proc macros can now have spans pointing _to their own crate_
+> - `#[track_caller]` now works on trait object method calls
+> - Point at `impl Trait` return types in more cases
+> - Multiple regression tests added
+>
+> I want to call out @FabianWolff, @Aaron1011 and @Smittyvb for delivering on a number of these categories.
+>
+> ---
+>
+> Not directly related to WG-diagnostics, but I want to call it out:
+> 
+> > [Eisel-Lemire algorithm Float-Parsing Algorithm #86761](https://github.com/rust-lang/rust/pull/86761) landed on nightly, removing a now unnecessary error.
+
+@*WG-rustc-dev-guide* from @**Santiago Pastorino** and @**Yuki Okushi|217081**
+> - @**Yuki Okushi|217081** joined the team as a new co-lead, thanks @**Joshua Nelson** for everything you've done!
+> - Not a lot has happened lately but here's a small set of changes and WIPs ...
+> 
+> #### Most notable changes
+> 
+> - Create issues for many TODOs [#1163](https://github.com/rust-lang/rustc-dev-guide/pull/1163)
+> - Update information on lints [#1154](https://github.com/rust-lang/rustc-dev-guide/pull/1154)
+> - Document how to mark features as incomplete [#1151](https://github.com/rust-lang/rustc-dev-guide/pull/1151)
+> - Document how to run unit tests [#1141](https://github.com/rust-lang/rustc-dev-guide/pull/1141)
+> 
+> #### Most notable WIPs
+> 
+> - Document inert vs active attributes [#1110](https://github.com/rust-lang/rustc-dev-guide/pull/1110)
+> - Explain the new valtree system for type level constants. [#1097](https://github.com/rust-lang/rustc-dev-guide/pull/1097)
+
+## Backport unilateral approvals
+
+- :beta: "Revert PR 81473 to resolve (on mainline) issues 81626 and 81658." [rust#86212](https://github.com/rust-lang/rust/pull/86212) 
+  - opened by @**pnkfelix**
+  - nominated by @**Pietro Albini** for 1.54 and have it land in 1.55
+  - should address [rust#81658](https://github.com/rust-lang/rust/issues/81658) (an invalid "field never read lint" diagnostic) until we can land again PR [rust#83171](https://github.com/rust-lang/rust/issues/83171) with an enhancement like PR [rust#83004](https://github.com/rust-lang/rust/issues/83004)
+  - unilaterally beta-backport approved by @**pnkfelix**
+  - beta backport PR: [rust#87369](https://github.com/rust-lang/rust/pull/87369)
+
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Don't use gc-sections with profile-generate." [rust#87004](https://github.com/rust-lang/rust/pull/87004)
+  - opened by @**Jamie Cunliffe** 
+  - nomination proposed by @**simulacrum** as this should fix [rust#78226](https://github.com/rust-lang/rust/issues/78226), preferably to be shipped in 1.54 a `P-critical` regression on AArch64 target
+  - Some PGO tests were failing last week, is bors now happy?
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-15.20.2354818/near/246099199) - is [rust#78226](https://github.com/rust-lang/rust/issues/78226) really a release blocker?
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Encode spans relative to the enclosing item" [rust#84373](https://github.com/rust-lang/rust/pull/84373)
+  - discussed last week, @_*wg-incr-comp* seem the best owners of this
+- "Wrap libraries in linker groups, allowing backwards/circular references" [rust#85805](https://github.com/rust-lang/rust/pull/85805)
+  - discussed last week
+  - @**nagisa** commented it could be potentially troublesome
+  - @**petrochenkov** mentioned to postpone for a few months
+  - @**pnkfelix** suggested an MCP to give visibility
+
+## Issues of Note
+
+### Short Summary
+
+- [2 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [79 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [53 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [2 P-critical, 1 P-high, 3 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [2 P-critical, 44 P-high, 81 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "run-make-fulldeps/pgo-branch-weights fails on AArch64 Linux" [rust#78226](https://github.com/rust-lang/rust/issues/78226) 
+  - discussed last week, linked to PR [rust#87004](https://github.com/rust-lang/rust/issues/87004), now merged and scheduled for 1.55.0 milestone
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970) 
+  - discussed last week
+  - @**Wesley Wiser** [asked](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-15.20.2354818/near/246102804) if a fix for [rust#84963](https://github.com/rust-lang/rust/issues/84963) is somewhere being worked on?
+  - other updates on stoppers / pending related PRs?
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-07-20](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-07-20.md)
+
+A mixed week, with some moderate regressions and moderate improvements. (I am personally wondering whether style-servo-debug needs to have a larger individual threshold for signalling a regression.) There were some notable PR's that were specifically oriented around performance enhancements.
+
+Triage done by **@pnkfelix**.
+Revision range: [5aff6dd07a562a2cba3c57fc3460a72acb6bef46..5c0ca08c662399c1c864310d1a20867d3ab68027](https://perf.rust-lang.org/?start=5aff6dd07a562a2cba3c57fc3460a72acb6bef46&end=5c0ca08c662399c1c864310d1a20867d3ab68027&absolute=false&stat=instructions%3Au)
+
+3 Regressions, 3 Improvements, 3 Mixed; 1 of them in rollups
+
+#### Regressions
+
+Replace associated item bound vars with placeholders when projecting [#86993](https://github.com/rust-lang/rust/issues/86993)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=b1f8e27b74c541d3d555149c8efa4bfe9385cd56&end=27e42058811e448b1a7dd8630d86ab247fbfcb9b&stat=instructions:u) (up to 1.5% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+- A perf run was [done on the PR originally](https://perf.rust-lang.org/compare.html?start=fdfe819580062a441024d713b49340cd3f7d7efc&end=7baa78ec683fd14db4d4c1869dbef5cbbc5b774d). The regression flagged here seems to be on a different set of benchmarks: `style-servo-debug` and `wf-projection-stress-65510-*`, neither of which was flagged as a regression in the original runs.
+- Results overall seem pretty mixed and hard to interpret. Left a [comment](https://github.com/rust-lang/rust/pull/86993#issuecomment-883624762) on the PR.
+
+Remove special case for `ExprKind::Paren` in `MutVisitor` [#87284](https://github.com/rust-lang/rust/issues/87284)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=014026d1a7ca991f82f12efa95ef4dffb29dc8af&end=6535449a002264ee08dec8e741f1aadd97428fae&stat=instructions:u) (up to 1.0% on `full` builds of `coercions-debug`)
+- This is on the borderline for "significant regression", and was the *only* regression associated with this PR.
+- Also, `coercions-debug` seems like it has a noisy history (that's pnkfelix's opinion from eyeballing it; it has also a single "?" on its comparison line.)
+
+Better diagnostics with mismatched types due to implicit static lifetime [#87244](https://github.com/rust-lang/rust/issues/87244)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=718d53b0cb7dde93499cb92950d60b412f5a3d05&end=da7d405357600a76f2b93b8aa41fe5ee5da7885d&stat=instructions:u) (up to 1.2% on `full` builds of `stm32f4-check`)
+- Widespread regressions that exceed the 0.2% threshold for non-noisy benchmarks.
+- Left a [comment](https://github.com/rust-lang/rust/pull/87244#issuecomment-883635813) asking if this was expected. But I suspect the situation does not warrant additional investment of effort, assuming there's no trivial fix identifiable from the PR author.
+
+#### Improvements
+
+- Rollup of 6 pull requests [#87118](https://github.com/rust-lang/rust/issues/87118)
+- Make expansions stable for incr. comp. [#86676](https://github.com/rust-lang/rust/issues/86676)
+- Some perf optimizations and logging [#87203](https://github.com/rust-lang/rust/issues/87203)
+
+#### Mixed
+
+Cache expansion hash globally [#87044](https://github.com/rust-lang/rust/issues/87044)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=3e1c75c6e25a4db968066bd2ef2dabc7c504d7ca&end=c7d6bcc788ef6b2293d2d5166a9b0339d5d03b0a&stat=instructions:u) (up to 1.9% on `full` builds of `deeply-nested-async-check`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=3e1c75c6e25a4db968066bd2ef2dabc7c504d7ca&end=c7d6bcc788ef6b2293d2d5166a9b0339d5d03b0a&stat=instructions:u) (up to -1.4% on `incr-unchanged` builds of `inflate-check`)
+- This was an improvement for a lot of incremental cases, and a regression for a few full-compilation cases: `deeply-nested-async-{check,debug,opt}`, and `coercions-debug`.
+- It seems like these results were [expected](https://github.com/rust-lang/rust/pull/87044#issuecomment-879407381), and they make sense given the nature of the PR.
+
+Update Rust Float-Parsing Algorithms to use the Eisel-Lemire algorithm. [#86761](https://github.com/rust-lang/rust/issues/86761)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=64d171b8a419eb6cb872ab579398eff8a741bbc6&end=f502bd3abd12111bbfae0974db018c165a977c0e&stat=instructions:u) (up to 3.2% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=64d171b8a419eb6cb872ab579398eff8a741bbc6&end=f502bd3abd12111bbfae0974db018c165a977c0e&stat=instructions:u) (up to -1.4% on `full` builds of `piston-image-opt`)
+- A perf run was done on the orignal PR, but the run there did not predict the regression that was now observed to `style-servo-debug` when this PR landed on nightly.
+- Left a [comment](https://github.com/rust-lang/rust/pull/86761#issuecomment-883645181), but I am guessing that `style-servo-debug` may need a bigger noise threshold (or rather, sensitivity to perturbations) than what we currently use.
+
+Move OnDiskCache to rustc_query_impl. [#86698](https://github.com/rust-lang/rust/issues/86698)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5a8a44196b3cf099f8c9b0156bd902eaec0b4e5f&end=18073052d8c3544ccb73effd289ed3acda0d66c0&stat=instructions:u) (up to -1.4% on `incr-unchanged` builds of `ctfe-stress-4-check`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5a8a44196b3cf099f8c9b0156bd902eaec0b4e5f&end=18073052d8c3544ccb73effd289ed3acda0d66c0&stat=instructions:u) (up to 1.1% on `incr-unchanged` builds of `deeply-nested-async-opt`)
+- A perf run was done on the original PR that predicted a much better outcome here.
+- Left a [comment](https://github.com/rust-lang/rust/pull/86698#issuecomment-883647259) asking PR author if they have any idea about the discrepancy.
+
+#### Untriaged Pull Requests
+
+- [#87153 \[debuginfo\] Emit associated type bindings in trait object type names.](https://github.com/rust-lang/rust/pull/87153)
+- [#86993 Replace associated item bound vars with placeholders when projecting](https://github.com/rust-lang/rust/pull/86993)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to 🛡️ against 💥 💥-payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+
+#### Nags requiring follow up
+
+None
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Binary search performance regressed in 1.25" [rust#53823](https://github.com/rust-lang/rust/issues/53823)
+  - Needs a fix [upstream on LLVM](https://bugs.llvm.org/show_bug.cgi?id=40027), see [comment](https://github.com/rust-lang/rust/issues/53823#issuecomment-882660032)``
+  - discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/tracking.20an.20old.20regression)
+  - T-compiler tagged FIY
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610)
+  - perhaps related to one or more issues about the same theme (see mentioned issues, ex. [rust#86431](https://github.com/rust-lang/rust/issues/86431) was mentioned)
+  - issue nominated as FIY for T-compiler. Can this be tracked in perf?
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-07-29.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-07-29.md
@@ -1,0 +1,155 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-07-29
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow <time:2021-07-30T10:00:00-04:00>: We have our planning meeting for the August steering meeting cycle. There is currently [one proposal](https://github.com/rust-lang/compiler-team/issues?q=is%3Aissue+is%3Aopen+label%3Ameeting-proposal++-label%3Ameeting-scheduled), perhaps more ideas.
+- :confetti: Today July, 29th release Rust stable 1.54 :confetti:
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "Make `resolve_instance` fallible" [compiler-team#449](https://github.com/rust-lang/compiler-team/issues/449) 
+  - "Reproducible command line + determinism" [compiler-team#450](https://github.com/rust-lang/compiler-team/issues/450) 
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comment: 6 months ago)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: 5 months ago)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comment: about 48 days ago)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comment: about 27 days ago)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comment: about 27 days ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comment: about 12 days ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+  - "Preserve, clarify, and extend debug information" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+- Things in FCP (make sure you're good with it)
+  - "Encode spans relative to the enclosing item" [compiler-team#443](https://github.com/rust-lang/compiler-team/issues/443) 
+  - "Don't abort compilation after giving a lint error" [compiler-team#447](https://github.com/rust-lang/compiler-team/issues/447) 
+  - "Rename various internal things" [compiler-team#451](https://github.com/rust-lang/compiler-team/issues/451) 
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - "Stabilize `const_fn_transmute`, `const_fn_union`" [rust#85769](https://github.com/rust-lang/rust/pull/85769) 
+  - "Stabilize `arbitrary_enum_discriminant`" [rust#86860](https://github.com/rust-lang/rust/pull/86860) 
+
+### WG checkins
+
+- @*wg-incr-comp* by @**pnkfelix** @**Wesley Wiser** 
+> The working group has been largely dormant. pnkfelix is hoping to fire things up again, and is [seeking input](https://rust-lang.zulipchat.com/#narrow/stream/241847-t-compiler.2Fwg-incr-comp/topic/what.E2.80.99s.20best.20way.20to.20drive.20conversation.20here.3F/near/247287693) about when/how to drive activity.
+
+- @*WG-llvm* by @**nagisa** ([past summary](https://hackmd.io/YIIP5vCnSjOYogzRSlJ9MQ?view))
+> Checkin text
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Always preserve sub-obligations in the projection cache" [rust#85868](https://github.com/rust-lang/rust/pull/85868)
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-22.20.2354818/near/246855877)
+  - Discussion seems was oriented to not backport this to 1.54, to re-enable incr-comp (at least we now have more useful error messages) and attempt to merge it into next beta 1.55
+  - makes sense to remove beta-backport nomination?
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Encode spans relative to the enclosing item" [rust#84373](https://github.com/rust-lang/rust/pull/84373) 
+  - opened by @**cjgillot** 
+  - assigned to @**Aaron Hill** @**mw** @**Vadim Petrochenkov**
+  - @**cjgillot** opened [MCP #443](https://github.com/rust-lang/compiler-team/issues/443) (currently in closing FCP phase)
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-22.20.2354818/near/246853451), @*wg-incr-comp* could have a discussion about this after the 1.54 release and the next beta cut
+- "Wrap libraries in linker groups, allowing backwards/circular references" [rust#85805](https://github.com/rust-lang/rust/pull/85805)
+  - discussed last week
+  - @**nagisa** commented it could be potentially troublesome
+  - @**Vadim Petrochenkov** [mentioned to postpone for a few months](https://github.com/rust-lang/rust/pull/85805#issuecomment-868825690)
+  - @**pnkfelix** suggested to draft a MCP to boost signal for this PR
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [79 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [53 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 0 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 0 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 44 P-high, 80 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970) 
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "`match` an `std::cmp::Ordering` generates less optimized code in nightly" [rust#86511](https://github.com/rust-lang/rust/issues/86511)
+  - issue was commented and a bit discussed but probably needs an owner
+  - @_*WG-prioritization*  tentatively assigned a `P-high` to make it float and perhaps not miss the next stable
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs 2021-07-27](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-07-27.md)
+
+A very quiet week with only improvements. There was one possible regression, but it was removed from consideration due to only barely impacting a somewhat noisy stress-test benchmark. Untriaged pull requests continue to pile up, but there is still not a good process for dealing with them. 
+
+Triage done by **@rylev**.
+
+0 Regressions, 3 Improvements, 0 Mixed; 0 of them in rollups
+
+#### Regressions
+
+Support HIR wf checking for function signatures [#87265](https://github.com/rust-lang/rust/issues/87265)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7db08eeb0057de86ea2bdbd4c3a085cb8516b653&end=7c89e389d00cfc7e86ae7e1b45880da4f5f5c9f5&stat=instructions:u) (up to 1.1% on `full` builds of `externs-opt`)
+- Given that this only impacts the somewhat noisy `externs` stress-test benchmark, it's not clear that we should treat this as an actual regression. 
+
+#### Improvements
+
+- Improve caching during trait evaluation  [#86946](https://github.com/rust-lang/rust/issues/86946)
+- Make mir borrowck's use of opaque types independent of the typeck query's result [#87287](https://github.com/rust-lang/rust/issues/87287)
+- Store all HIR owners in the same container [#83723](https://github.com/rust-lang/rust/issues/83723)
+
+#### Mixed
+
+None
+
+#### Untriaged Pull Requests
+
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to 🛡️ against 💥 💥-payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+
+#### Nags requiring follow up
+
+None
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610)
+  - briefly mentioned last week, discussion postponed to this week
+  - issue nominated as FIY for T-compiler
+  - perhaps related to one or more issues about the same theme (see mentioned issues, ex. [rust#86431](https://github.com/rust-lang/rust/issues/86431) was mentioned)
+  - Actionable for this issue? Can this be tracked in perf? Worth a `P-high` to keep it visible on the radar?
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-08-05.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-08-05.md
@@ -1,0 +1,168 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-08-05
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+  
+### MCPs/FCPs  
+  
+- New MCPs (take a look, see if you like them!)
+  - "Make AST->HIR lowering incremental" [compiler-team#452](https://github.com/rust-lang/compiler-team/issues/452) 
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comments: GH 6m ago, Zulip 20d ago)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comments: GH 6m ago, Zulip 25d ago)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comments: GH 55d ago, Zulip 41d ago)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comments: GH 49d ago, Zulip none)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comments: GH 34d ago, Zulip 45d ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comments: GH 28d ago, Zulip 15d ago)
+  - "Make `resolve_instance` fallible" [compiler-team#449](https://github.com/rust-lang/compiler-team/issues/449) (last comments: GH 10d ago, Zulip none)
+  - "Reproducible command line + determinism" [compiler-team#450](https://github.com/rust-lang/compiler-team/issues/450) (last comments: GH 9d ago, Zulip 6d ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+  - "Preserve, clarify, and extend debug information" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+- Things in FCP (make sure you're good with it)
+  - "Don't abort compilation after giving a lint error" [compiler-team#447](https://github.com/rust-lang/compiler-team/issues/447) 
+  - "Rename various internal things" [compiler-team#451](https://github.com/rust-lang/compiler-team/issues/451) 
+- Accepted MCPs
+  - "Encode spans relative to the enclosing item" [compiler-team#443](https://github.com/rust-lang/compiler-team/issues/443) 
+- Finalized FCPs (disposition merge)
+  - "Stabilize `const_fn_transmute`, `const_fn_union`" [rust#85769](https://github.com/rust-lang/rust/pull/85769) 
+  - "Associated functions that contain extern indicator or have `#[rustc_std_internal_symbol]` are reachable" [rust#86492](https://github.com/rust-lang/rust/pull/86492) 
+  - "Allow reifying intrinsics to `fn` pointers." [rust#86699](https://github.com/rust-lang/rust/pull/86699) 
+  - "Stabilize `arbitrary_enum_discriminant`" [rust#86860](https://github.com/rust-lang/rust/pull/86860)
+  
+### WG checkins
+
+@*WG-mir-opt* by @**oli**:
+> [wg-mir-opt is out of review capacity](https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/wg-mir-opt.20is.20out.20of.20review.20capacity). We have several open PRs but no one to review them. We could move to a more permissive model where we add new mir opts that are too large to review properly (at present) into the unsound mir opt list (or at least mir opt level 4). This way they don't bitrot and people can try them, but quality suffers.
+
+@wg-polymorphization by @**davidtwco**:
+> There's no update from the polymorphization working group. Everyone involved is working on other things. 
+> 
+> @_**davidtwco** is starting a new job in September where he'll be working on rustc and should be able to contribute more soon!
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+
+- unilateral beta backport [rust#87483](https://github.com/rust-lang/rust/pull/87483) "Mir borrowck does not generate lifetime variables for 'static lifetimes during opaque type resolution"
+
+- :beta: "Always preserve sub-obligations in the projection cache" [rust#85868](https://github.com/rust-lang/rust/pull/85868)
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-29.20.2354818/near/247588561)
+  - @**Wesley Wiser** [comments](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-29.20.2354818/near/247588679) this should reviewed & merged on nightly before we talk about beta backports
+  - @**pnkfelix** [comments](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-29.20.2354818/near/247588695): also premature to discuss beta backporting so let's keep it nominated as a reminder
+- :beta: "Update compiler_builtins to fix i128 shift/mul on thumbv6m" [rust#87633](https://github.com/rust-lang/rust/pull/87633)
+  - opened by @**Amanieu**
+  - nominated by @**simulacrum**, patch seems harmless (see [comment](https://github.com/rust-lang/rust/pull/87633#issuecomment-890556479))
+  - fixes [rust#86063](https://github.com/rust-lang/rust/issues/86063), a bug in LLVM expansion of 128-bit shifts (see [comment](https://github.com/rust-lang/rust/issues/86063#issuecomment-886555639))
+  - slipped into stable but we can still backport to beta
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Encode spans relative to the enclosing item" [rust#84373](https://github.com/rust-lang/rust/pull/84373) 
+  - opened by @**cjgillot** 
+  - assigned to @**Aaron Hill** @**mw** @**Vadim Petrochenkov**
+  - @**cjgillot** opened [MCP #443](https://github.com/rust-lang/compiler-team/issues/443) (currently in closing FCP phase)
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-22.20.2354818/near/246853451), @*wg-incr-comp* could have a discussion about this after the 1.54 release and the next beta cut
+- "Wrap libraries in linker groups, allowing backwards/circular references" [rust#85805](https://github.com/rust-lang/rust/pull/85805)
+  - discussed last week
+  - @**nagisa** commented it could be potentially troublesome
+  - @**Vadim Petrochenkov** [mentioned to postpone for a few months](https://github.com/rust-lang/rust/pull/85805#issuecomment-868825690)
+  - @**pnkfelix** suggested to draft a MCP to boost signal for this PR
+- "Ignore comments in tidy-filelength" [rust#87462](https://github.com/rust-lang/rust/pull/87462)
+  - Opened by @**Ibraheem Ahmed** 
+  - PR goal seems to be to avoid nagging on long files if the length is primarily due to comment lines
+  - @**simulacrum** [suggests](https://github.com/rust-lang/rust/pull/87462#issuecomment-890577887) an MCP could be a better fit
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [81 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [54 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 2 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 1 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 44 P-high, 81 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Unstable fingerprints - what to do on beta (and stable)" [rust#84970](https://github.com/rust-lang/rust/issues/84970)
+  - @**pnkfelix** [suggested](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-29.20.2354818/near/247590391) that we could downgrade after evaluating the bug reporting after the release of 1.54
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "`match` an `std::cmp::Ordering` generates less optimized code in nightly" [rust#86511](https://github.com/rust-lang/rust/issues/86511) 
+  - the idea was to offer mentorship to @**Simon Chan** to drive the issue investigation (maybe leave a message in the issue?)
+- "ICE: unexpected concrete region in borrowck: ReStatic" [rust#87455](https://github.com/rust-lang/rust/issues/87455)
+  - @**oli** reopened and [comments](https://github.com/rust-lang/rust/issues/87455#issuecomment-889839189) that this needs a backport
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-08-03](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-08-03.md)
+
+Quiet week for performance, with no large changes. Regressions are limited to
+just a few benchmarks.
+
+Triage done by **@simulacrum**.
+Revision range: [998cfe5aad7c21eb19a4bca50f05a13354706970..3354a44d2fa8d5ba6b8d6b40d2596de2c8292ec1](https://perf.rust-lang.org/?start=998cfe5aad7c21eb19a4bca50f05a13354706970&end=3354a44d2fa8d5ba6b8d6b40d2596de2c8292ec1&absolute=false&stat=instructions%3Au)
+
+2 Regressions, 0 Improvements, 0 Mixed; 1 of them in rollups
+
+#### Regressions
+
+Rollup of 9 pull requests [#87640](https://github.com/rust-lang/rust/issues/87640)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ef9549b6c0efb7525c9b012148689c8d070f9bc0&end=1f0a591b3a5963a0ab11a35dc525ad9d46f612e4&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `html5ever-check`)
+- Regressions across a few benchmarks, without an obvious cause. May be due to
+  [#87385](https://github.com/rust-lang/rust/pull/87385), but logs don't appear
+  to show the warning in those crates at a cursory check. Tagged with
+  perf-regression for further investigation.
+
+Implement advance_by, advance_back_by for slice::{Iter, IterMut} [#87387](https://github.com/rust-lang/rust/issues/87387)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=b289bb7fdfcb6f54d825927ab9b5722cabc2a140&end=6b0b07d41f07e1ba5808693d900903499ccf7a32&stat=instructions:u) (up to 1.6% on `full` builds of `regex-opt`)
+- Unclear cause, likely LLVM-related.
+
+#### Improvements
+
+- None this week.
+
+#### Mixed
+
+- None this week.
+
+#### Untriaged Pull Requests
+
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to 🛡️ against 💥 💥-payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610)
+  - Added an action item on [HackMD](https://hackmd.io/5BtjuenFTn6M74IDwLOjgw)
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-08-12.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-08-12.md
@@ -1,0 +1,170 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-08-12
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- New MCPs (take a look, see if you like them!)
+  - "Add `TyKind::Const` and remove `GenericArgKind::Const`" [compiler-team#453](https://github.com/rust-lang/compiler-team/issues/453) 
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comments: GH 7m ago, Zulip 4d ago)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comments: GH 6m ago, Zulip 43d ago)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comments: GH 2m ago, Zulip 49d ago)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comments: GH 49d ago, Zulip none)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comments: GH 34d ago, Zulip 52d ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comments: GH 28d ago, Zulip 20d ago)
+  - "Make `resolve_instance` fallible" [compiler-team#449](https://github.com/rust-lang/compiler-team/issues/449) (last comments: GH 10d ago, Zulip none)
+  - "Reproducible command line + determinism" [compiler-team#450](https://github.com/rust-lang/compiler-team/issues/450) (last comments: GH 9d ago, Zulip 11d ago)
+  - "Make AST->HIR lowering incremental" [compiler-team#452](https://github.com/rust-lang/compiler-team/issues/452) (last comment: GH 10 days ago, Zulip None)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+  - "Preserve, clarify, and extend debug information" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+- Things in FCP (make sure you're good with it)
+  - "Rename various internal things" [compiler-team#451](https://github.com/rust-lang/compiler-team/issues/451) 
+- Accepted MCPs
+  - "Don't abort compilation after giving a lint error" [compiler-team#447](https://github.com/rust-lang/compiler-team/issues/447) 
+- Finalized FCPs (disposition merge)
+  - No new finished FCP (disposition merge) this time.
+
+### WG checkins
+
+@*WG-rfc-2229* by @**Aman Arora** 
+> We have mostly been working mostly just been on bug fixes as more people try 2021 edition
+
+@*WG-rls2.0* by @**matklad** ([latest report](https://hackmd.io/zhv96UdPQI-HI9BlW0XuTw))
+
+Steering issue covered by this checkin:
+
+* https://github.com/rust-analyzer/rust-analyzer/issues/9580
+
+This has been mostly reactive sprint. I don't think we did anything super "big" this time, but we shipped a lot new features, fixed a bunch of bad bugs, and did some observability improvements (eg, we now know that roughly 2/3 of code is source code, and 1/3 is macro-generated code).
+
+One interesting big thing is that we realized that we've used a wrong model for macro expansion this whole time: https://github.com/rust-analyzer/rust-analyzer/issues/9403
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Always preserve sub-obligations in the projection cache" [rust#85868](https://github.com/rust-lang/rust/pull/85868) 
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-29.20.2354818/near/247588561)
+  - @**Wesley Wiser** [comments](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-29.20.2354818/near/247588679) this should reviewed & merged on nightly before we talk about beta backports
+  - @**pnkfelix** [comments](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-29.20.2354818/near/247588695): also premature to discuss beta
+- :beta: "Do not ICE on HIR based WF check when involving lifetimes"
+[rust#87811](https://github.com/rust-lang/rust/pull/87811) 
+  - Fixes [#87549](https://github.com/rust-lang/rust/issues/87549) (a regression causing a ICE on incoreect code compiled with `incremental=true`)
+  - PR provided by @**Esteban Küber** and nominated for backport
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Encode spans relative to the enclosing item" [rust#84373](https://github.com/rust-lang/rust/pull/84373)
+  - opened by @**cjgillot** 
+  - assigned to @**Aaron Hill** @**mw** @**Vadim Petrochenkov**
+  - @**cjgillot** opened [MCP #443](https://github.com/rust-lang/compiler-team/issues/443) (currently in closing FCP phase)
+  - [discussed last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-07-22.20.2354818/near/246853451), @*wg-incr-comp* could have a discussion about this after the 1.54 release and the next beta cut
+- "Remove all json handling from rustc_serialize" [rust#85993](https://github.com/rust-lang/rust/pull/85993) 
+  - PR nominated for discussion (see nominations)
+- "Preserve, clarify, and extend debug information" [rust#83947](https://github.com/rust-lang/rust/pull/83947)
+  - @**Vadim Petrochenkov** added more comments labeled with `S-waiting-on-team`
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [85 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [57 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 1 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 4 P-high, 2 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 49 P-high, 81 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "ICE: unexpected concrete region in borrowck: ReStatic" [rust#87455](https://github.com/rust-lang/rust/issues/87455) 
+  - opened by @**Eric Huss**
+  - needs [rust#87483](https://github.com/rust-lang/rust/pull/87483) to be backported (was beta-accepted [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-08-05.20.2354818/near/248489051))
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-08-11](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-08-11.md)
+
+A quiet week for performance. Changes, both positive and negative, tended to be isolated to few benchmarks.
+
+Triage done by **@pnkfelix**.
+Revision range: [3354a44d2fa8d5ba6b8d6b40d2596de2c8292ec1..6b20506d17f4e5e5bf5bcad7e94add4d754b0ae3](https://perf.rust-lang.org/?start=3354a44d2fa8d5ba6b8d6b40d2596de2c8292ec1&end=6b20506d17f4e5e5bf5bcad7e94add4d754b0ae3&absolute=false&stat=instructions%3Au)
+
+2 Regressions, 1 Improvements, 0 Mixed; 0 of them in rollups
+
+#### Regressions
+
+Use zeroed allocations in the mir interpreter instead eagerly touching the memory [#87777](https://github.com/rust-lang/rust/issues/87777)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=1f94abcda6884893d4723304102089198caa0839&end=4c29cc8fd09889880880cb6081174c79744ab1b6&stat=instructions:u) (up to 1.7% on `incr-unchanged` builds of `ctfe-stress-4-check`)
+- The motivation for this PR was to reduce the number of page faults, for the same family of ctfe-stress-4 benchmarks.
+- So, perf runs were done on the PR itself, to illustrate the motivated change.
+- The number of page faults [did decrease (by up to 25%)](https://perf.rust-lang.org/compare.html?start=1f94abcda6884893d4723304102089198caa0839&end=4c29cc8fd09889880880cb6081174c79744ab1b6&stat=faults).
+- The regression with respect to instruction counts appears isolated to just the ctfe-stress-4 family; the page fault reduction outweighs instruction count hit.
+- (Unfortunately the page fault decrease did not yield a corresponding improvement to reported wall-clock or task-clock times.)
+
+Hide allocator details from TryReserveError [#87408](https://github.com/rust-lang/rust/issues/87408)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=db3cb435c1197ef3e3919c03b7f81ca8bffbd007&end=996ff2e0a0f911f52bb1de6bdd0cfd5704de1fc9&stat=instructions:u) (up to 4.2% on `full` builds of `html5ever-opt`)
+- The regression with respect to instruction counts appears isolated to just the html5ever-opt benchmark; all other reported changes pale in significance.
+- Potentially significant: the max-rss for html5ever-opt also regressed here, by 8%.
+- (Skimming over the PR itself, I do not see any obvious reason for this significant of a regression to max-rss.)
+- Some other benchmarks also regressed with respect to max-rss, but none so significantly.
+- Left a [comment on the PR](https://github.com/rust-lang/rust/pull/87408#issuecomment-896924754) as a heads up.
+
+#### Improvements
+
+- #[inline] slice::Iter::advance_by [#87736](https://github.com/rust-lang/rust/issues/87736)
+
+#### Mixed
+
+None
+
+#### Untriaged Pull Requests
+
+- [#87640 Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/87640)
+- [#87587 Various refactorings of the TAIT infrastructure](https://github.com/rust-lang/rust/pull/87587)
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to 🛡️ against 💥 💥-payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Remove all json handling from rustc_serialize" [rust#85993](https://github.com/rust-lang/rust/pull/85993)
+  - Nominated by @**Aaron Hill**  to point out that [a broader discussion is needed](https://github.com/rust-lang/rust/pull/85993#issuecomment-894686998)
+  - @**oli** [suggests an MCP](https://github.com/rust-lang/rust/pull/85993#issuecomment-895309985)
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610) 
+  - Added an action item on [HackMD](https://hackmd.io/5BtjuenFTn6M74IDwLOjgw), needs an owner
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "[RFC2603] Extend `<const>` to include `str` and structural constants." [rfcs#3161](https://github.com/rust-lang/rfcs/pull/3161)
+  - nominated by @**eddyb** 
+  - [review and concerns](https://github.com/rust-lang/rfcs/pull/3161#issuecomment-896587191)

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-08-19.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-08-19.md
@@ -1,0 +1,179 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-08-19
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Steering meeting on <time:2021-08-20T10:00:00-04:00> to discuss how to increase the number of reviewers available to handle the review queue load. ([Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Review.20assignments.20steering.20meeting))
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  -  "prefer-dynamic=subset" [compiler-team#455](https://github.com/rust-lang/compiler-team/issues/455) 
+- Old MCPs (not seconded, take a look)
+  -  "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comments: GH 7m ago, Zulip 12d ago)
+  -  "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comments: GH 6m ago, Zulip 50d ago)
+  -  "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comments: GH 2m ago, Zulip 49d ago)
+  -  "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comments: GH 49d ago, Zulip none)
+  -  "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comments: GH 48d ago, Zulip 59d ago)
+  -  "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comments: GH 28d ago, Zulip 20d ago)
+  -  "Make `resolve_instance` fallible" [compiler-team#449](https://github.com/rust-lang/compiler-team/issues/449) (last comments: GH 18d ago, Zulip none)
+  -  "Add `TyKind::Const` and remove `GenericArgKind::Const`" [compiler-team#453](https://github.com/rust-lang/compiler-team/issues/453) (last comment: GH none, Zulip yesterday)
+- Pending FCP requests (check your boxes!)
+  -  "Reproducible command line + determinism" [compiler-team#450](https://github.com/rust-lang/compiler-team/issues/450)
+  -  "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+  -  "Extend `-Cdebuginfo` with new options and named aliases" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+- Things in FCP (make sure you're good with it)
+  -  "Make AST->HIR lowering incremental" [compiler-team#452](https://github.com/rust-lang/compiler-team/issues/452) 
+- Accepted MCPs
+  -  "Rename various internal things" [compiler-team#451](https://github.com/rust-lang/compiler-team/issues/451) 
+- Finalized FCPs (disposition merge)
+  - No new finished FCP (disposition merge) this time.
+
+### WG checkins
+
+@*WG-self-profile* by @**mw** @**Wesley Wiser** ([previous checkin](https://hackmd.io/tuLB5d6ETKCZGS3cpzzRiA#WG-checkins))
+> @rylev and @**mw** are slowly working towards being able to record non-timestamp data like the sizes of files that the compiler emits -- e.g. object files and incr. comp. on-disk data. @**Wesley Wiser** is doing the reviewing. We should have something to show by the next checkin :)
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Always preserve sub-obligations in the projection cache" [rust#85868](https://github.com/rust-lang/rust/pull/85868) 
+  - @**pnkfelix** self-assigned to find another reviewer
+  - feedback from @Jack Huey on it to @Aaron Hill. But Jack also said they would not be comfortable reviewing without at least some support from e.g. @nikomatsakis (perhaps during one of Niko's office times)
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Extend `-Cdebuginfo` with new options and named aliases" [rust#83947](https://github.com/rust-lang/rust/pull/83947)
+  - opened by @**Julia Tatz**
+  - assigned and reviewed by @**nagisa** and @**Vadim Petrochenkov**
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-08-12.20.2354818/near/249241832)
+  - [decided to pass this through an FCP](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-08-12.20.2354818/near/249242280) but author didn't respond
+- "Encode spans relative to the enclosing item" [rust#84373](https://github.com/rust-lang/rust/pull/84373) 
+  - opened by @**cjgillot** 
+  - assigned to @**Vadim Petrochenkov**
+  - pending wg-incr-comp discussion
+- "Remove all json handling from rustc_serialize" [rust#85993](https://github.com/rust-lang/rust/pull/85993) 
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-08-12.20.2354818/near/249240458), we'd like to have @**Vadim Petrochenkov** and @**cjgillot** in the loop
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler
++label%3AP-critical+no%3Aassignee)
+- [83 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [56 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 2 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 49 P-high, 81 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "LLVM crash: Basic Block does not have terminator!" [rust#88043](https://github.com/rust-lang/rust/issues/88043)
+  - opened by @**David Tolnay** 
+  - seems caused by [rust#83417](https://github.com/rust-lang/rust/pull/83417) cc: @**oli**, suggests a quick revert and then look at this again without pressure
+  - @**david tolnay** also [points out](https://github.com/rust-lang/rust/issues/88043#issuecomment-900517377) relation with [rust#88043](https://github.com/rust-lang/rust/issues/88043#issuecomment-900517377)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "ICE: unexpected concrete region in borrowck: ReStatic" [rust#87455](https://github.com/rust-lang/rust/issues/87455) 
+  - regression in crate run for 1.55, manifested in a [couple of issues](https://github.com/rust-lang/rust/issues/87455#issuecomment-897891685)
+  - @**pnkfelix** self-assigned to backport [rust#87843](https://github.com/rust-lang/rust/pull/87483)
+- "ICE: unexpected concrete region in borrowck: ReEarlyBound(0, 'a)" [rust#83190](https://github.com/rust-lang/rust/issues/83190) 
+  - assigned same `P-high` as sibling [rust#87455](https://github.com/rust-lang/rust/issues/87455) :point_up_2: 
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-08-17](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-08-17.md)
+
+A fairly busy week which was to expected given that we've [adjusted our algorithm](https://github.com/rust-lang/rustc-perf/pull/956) for whether we label a change as a regression or not. Most regressions were relatively small, and only one has not yet been addressed in some way.
+
+Triage done by **@rylev**.
+Revision range: [6b20506d17f4e5e5bf5bcad7e94add4d754b0ae3..aa8f27bf4d980023a8b245ceb25a490a18041eb2](https://perf.rust-lang.org/?start=6b20506d17f4e5e5bf5bcad7e94add4d754b0ae3&end=aa8f27bf4d980023a8b245ceb25a490a18041eb2&absolute=false&stat=instructions%3Au)
+59 comparisons made in total
+
+3 Regressions, 2 Improvements, 2 Mixed; 0 of them in rollups
+
+#### Regressions
+
+encode `generics_of` for fields and ty params [#87815](https://github.com/rust-lang/rust/issues/87815)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=2d10c2a3302d53e10a4ad3ac581103faaae9eeb6&end=c4c2986c499ee9440b7ae23bf5a62c6168e1ce17&stat=instructions:u) (up to 1.2% on `incr-unchanged` builds of `diesel`)
+- While the regressions are fairly small, the largest ones seem to be happening in real-world crates like diesel, serde, and futures. 
+- The largest regressions seem to be in the `explicit_predicates_of` query which would seem to be directly impacted by this change.
+- Left a [comment](https://github.com/rust-lang/rust/pull/87815#issuecomment-900465263) to see how we should address this issue. 
+
+
+Various refactorings of the TAIT infrastructure [#87587](https://github.com/rust-lang/rust/issues/87587)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=47b41b7788a6f85c749049062f1e4eed497cd894&end=d488de82f30fd1dcb0220d57498638596622394e&stat=instructions:u) (up to 1.5% on `full` builds of `inflate`)
+- The issue is [expected](https://github.com/rust-lang/rust/pull/87587#issuecomment-896754235) and is being monitored with a possible solution in the works.
+
+
+Name the captured upvars for closures/generators in debuginfo [#85020](https://github.com/rust-lang/rust/issues/85020)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=c6094fc7b9981d755abeb8c0e866a0f6315b3ec3&end=99efc51dae1dbe9d741707a7ddef84c29e654df5&stat=instructions:u) (up to 4.9% on `incr-patched: println` builds of `webrender-wrench`)
+- This is a large regression in one benchmark, but it seems to be in codegen which this change would impact. 
+- [There is a comment](https://github.com/rust-lang/rust/pull/85020#issuecomment-898823772) justifying this as concerning but worth it given it only impacts one benchmark. I still believe this might be one worth keeping an eye on.
+
+#### Improvements
+
+- Avoid using the `copy_nonoverlapping` wrapper through `mem::replace`. [#87827](https://github.com/rust-lang/rust/issues/87827)
+- Run RemoveZsts pass at mir-opt-level=1 [#83417](https://github.com/rust-lang/rust/issues/83417)
+
+#### Mixed
+
+Introduce `hir::ExprKind::Let` - Take 2 [#80357](https://github.com/rust-lang/rust/issues/80357)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=2bd17c1d43bba43412cc2f051323a279d6751e43&end=2a6fb9a4c0e5ca7a81999065943b211c226fe9d8&stat=instructions:u) (up to -2.1% on `incr-patched: println` builds of `webrender`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=2bd17c1d43bba43412cc2f051323a279d6751e43&end=2a6fb9a4c0e5ca7a81999065943b211c226fe9d8&stat=instructions:u) (up to 0.7% on `full` builds of `cranelift-codegen`)
+
+
+BTree: merge the complication introduced by #81486 and #86031 [#87696](https://github.com/rust-lang/rust/issues/87696)
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=2a6fb9a4c0e5ca7a81999065943b211c226fe9d8&end=23461b210f1b0a121592a18fc4fb666106006668&stat=instructions:u) (up to -0.6% on `full` builds of `issue-46449`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=2a6fb9a4c0e5ca7a81999065943b211c226fe9d8&end=23461b210f1b0a121592a18fc4fb666106006668&stat=instructions:u) (up to 1.7% on `full` builds of `ripgrep`)
+- This is mostly a wash in terms of performance (with performance shifting somewhat equally across all the benchmarks), with the largest changes happening in stress tests.
+
+
+#### Untriaged Pull Requests
+
+- [#87640 Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/87640)
+- [#87587 Various refactorings of the TAIT infrastructure](https://github.com/rust-lang/rust/pull/87587)
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to shield against exploding payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Remove all json handling from rustc_serialize" [rust#85993](https://github.com/rust-lang/rust/pull/85993)
+  - discussed in `S-waiting-on-team`
+- "Binary size is significant increased from `1.46.0` to `1.51.0`" [rust#86610](https://github.com/rust-lang/rust/issues/86610)
+  - Has action item on [HackMD](https://hackmd.io/5BtjuenFTn6M74IDwLOjgw) to add binary size tracking to perf.rlo, needs an owner
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "[RFC2603] Extend `<const>` to include `str` and structural constants." [rfcs#3161](https://github.com/rust-lang/rfcs/pull/3161)
+  - discussed [last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-08-12.20.2354818/near/249243501)
+  - @**mw** [suggested](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-08-12.20.2354818/near/249247119) to merge the current implementation, not the RFC, and gather real-world data
+  - still needs discussion or `I-nominated` can be removed?
+

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-08-26.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-08-26.md
@@ -1,0 +1,192 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-08-26
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow at <time:2021-08-27T10:00:00-04:00> **Compiler Team Planning meeting** ([link](https://forge.rust-lang.org/compiler/steering-meeting.html))
+- Tomorrow from <time:2021-08-27T10:00:00-04:00> until <time:2021-08-27T14:00:00-04:00> **Polonius Hackathon** on #**t-compiler/wg-polonius**, [google meet link](meet.google.com/szw-fqkz-qwu)
+- `T-compiler` agenda now has a new section: the 5 most recently updated PRs waiting for review (thanks @**Santiago Pastorino** for contributing the patch and @**inquisitivecrystal** for assigning the team label to most of them. [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bsteering.20meeting.5D.202021-08-20.20compiler-team.23446/near/250124654).
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "Add different entry points for x.py" [compiler-team#396](https://github.com/rust-lang/compiler-team/issues/396) (last comment: GH 7m ago, Zulip 17d ago)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: GH 6m ago, Zulip 2m ago)
+  - "Don't steal the resolver when lowering HIR; instead store an immutable resolver in TyCtxt" [compiler-team#437](https://github.com/rust-lang/compiler-team/issues/437) (last comment: GH 2m ago, Zulip 2m ago)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comment: GH 2m days ago, Zulip None)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comment: GH about 2m ago, Zulip 2m ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comment: GH about 40 days ago, Zulip 20d ago)
+  - "Add `TyKind::Const` and remove `GenericArgKind::Const`" [compiler-team#453](https://github.com/rust-lang/compiler-team/issues/453) (last comment: GH about 6d ago, Zulip 10d ago)
+  - "prefer-dynamic=subset" [compiler-team#455](https://github.com/rust-lang/compiler-team/issues/455) (last comment: GH about 6d ago, Zulip 8d ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+- Things in FCP (make sure you're good with it)
+  - "Make `resolve_instance` fallible" [compiler-team#449](https://github.com/rust-lang/compiler-team/issues/449) 
+  - "Reproducible command line + determinism" [compiler-team#450](https://github.com/rust-lang/compiler-team/issues/450) 
+  - "Make AST->HIR lowering incremental" [compiler-team#452](https://github.com/rust-lang/compiler-team/issues/452) 
+  - "Transfer `rustc-demangle` to the @rust-lang GitHub org." [compiler-team#456](https://github.com/rust-lang/compiler-team/issues/456) 
+  - "Extend `-Cdebuginfo` with new options and named aliases" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - No new finished FCP (disposition merge) this time.
+
+### WG checkins
+
+- @*WG-async-foundations* by @**nikomatsakis** @**tmandry** ([previous checkin](https://hackmd.io/wCIbJPBKSxKeScnuh3dr2Q))
+> Checkin text
+
+- @*WG-traits* by @**nikomatsakis** @**Jack Huey** ([previous checkin](https://hackmd.io/PgfxdZIrTEOQ5Mw_ZEEesA))
+> * [#85499](https://github.com/rust-lang/rust/pull/85499) was merged, which fixes the common `OutputTypeParameterMismatch` ICE (ends up closing over a dozen issues)
+> * Continuing work on GATs
+>   * [blog post](https://blog.rust-lang.org/2021/08/03/GATs-stabilization-push.html) announcing push for GATs stabilization
+>   * [retconned lang initiatve repo](https://github.com/nikomatsakis/generic-associated-types-initiative) - check out open design discussions, feedback welcome!
+>   * Multiple PRs opened/merged fixing bugs and diagnostics, will continue moving forward
+> * Continuing work on type alias impl trait
+>   * Many tests added
+>   * Refactorings being done to change TAIT to act like an unbound ty var, simplifying the implementation and make it "trivial" to support more use cases than was originally planned for initial stabilization
+> * Continuing work on trait upcasting
+>   * [retconned lang initiative repo](https://github.com/nikomatsakis/dyn-upcasting-coercion-initiative/) - check out open design discussions, feedback welcome!
+>   * A few PRs have been merged implement actual trait selection, type checking, and coercion
+>   * PR open for unsafety checking
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Always preserve sub-obligations in the projection cache" [rust#85868](https://github.com/rust-lang/rust/pull/85868) 
+  - @**nikomatsakis** will try to review
+  - @**Jack Huey** approved but mentions a substancial perf loss, thus [the need to add some tests](https://github.com/rust-lang/rust/pull/85868#pullrequestreview-738824341) 
+- :beta: "Split critical edge targeting the start block" [rust#88124](https://github.com/rust-lang/rust/pull/88124) 
+  - Opened by @**tm**
+  - Assigned to @**oli**
+  - Nominated by @**Wesley Wiser**
+  - Fixes [#88043](https://github.com/rust-lang/rust/issues/88043) a `P-critical` due to exposing an LLVM bug
+- :stable: "Split critical edge targeting the start block" [rust#88124](https://github.com/rust-lang/rust/pull/88124) 
+  - see above
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Extend `-Cdebuginfo` with new options and named aliases" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+  - [need more user-facing documentation](https://github.com/rust-lang/rust/pull/83947#issuecomment-901955302) ...
+  - ... and we decided to [make it a blocker](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-08-19.20.2354818/near/249992881)
+  - Who should provide documentation? The PR author? Maybe a direct ping?
+
+### Most recent PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "move obligation dedup from `impl_or_trait_obligations` to project caching" [rust#84944](https://github.com/rust-lang/rust/pull/84944) (last comment: about 16 days ago)
+  - seems fine, [needs sign-off from Niko](https://github.com/rust-lang/rust/pull/84944#issuecomment-877254683)
+- "Support #[global_allocator] without the allocator shim" [rust#86844](https://github.com/rust-lang/rust/pull/86844) (last comment: about 16 days ago)
+- "check where-clause for explicit `Sized` before suggesting `?Sized`" [rust#86455](https://github.com/rust-lang/rust/pull/86455) (last comment: about 10 days ago)
+  - fixes [rustc#85945](https://github.com/rust-lang/rust/issues/85945)
+- "Abort in panic_abort eh_personality" [rust#86801](https://github.com/rust-lang/rust/pull/86801) (last comment: about 10 days ago)
+- "Refactor unsized suggestions" [rust#86454](https://github.com/rust-lang/rust/pull/86454) (last comment: about 10 days ago)
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [83 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [56 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 3 P-high, 1 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 48 P-high, 81 P-medium, 9 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "LLVM crash: Basic Block does not have terminator!" [rust#88043](https://github.com/rust-lang/rust/issues/88043)
+  - reopened to track the stable-to-stable regression
+  - (see beta and stable nominations)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "ICE: unexpected concrete region in borrowck: ReStatic" [rust#87455](https://github.com/rust-lang/rust/issues/87455) 
+  - @**pnkfelix** self-assigned backport of [rust#87843](https://github.com/rust-lang/rust/pull/87483), provided PR [rust#88190](https://github.com/rust-lang/rust/pull/88190) (approved by @**simulacrum**)
+- "ICE: unexpected concrete region in borrowck: ReEarlyBound(0, 'a)" [rust#83190](https://github.com/rust-lang/rust/issues/83190)
+  - regression in crate run for 1.55, manifested in a couple of issues
+  - should be resolved by [rust#88190](https://github.com/rust-lang/rust/pull/88190), authored by Felix
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-08-25](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-08-24.md)
+
+A few regressions but largely an improvement this week, mostly due to the upgrade to LLVM 13.
+
+Triage done by **@simulacrum**. 2 Regressions, 1 Improvements, 2 Mixed; 0 of them in rollups
+
+#### Regressions
+
+Update the backtrace crate in libstd [#88151](https://github.com/rust-lang/rust/issues/88151)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=2451f42c1deb9379d5e8e5fa86b0bf857ae048ec&end=7960030d6915a771f5ab72c3897a7ed50c3ed4bd&stat=instructions:u) (up to 2.6% on `incr-patched: u8 3072` builds of `issue-46449`)
+- Standard regression from an increase in std/core size due to added items.
+
+Add fast path for Path::cmp that skips over long shared prefixes [#86898](https://github.com/rust-lang/rust/issues/86898)
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=7611fe438dae91084d17022e705bf64374d5ba4b&end=bcfd3f7e88084850f87b8e34b4dcb9fceb872d00&stat=instructions:u) (up to -0.3% on `incr-unchanged` builds of `helloworld`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7611fe438dae91084d17022e705bf64374d5ba4b&end=bcfd3f7e88084850f87b8e34b4dcb9fceb872d00&stat=instructions:u) (up to 1.2% on `incr-patched: println` builds of `ripgrep`)
+- Largely in -doc builds, seems to be a small but real regression.
+
+#### Improvements
+
+- Reenable RemoveZsts [#88176](https://github.com/rust-lang/rust/issues/88176)
+
+#### Mixed
+
+Revert "Auto merge of #83417 - erikdesjardins:enableremovezsts, r=oli-obk" [#88056](https://github.com/rust-lang/rust/issues/88056)
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=aa8f27bf4d980023a8b245ceb25a490a18041eb2&end=806b3995b8f622d5de10afcc11c10a028a7b876a&stat=instructions:u) (up to -0.5% on `incr-patched: println` builds of `cargo`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=aa8f27bf4d980023a8b245ceb25a490a18041eb2&end=806b3995b8f622d5de10afcc11c10a028a7b876a&stat=instructions:u) (up to 4.5% on `incr-unchanged` builds of `deeply-nested-async`)
+- Regression is canceled out by the later #88176 (see improvements above).
+Upgrade to LLVM 13 [#87570](https://github.com/rust-lang/rust/issues/87570)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=e7f7fe462a54b1caeb804a974cd43ba9fd7bee5c&end=db002a06ae9154a35d410550bc5132df883d7baa&stat=instructions:u) (up to -10.4% on `incr-unchanged` builds of `helloworld`)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e7f7fe462a54b1caeb804a974cd43ba9fd7bee5c&end=db002a06ae9154a35d410550bc5132df883d7baa&stat=instructions:u) (up to 9.6% on `full` builds of `match-stress-enum`)
+- Overall an improvement, regressions are significantly more limited to just a
+  few cases compared to the improvements seen across the board.
+
+#### Untriaged Pull Requests
+
+- [#87815 encode `generics_of` for fields and ty params](https://github.com/rust-lang/rust/pull/87815)
+- [#87781 Remove box syntax from compiler and tools](https://github.com/rust-lang/rust/pull/87781)
+- [#87640 Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/87640)
+- [#87587 Various refactorings of the TAIT infrastructure](https://github.com/rust-lang/rust/pull/87587)
+- [#87570 Upgrade to LLVM 13](https://github.com/rust-lang/rust/pull/87570)
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to shield against exploding payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+- [#80357 Introduce `hir::ExprKind::Let` - Take 2](https://github.com/rust-lang/rust/pull/80357)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "ACCESS_VIOLATION when dereferencing once_cell::Lazy in closure with LTO" [rust#81408](https://github.com/rust-lang/rust/issues/81408) 
+  - Windows-only, happens when using LLD linker and building with Thin LTO, [a bit more details and a repro](https://github.com/rust-lang/rust/issues/81408#issuecomment-847122562) from @**memoryruins** 
+  - As it seems an LLVM issue, has this been reported upstream? ([see comment](https://github.com/rust-lang/rust/issues/81408#issuecomment-883092504))
+  - Wg-prio assigned `P-high`, issue is still present with LLVM13 so `I-nominated` to get more eyeballs on it, where to go from here?
+ 
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-09-02.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-09-02.md
@@ -1,0 +1,234 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-09-02
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- :loudspeaker: Next week, September, 9th release Rust stable 1.55 :loudspeaker:
+
+## MCPs/FCPs
+
+Note: [2021-08-27 MCP review](https://hackmd.io/yQ8jefI0Q0mBwFMAjGKfQw)
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: GH none, Zulip 2m ago)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comment: GH +2m ago, Zulip yesterday)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comment: GH none, Zulip +2m ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comment: GH none, Zulip 40d ago)
+  - "Add `TyKind::Const` and remove `GenericArgKind::Const`" [compiler-team#453](https://github.com/rust-lang/compiler-team/issues/453) (last comment: GH none, Zulip 15d ago)
+  - "prefer-dynamic=subset" [compiler-team#455](https://github.com/rust-lang/compiler-team/issues/455) (last comment: GH none, Zulip today)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+- Things in FCP (make sure you're good with it)
+  - "Transfer `rustc-demangle` to the @rust-lang GitHub org." [compiler-team#456](https://github.com/rust-lang/compiler-team/issues/456) 
+  - "Add the `-Z randomize-layout` flag" [compiler-team#457](https://github.com/rust-lang/compiler-team/issues/457) 
+  - "Add `m68k-unknown-linux-gnu` as new Tier 3 backend" [compiler-team#458](https://github.com/rust-lang/compiler-team/issues/458) 
+- Accepted MCPs
+  - "Make `resolve_instance` fallible" [compiler-team#449](https://github.com/rust-lang/compiler-team/issues/449) 
+  - "Reproducible command line + determinism" [compiler-team#450](https://github.com/rust-lang/compiler-team/issues/450) 
+  - "Make AST->HIR lowering incremental" [compiler-team#452](https://github.com/rust-lang/compiler-team/issues/452) 
+- Finalized FCPs (disposition merge)
+  - "Extend `-Cdebuginfo` with new options and named aliases" [rust#83947](https://github.com/rust-lang/rust/pull/83947) 
+  - "Stabilize "force warn" option " [rust#86516](https://github.com/rust-lang/rust/issues/86516)
+
+### WG checkins
+
+- @*WG-diagnostics* from @**Esteban Küber** and @**oli** ([previous checkin](https://hackmd.io/1NeIcqXERkug9KItmB1TwQ)):
+> nothing major since last checkin: multiple small improvements and the landing of a new structured suggestion output that mimics diff patches with coloring
+
+- @*WG-rustc-dev-guide* from @**Santiago Pastorino** and @**Yuki Okushi|217081** ([previous checkin](https://hackmd.io/1NeIcqXERkug9KItmB1TwQ)):
+>#### Most notable changes
+>
+>- Documenting diagnostic items with their usage and naming conventions [#1192](https://github.com/rust-lang/rustc-dev-guide/pull/1192)
+>- Expand THIR section with more details [#1183](https://github.com/rust-lang/rustc-dev-guide/pull/1183)
+>- Add description of -opt-bisect-limit LLVM option [#1182](https://github.com/rust-lang/rustc-dev-guide/pull/1182)
+>
+>#### Most notable WIPs
+>
+>- `ty::Unevaluated`: dealing with unused substs [#1190](https://github.com/rust-lang/rustc-dev-guide/pull/1190)
+>- Update build instructions for rustdoc [#1117](https://github.com/rust-lang/rustc-dev-guide/pull/1117)
+>- Move "ctags" section into "Suggested Workflow" [#1115](https://github.com/rust-lang/rustc-dev-guide/pull/1115)
+>- Document inert vs active attributes [#1110](https://github.com/rust-lang/rustc-dev-guide/pull/1110)
+>- Explain the new valtree system for type level constants. [#1097](https://github.com/rust-lang/rustc-dev-guide/pull/1097)
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Always preserve sub-obligations in the projection cache" [rust#85868](https://github.com/rust-lang/rust/pull/85868) 
+  - reviewed by @**Jack Huey**
+  - [perf results](https://github.com/rust-lang/rust/pull/85868#issuecomment-907458600): large improvements and large regressions
+  - still needs to land on nightly?
+- :beta: "Tracking issue for `UNSUPPORTED_CALLING_CONVENTIONS`" [rust#88397](https://github.com/rust-lang/rust/pull/88397) 
+  - opened by @**nagisa**
+  - approved by @**simulacrum**
+  - nominated to make this lint into stable 1.55
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- None at this time
+
+### Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "Make *const (), *mut () okay for FFI" [rust#84267](https://github.com/rust-lang/rust/pull/84267) (last comment: 4 months ago)
+  - rust-five bot assigned to @**Matthew Jasper**
+- "move obligation dedup from `impl_or_trait_obligations` to project caching" [rust#84944](https://github.com/rust-lang/rust/pull/84944) (last comment: now)
+  - assigned to @**nikomatsakis**
+  - discussed last week (see [Wesley's comment](https://github.com/rust-lang/rust/pull/84944#issuecomment-906810332))
+- "Replace dominators algorithm with simple Lengauer-Tarjan" [rust#85013](https://github.com/rust-lang/rust/pull/85013) (last comment: 3 months ago)
+rustc_query_impl compile time.
+- "Refactor query forcing" [rust#78780](https://github.com/rust-lang/rust/pull/78780) (last comment: 8 days ago)
+  - assigned to @**Wesley Wiser**
+  - [Perf run results](https://github.com/rust-lang/rust/pull/78780#issuecomment-905701857): no runtime modification, and -8% on   - 
+- "Replace Copy/Clone compiler magic on arrays with library impls" [rust#86041](https://github.com/rust-lang/rust/pull/86041) (last comment: about +2 months ago)
+  - also labeled `T-libs`
+  - assigned to @**Josh Triplett**
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [82 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [56 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 2 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 2 P-high, 1 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 47 P-high, 82 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "LLVM crash: Basic Block does not have terminator!" [rust#88043](https://github.com/rust-lang/rust/issues/88043) 
+  - Fix in PR [#88124](https://github.com/rust-lang/rust/pull/88124) is beta- and stable- backport accepted, PR is merged
+  - tracking the stable-to-stable regression (Wesley's [comment](https://github.com/rust-lang/rust/issues/88043#issuecomment-902126551))
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "ICE: unexpected concrete region in borrowck: ReStatic" [rust#87455](https://github.com/rust-lang/rust/issues/87455) 
+  - @**pnkfelix** provided backport in PR [rust#88190](https://github.com/rust-lang/rust/pull/88190) (approved by  @**simulacrum**)
+  - Backport landing in 1.55
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- "Regression ICE - broken MIR under `-C opt-level=s` on `if let Some(v) = None as Option<...>`" [rust#88307](https://github.com/rust-lang/rust/issues/88307) 
+  - should be resolved by PR [rust#88572](https://github.com/rust-lang/rust/pull/88572), PR is waiting for review (rust-high-five assigned to Wesley)
+
+## Performance logs
+
+> [triage logs for 2021-09-01](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-09-01.md)
+
+A very busy week with relatively even amounts of regressions and improvements (albeit with improvements outweighing regressions). The largest win was the use of profile-guided optimization (PGO) builds on x86_64 linux builds which brings fairly large improvements in real-world crates. There were 2 regressions that caused fairly large (~3.5%) regressions in real-world crates which need to be investigated.
+
+Triage done by **@rylev**. 5 Regressions, 4 Improvements, 5 Mixed; 0 of them in rollups
+56 comparisons made in total
+
+#### Regressions
+
+Get piece unchecked in `write` [#83302](https://github.com/rust-lang/rust/issues/83302)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a49e38e672c60da788360e088f00ad12353e3913&end=de42550d0ac525f44ec79300a1cb349ade181c1a&stat=instructions:u) (up to 3.5% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo`)
+- This is a largely a change in std lib code, and we don't really have a good process for dealing with how std lib changes effect performance.
+- This seems to be primarily affecting debug and check builds, but there doesn't seem to be a query that is clearly to blame here. Given the motivation of this PR is primarily performance, I think it deserves a closer look.
+- Added a comment on the PR [here](https://github.com/rust-lang/rust/pull/83302#issuecomment-910058149).
+
+
+Warn about unreachable code following an expression with an uninhabited type [#85556](https://github.com/rust-lang/rust/issues/85556)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=de42550d0ac525f44ec79300a1cb349ade181c1a&end=5ca596f486707ac1362edad717ad0e9f5b71d0a3&stat=instructions:u) (up to 9.0% on `incr-unchanged` builds of `webrender-wrench`)
+- This regression seems to only be happening in one benchmark `webrender-wrench` and is consistently affecting the `extern_crate`, 
+`incr_comp_intern_dep_graph_node`, and `metadata_decode_entry_extern_crate` queries. 
+- Given the nature of the change which only impacts liveness checking, I'm unsure why this might be the case. However, given that the regressions are fairly large, I do think additional investigation is worth looking into.
+- Left a comment on the PR [here](https://github.com/rust-lang/rust/pull/85556#issuecomment-910064890).
+
+
+lazily "compute" anon const default substs [#87280](https://github.com/rust-lang/rust/issues/87280)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=ad02dc46badee510bd3a2c093edf80fcaade91b1&end=517c28e421b0d601c6f8eb07ea6aafb8e16975ad&stat=instructions:u) (up to 4.8% on `full` builds of `ctfe-stress-4`)
+- This is an important change for const generics, and the const generics team discussed whether the performance hit seemed worth it, and they reached this conclusion [that it was](https://github.com/rust-lang/rust/pull/87280#issuecomment-906288243).
+
+Treat types in unnormalized function signatures as well-formed [#88312](https://github.com/rust-lang/rust/issues/88312)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=66acdee9f7822ff2427f2b967e537215421eeb16&end=59ce76548484806ac4970c57c0bb6ad9e53b80f6&stat=instructions:u) (up to 3.4% on `full` builds of `serde`)
+- This regression affects many real world crates in significant ways. The query affected by this seems to be additional calls to `implied_outlives_bounds` which I believe would be impacted by this change. 
+- Left a comment on the PR [here](https://github.com/rust-lang/rust/pull/88312#issuecomment-910073037).
+
+
+build llvm libunwind.a in rustbuild [#85600](https://github.com/rust-lang/rust/issues/85600)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=42a2a53ec13b0e6e915acd09a2a9a963e5fa3b92&end=926f069950d7211a87fbd81778b420de420daad7&stat=instructions:u) (up to 0.3% on `incr-patched: println` builds of `regression-31157`)
+- The performance change is rather small, but quite surprising since the change is just in how linunwind is being build which (presumably?) should mean that this is a perf noop. 
+- Left a comment on the PR [here](https://github.com/rust-lang/rust/pull/85600#issuecomment-910075406), but noted that it didn't seem strictly necessary to investigate due to the rather small impact of the performance change.
+
+
+#### Improvements
+
+- PGO for LLVM builds on x86_64-unknown-linux-gnu in CI [#88069](https://github.com/rust-lang/rust/issues/88069)
+- Morph `layout_raw` query into `layout_of`. [#88308](https://github.com/rust-lang/rust/issues/88308)
+- Introduce `~const` [#88328](https://github.com/rust-lang/rust/issues/88328)
+- Cow'ify some pprust methods [#88262](https://github.com/rust-lang/rust/issues/88262)
+- Don't use `guess_head_span` in `predicates_of` for foreign span [#88414](https://github.com/rust-lang/rust/issues/88414)
+
+#### Mixed
+
+Normalize projections under binders [#85499](https://github.com/rust-lang/rust/issues/85499)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=7b0e554ee2c94e9b3865a8c2d24d720224512dec&end=0afc20860eb98a29d9bbeea80f2acc5be38c6bf3&stat=instructions:u) (up to -36.8% on `incr-unchanged` builds of `deeply-nested-async`)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=7b0e554ee2c94e9b3865a8c2d24d720224512dec&end=0afc20860eb98a29d9bbeea80f2acc5be38c6bf3&stat=instructions:u) (up to 1.4% on `incr-patched: add static arr item` builds of `coercions`)
+- The large wins are in the `deeply-nested-async` benchmark which due to being a stress test can often have big swings in performance.
+- A perf run was run on the PR, and it was not labeled as a mixed result because of slightly different thresholds that were used back then. 
+- The PR is a pretty important one and the perf results are largely neutral so need to ping the authors here.
+
+
+Use undef for uninitialized bytes in constants [#83698](https://github.com/rust-lang/rust/issues/83698)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=3b3ce374d203445eb1d0dce50f4211f4aceb7db6&end=20997f6ad81721542e9ef97bb2f58190903a34d8&stat=instructions:u) (up to -10.3% on `full` builds of `ctfe-stress-4`)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=3b3ce374d203445eb1d0dce50f4211f4aceb7db6&end=20997f6ad81721542e9ef97bb2f58190903a34d8&stat=instructions:u) (up to 0.6% on `incr-patched: println` builds of `coercions`)
+- Largely a performance win albeit in ctf-stress-test which being a stress test can yield large changes in certain cases. 
+- The regressions here are all very small, and overall despite this being technically a mixed result, the improvements outweigh the regressions.
+
+
+`#[inline]` non-generic `pub fn`s in `rustc_target::abi` and `ty::layout`. [#88326](https://github.com/rust-lang/rust/issues/88326)
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=720a1b23c1eda3c78e28126362238a500eaa20d4&end=dfd6306d26af1a163aaaa1456b4594244ddd182f&stat=instructions:u) (up to -1.5% on `incr-patched: add static arr item` builds of `coercions`)
+- Very small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=720a1b23c1eda3c78e28126362238a500eaa20d4&end=dfd6306d26af1a163aaaa1456b4594244ddd182f&stat=instructions:u) (up to 0.3% on `full` builds of `ripgrep`)
+- The PR author already noticed that this ended up being a bit of a wash in terms of [performance](https://github.com/rust-lang/rust/pull/88326#issuecomment-907122343). Given that improvements still outweigh regressions, there's no need to look into this (though I imagine the author will continue to do so).
+
+
+Treat macros as HIR items [#88019](https://github.com/rust-lang/rust/issues/88019)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=2031fd6e46fbe4da271bb23d55c211b2e16dd91f&end=05cccdc9b321e6565b3e62e8b52aec53d106ef2f&stat=instructions:u) (up to -3.2% on `incr-unchanged` builds of `tuple-stress`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=2031fd6e46fbe4da271bb23d55c211b2e16dd91f&end=05cccdc9b321e6565b3e62e8b52aec53d106ef2f&stat=instructions:u) (up to 0.8% on `incr-unchanged` builds of `wg-grammar`)
+- The improvements here outweigh the regressions considerably, and this is a fairly important bug fix. This PR has already had its performance [justified](https://github.com/rust-lang/rust/pull/88019#issuecomment-901585864).
+
+#### Untriaged Pull Requests
+
+- [#87815 encode `generics_of` for fields and ty params](https://github.com/rust-lang/rust/pull/87815)
+- [#87781 Remove box syntax from compiler and tools](https://github.com/rust-lang/rust/pull/87781)
+- [#87640 Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/87640)
+- [#87587 Various refactorings of the TAIT infrastructure](https://github.com/rust-lang/rust/pull/87587)
+- [#87570 Upgrade to LLVM 13](https://github.com/rust-lang/rust/pull/87570)
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86898 Add fast path for Path::cmp that skips over long shared prefixes](https://github.com/rust-lang/rust/pull/86898)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to 🛡️ against 💥 💥-payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+- [#80357 Introduce `hir::ExprKind::Let` - Take 2](https://github.com/rust-lang/rust/pull/80357)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-09-09.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-09-09.md
@@ -1,0 +1,199 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-09-09
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- :tada: Today 9/9th, release Rust stable 1.55 :tada:
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last comment: GH none, Zulip: none)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last comment: GH  20d ago, Zulip: 1w ago)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last comment: 2 months ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last comment: GH none, Zulip about a month ago)
+  - "Add `TyKind::Const` and remove `GenericArgKind::Const`" [compiler-team#453](https://github.com/rust-lang/compiler-team/issues/453) (last comment: GH None, Zulip about 2 weeks ago)
+  - "prefer-dynamic=subset" [compiler-team#455](https://github.com/rust-lang/compiler-team/issues/455) (last comment: GH none, Zulip 2 days ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+- Things in FCP (make sure you're good with it)
+  - "Add `TerminatorKind::Box` to MIR" [compiler-team#460](https://github.com/rust-lang/compiler-team/issues/460) 
+- Accepted MCPs
+  - "Transfer `rustc-demangle` to the @rust-lang GitHub org." [compiler-team#456](https://github.com/rust-lang/compiler-team/issues/456) 
+  - "Add the `-Z randomize-layout` flag" [compiler-team#457](https://github.com/rust-lang/compiler-team/issues/457) 
+  - "Add `m68k-unknown-linux-gnu` as new Tier 3 backend" [compiler-team#458](https://github.com/rust-lang/compiler-team/issues/458)
+- Finalized FCPs (disposition merge)
+  - "Stabilize "force warn" option " [rust#86516](https://github.com/rust-lang/rust/issues/86516) 
+  - "Support `#[track_caller]` on closures and generators" [rust#87064](https://github.com/rust-lang/rust/pull/87064) 
+  - "stabilize disjoint capture in closures (RFC 2229)" [rust#88126](https://github.com/rust-lang/rust/issues/88126) 
+  - "Stabilize reserved prefixes" [rust#88140](https://github.com/rust-lang/rust/issues/88140) 
+
+### WG checkins
+
+@*wg-incr-comp* by @**pnkfelix** and @**Wesley Wiser** ([previous checkin](https://hackmd.io/QCs_hIbpTbKgcSy-0V0Liw)):
+> On 20 Aug, wesleywiser mw and pnkfelix met with cjgillot to discuss PR #84373
+> It was productive in getting things unblocked, and we hope to have more meetings and progress in the future.
+ 
+@*WG-llvm* by @**nagisa** ([previous checkin](https://hackmd.io/QCs_hIbpTbKgcSy-0V0Liw)):
+> There was recently a bump to [LLVM 13](https://github.com/rust-lang/rust/pull/87570), with all of the associated fallout and fixes. There's also an effort to enable the [new pass manager by default](https://github.com/rust-lang/rust/pull/88243). This pass manager takes a different tradeoff between space and time, and as a result rustc would use more memory but also optimize code faster.
+> In some other news:
+>* we're considering using the `object` crate in more places to replace some artifact writing functionality we currently use from LLVM.
+>* The work towards type-less pointer support has largely happened to the extent it is enabled by LLVM 13.
+>* Support for LLVM 10 will likely be dropped in the near future, making LLVM 11 the oldest supported version.
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Preserve most sub-obligations in the projection cache" [rust#85868](https://github.com/rust-lang/rust/pull/85868)
+  - Team is inclined to r+ this, perf regressions are already triaged (necessary for correctness)
+  - @**Jack Huey** [commented last week](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-09-02.20.2354818/near/251720629) that the code needs a comment
+- :beta: "2229: Don't move out of drop type" [rust#88477](https://github.com/rust-lang/rust/pull/88477) 
+  - Fixes [rust#88476](https://github.com/rust-lang/rust/issues/88476) (Rust 2021 related)
+  - reviewed by @**Gary Guo**
+  - [approved by all team members](https://github.com/rust-lang/rust/pull/88477#issuecomment-912577175)
+- :beta: "Fix 2021 `dyn` suggestion that used code as label" [rust#88657](https://github.com/rust-lang/rust/pull/88657)
+  - opened by @**Noah Lev** 
+  - assigned for review to @**Mara** 
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Perform type inference in range pattern" [rust#88090](https://github.com/rust-lang/rust/pull/88090) 
+  - opened by @**Gary Guo**
+  - fixes [rust#88074](https://github.com/rust-lang/rust/issues/88074)
+  - @**Esteban Küber** left some comments
+  - @**Jack Huey** [I-nominated](https://github.com/rust-lang/rust/pull/88090#issuecomment-914580827) for `T-lang`
+
+### Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "Replace dominators algorithm with simple Lengauer-Tarjan" [rust#85013](https://github.com/rust-lang/rust/pull/85013) (last comment: 3 months ago)
+  - Question from @**apiraino**: why people from wg-triage have been removing and adding `S-waiting-for-review` for the last 2 months? Is it meant to emit a "ping" reminder?
+- "Refactor query forcing" [rust#78780](https://github.com/rust-lang/rust/pull/78780) (last comment: 3 months ago)
+  - assigned to @**Wesley Wiser**
+  - [Perf run results](https://github.com/rust-lang/rust/pull/78780#issuecomment-905701857): no runtime modification, and -8% on `rustc_query_impl` compile time 
+- "Update the x86_64-unknown-l4re-uclibc tier 3 target" [rust#85967](https://github.com/rust-lang/rust/pull/85967) (last comment: 3 months ago)
+  - [There is a review](https://github.com/rust-lang/rust/pull/85967#pullrequestreview-680959056) from June from @**Vadim Petrochenkov** which might need some discussion 
+- "Add basic checks for well-formedness of `fn`/`fn_mut` lang items" [rust#86246](https://github.com/rust-lang/rust/pull/86246) (last comment: 2 months ago)
+- "Emit clearer diagnostics for parens around `for` loop heads" [rust#86422](https://github.com/rust-lang/rust/pull/86422) (last comment: 2 months ago)
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [1 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [77 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [53 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 1 P-high, 0 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 0 P-high, 1 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 46 P-high, 81 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Type called union wreaks havoc since 1.54" [rust#88583](https://github.com/rust-lang/rust/issues/88583) 
+  - opened by @**David Tolnay** 
+  - [@**Josh Triplett** and  @**pnkfelix** discussed](https://github.com/rust-lang/rust/issues/88583#issuecomment-914482165)
+  - they agree that a revert of [rust#84571](https://github.com/rust-lang/rust/pull/84571) is needed
+  - nominated to get attention on this revert
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-09-7](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-09-07.md)
+
+A busy week, with lots of mixed changes, though in the end only a few were deemed significant enough to report here.
+
+Triage done by **@pnkfelix**. 3 Regressions, 1 Improvements, 3 Mixed; 0 of them in rollups
+57 comparisons made in total
+
+#### Regressions
+
+Shrink Session a bit [#88530](https://github.com/rust-lang/rust/issues/88530)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=64929313f53181636e4dd37e25836973205477e4&end=fcce644119cf4e8e36001368e514bb5ed67cb855&stat=instructions:u) (up to 2.6% on `full` builds of `deeply-nested-async`)
+
+Concrete regions can show up in mir borrowck if the originated from there [#88533](https://github.com/rust-lang/rust/issues/88533)
+- Very small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=29ef6cf1637aa8317f8911f93f14e18d404c1b0e&end=a3956106d12cebec91be0637759e29ab6908b4cd&stat=instructions:u) (up to 1.0% on `incr-patched: add static arr item` builds of `coercions`)
+- This is a small regression to `coercions` and that may be noise. However, there are many others that are over 0.4% regression to instruction counts. The combination of those two factors led pnkfelix to think that we may want to take a second look at the effects of this PR.
+
+Introduce `let...else` [#87688](https://github.com/rust-lang/rust/issues/87688)
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=a3956106d12cebec91be0637759e29ab6908b4cd&end=c2a408840ad18f74280805535f0b7193528ff3df&stat=instructions:u) (up to -0.3% on `incr-unchanged` builds of `deeply-nested-closures`)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a3956106d12cebec91be0637759e29ab6908b4cd&end=c2a408840ad18f74280805535f0b7193528ff3df&stat=instructions:u) (up to 0.4% on `full` builds of `issue-46449`)
+- Small regression (approximately 1%) in instruction counts on several of the `*-doc` tests, found via human eye.
+
+#### Improvements
+
+- Move global analyses from lowering to resolution [#88597](https://github.com/rust-lang/rust/issues/88597)
+
+#### Mixed
+
+Preserve most sub-obligations in the projection cache [#85868](https://github.com/rust-lang/rust/issues/85868)
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b834c4c1bad7521af47f38f44a4048be0a1fe2ee&end=371f3cd3fe523d0b398ed1db1620667c53ba7d02&stat=instructions:u) (up to -6.9% on `incr-unchanged` builds of `deeply-nested`)
+- Very large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=b834c4c1bad7521af47f38f44a4048be0a1fe2ee&end=371f3cd3fe523d0b398ed1db1620667c53ba7d02&stat=instructions:u) (up to 9.4% on `full` builds of `deeply-nested`)
+
+
+BTreeMap/BTreeSet::from_iter: use bulk building to improve the performance [#88448](https://github.com/rust-lang/rust/issues/88448)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=11bbb5231349a0a144d86d5c0c21061a06d1969d&end=ffaf857045f4f4d8bb563e0a5077f9b065f42916&stat=instructions:u) (up to -3.0% on `full` builds of `inflate`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=11bbb5231349a0a144d86d5c0c21061a06d1969d&end=ffaf857045f4f4d8bb563e0a5077f9b065f42916&stat=instructions:u) (up to 4.5% on `incr-patched: println` builds of `clap-rs`)
+
+Avoid invoking the hir_crate query to traverse the HIR [#88435](https://github.com/rust-lang/rust/issues/88435)
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=e30b68353fe22b00f40d021e7914eeb78473b3c1&end=7849e3e9dda60e8ec826ee245c6b180e73911b37&stat=instructions:u) (up to -1.2% on `incr-patched: add static arr item` builds of `coercions`)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e30b68353fe22b00f40d021e7914eeb78473b3c1&end=7849e3e9dda60e8ec826ee245c6b180e73911b37&stat=instructions:u) (up to 0.5% on `incr-unchanged` builds of `helloworld`)
+- pnkfelix included this one as notable largely because the expected perf changes from [the actual PR](https://github.com/rust-lang/rust/pull/88435#issuecomment-907700333) largely showed slight improvements across the board, while after it landed on nightly, it is best categorized as "Mixed"
+
+#### Untriaged Pull Requests
+
+- [#88597 Move global analyses from lowering to resolution](https://github.com/rust-lang/rust/pull/88597)
+- [#88552 Stop allocating vtable entries for non-object-safe methods](https://github.com/rust-lang/rust/pull/88552)
+- [#88312 Treat types in unnormalized function signatures as well-formed](https://github.com/rust-lang/rust/pull/88312)
+- [#87815 encode `generics_of` for fields and ty params](https://github.com/rust-lang/rust/pull/87815)
+- [#87781 Remove box syntax from compiler and tools](https://github.com/rust-lang/rust/pull/87781)
+- [#87640 Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/87640)
+- [#87587 Various refactorings of the TAIT infrastructure](https://github.com/rust-lang/rust/pull/87587)
+- [#87570 Upgrade to LLVM 13](https://github.com/rust-lang/rust/pull/87570)
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86898 Add fast path for Path::cmp that skips over long shared prefixes](https://github.com/rust-lang/rust/pull/86898)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to 🛡️ against 💥 💥-payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#85556 Warn about unreachable code following an expression with an uninhabited type](https://github.com/rust-lang/rust/pull/85556)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+- [#83302 Get piece unchecked in `write`](https://github.com/rust-lang/rust/pull/83302)
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Perform type inference in range pattern" [rust#88090](https://github.com/rust-lang/rust/pull/88090)
+  - (see `S-waiting-on-team`)
+- "Type called union wreaks havoc since 1.54" [rust#88583](https://github.com/rust-lang/rust/issues/88583) 
+  - (see `P-critical` list)
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-09-16.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-09-16.md
@@ -1,0 +1,198 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-09-16
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last review activity: GH none, Zulip: none)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last review activity: GH none, Zulip: about 2w ago)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last review activity: GH none, Zulip: about 2m ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last review activity: GH none, Zulip about 40d ago)
+  - "Add `TyKind::Const` and remove `GenericArgKind::Const`" [compiler-team#453](https://github.com/rust-lang/compiler-team/issues/453) (last review activity: GH None, Zulip about 1m ago)
+  - "prefer-dynamic=subset" [compiler-team#455](https://github.com/rust-lang/compiler-team/issues/455) (last review activity: GH none, Zulip 9d ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431) 
+- Things in FCP (make sure you're good with it)
+  - "Add `pie` relocation-model" [compiler-team#461](https://github.com/rust-lang/compiler-team/issues/461) 
+- Accepted MCPs
+  - "Add `Rvalue::ShallowInitBox` to MIR" [compiler-team#460](https://github.com/rust-lang/compiler-team/issues/460) 
+- Finalized FCPs (disposition merge)
+  - "Stabilize "force warn" option " [rust#86516](https://github.com/rust-lang/rust/issues/86516) 
+  - "Support `#[track_caller]` on closures and generators" [rust#87064](https://github.com/rust-lang/rust/pull/87064) 
+  - "stabilize disjoint capture in closures (RFC 2229)" [rust#88126](https://github.com/rust-lang/rust/issues/88126) 
+  - "Stabilize reserved prefixes" [rust#88140](https://github.com/rust-lang/rust/issues/88140) 
+  - "2229: Don't move out of drop type" [rust#88477](https://github.com/rust-lang/rust/pull/88477)
+  
+### WG checkins
+
+@*WG-mir-optimization* by @**oli** ([previous checkin](https://hackmd.io/vQr9mk6zSdib5vg9OlHuOQ)):
+> nothing to report at this time
+
+@*WG-polymorphization* checkin by @**davidtwco** ([previous checkin](https://hackmd.io/vQr9mk6zSdib5vg9OlHuOQ)):
+> No update from the working group, expect that some progress will be made in the next few weeks. 
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Change scope of temporaries in match guards" [rust#88678](https://github.com/rust-lang/rust/pull/88678)
+  - opened by @**Matthew Jasper**
+  - assigned @**oli**, comments that [this fix is small and contained](https://rust-lang.zulipchat.com/#narrow/stream/269128-miri/topic/Cron.20Job.20Failure.202021-09-05/near/252170503)
+- :beta: "Add a regression test for #88649" [rust#88691](https://github.com/rust-lang/rust/pull/88691)
+  - opened by @**hyd-dev**
+  - PR closed [rust#88649](https://github.com/rust-lang/rust/issues/88649)
+  - @**simulacrum** beta-nominated along [rust#88678](https://github.com/rust-lang/rust/pull/88678) 
+- :beta: "Revert anon union parsing" [rust#88775](https://github.com/rust-lang/rust/pull/88775)
+  - opened by @**pnkfelix**, beta-nominated to have this fix for [rust#88583](https://github.com/rust-lang/rust/issues/88583) in edition 2021
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Perform type inference in range pattern" [rust#88090](https://github.com/rust-lang/rust/pull/88090)
+  - I-nominated, waiting for `T-lang` feedback
+
+### Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "Replace dominators algorithm with simple Lengauer-Tarjan" [rust#85013](https://github.com/rust-lang/rust/pull/85013) (last review activity: 3 months ago)
+  - last week @**pnkfelix** self-assigned 
+- "Add basic checks for well-formedness of `fn`/`fn_mut` lang items" [rust#86246](https://github.com/rust-lang/rust/pull/86246) (last review activity: 3 months ago)
+  - last week @**pnkfelix** self-assigned 
+- "check where-clause for explicit `Sized` before suggesting `?Sized`" [rust#86455](https://github.com/rust-lang/rust/pull/86455) (last review activity: 2 months ago)
+- "Use DefPathHash instead of HirId to break inlining cycles." [rust#85321](https://github.com/rust-lang/rust/pull/85321) (last review activity: 2 months ago)
+- "Account for incorrect `impl Foo<const N: ty> {}` syntax" [rust#85346](https://github.com/rust-lang/rust/pull/85346) (last review activity: 2 months ago)
+
+## Issues of Note
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [76 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [51 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 1 P-high, 2 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 0 P-high, 0 P-medium, 2 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 45 P-high, 83 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Type called union wreaks havoc since 1.54" [rust#88583](https://github.com/rust-lang/rust/issues/88583) 
+  - fixed by Felix's PR [rust#88775](https://github.com/rust-lang/rust/pull/88775)
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2021-09-14](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-09-14.md)
+
+Fairly busy week, with some large improvements on several benchmarks. Several larger rollups landed, in part due to recovery from a temporary CI outage, which has complicated some of the performance monitoring work. These should, however, now be resolved.
+
+Triage done by **@simulacrum**. 2 Regressions, 2 Improvements, 5 Mixed; 2 of them in rollups
+31 comparisons made in total
+
+#### Regressions
+
+Encode spans relative to the enclosing item [#84373](https://github.com/rust-lang/rust/issues/84373)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=8c2b6ea37d7719a0370bd404030eef9702c1752c&end=547d9374d26f203ab963b3ffe1ed36bd70f16633&stat=instructions:u) (up to 2.1% on `incr-unchanged` builds of `tuple-stress`)
+- Regressions are much smaller on "full" benchmarks (<0.5%). This support has
+  also landed gated behind a -Z flag, so the incremental cost is being paid
+  without the possible wins.
+
+Rollup of 7 pull requests [#88881](https://github.com/rust-lang/rust/issues/88881)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=9ef27bf7dc50a8b51435579b4f2e86f7ee3f7a94&end=c7dbe7a830100c70d59994fd940bf75bb6e39b39&stat=instructions:u) (up to 2.1% on `full` builds of `inflate`)
+- No clear cause. Investigation is partially ongoing, but may warrant an
+  assignee -- there's several possible candidates.
+
+#### Improvements
+
+- Rollup of 10 pull requests [#88857](https://github.com/rust-lang/rust/issues/88857)
+- Use FxHashSet instead of Vec for well formed tys [#88771](https://github.com/rust-lang/rust/issues/88771)
+
+#### Mixed
+
+Split rustc_mir [#80522](https://github.com/rust-lang/rust/issues/80522)
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=47ae8deb8a35030bdc4e502b03400800864cc264&end=97032a6dfacdd3548e4bff98c90a6b3875a14077&stat=instructions:u) (up to -2.0% on `full` builds of `deeply-nested-async`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=47ae8deb8a35030bdc4e502b03400800864cc264&end=97032a6dfacdd3548e4bff98c90a6b3875a14077&stat=instructions:u) (up to 0.8% on `full` builds of `await-call-tree`)
+- Mixed results. Noted in a comment that this also was a slight regression in
+  bootstrap time as measured by perf.rust-lang.org, which seems unfortunate and
+  may merit some investigation.
+
+Rollup of 15 pull requests [#88824](https://github.com/rust-lang/rust/issues/88824)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=b69fe57261086e70aea9d5b58819a1794bf7c121&end=22719efcc570b043f2e519d6025e5f36eab38fe2&stat=instructions:u) (up to -0.7% on `incr-patched: println` builds of `html5ever`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=b69fe57261086e70aea9d5b58819a1794bf7c121&end=22719efcc570b043f2e519d6025e5f36eab38fe2&stat=instructions:u) (up to 1.0% on `incr-unchanged` builds of `derive`)
+- Report seems a little bit close to noise, and is definitely mixed. No clear
+  cause, but also a fairly large rollup.
+
+Refactor query forcing [#78780](https://github.com/rust-lang/rust/issues/78780)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=43769af69e43d0fb9770f0a392671f000595df78&end=8c2b6ea37d7719a0370bd404030eef9702c1752c&stat=instructions:u) (up to -0.9% on `incr-full` builds of `unused-warnings`)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=43769af69e43d0fb9770f0a392671f000595df78&end=8c2b6ea37d7719a0370bd404030eef9702c1752c&stat=instructions:u) (up to 1.3% on `incr-patched: println` builds of `coercions`)
+- Solid improvement in rustc_query_impl compile times (8%). Overall looks like
+  results are overall more of an improvement than a regression.
+
+Update LLVM submodule [#88765](https://github.com/rust-lang/rust/issues/88765)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=0273e3bce7a0ce49e96a9662163e2380cb87e0be&end=0212c70b1df2aa542aef48d5fcde0af3734970c6&stat=instructions:u) (up to -0.7% on `full` builds of `ctfe-stress-4`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=0273e3bce7a0ce49e96a9662163e2380cb87e0be&end=0212c70b1df2aa542aef48d5fcde0af3734970c6&stat=instructions:u) (up to 0.7% on `incr-unchanged` builds of `ripgrep`)
+- Fairly mixed results, no clear picture either way.
+
+#### Untriaged Pull Requests
+
+- [#88881 Rollup of 7 pull requests](https://github.com/rust-lang/rust/pull/88881)
+- [#88824 Rollup of 15 pull requests](https://github.com/rust-lang/rust/pull/88824)
+- [#88765 Update LLVM submodule](https://github.com/rust-lang/rust/pull/88765)
+- [#88710 Use index newtyping for TyVid](https://github.com/rust-lang/rust/pull/88710)
+- [#88597 Move global analyses from lowering to resolution](https://github.com/rust-lang/rust/pull/88597)
+- [#88552 Stop allocating vtable entries for non-object-safe methods](https://github.com/rust-lang/rust/pull/88552)
+- [#88533 Concrete regions can show up in mir borrowck if the originated from there](https://github.com/rust-lang/rust/pull/88533)
+- [#88530 Shrink Session a bit](https://github.com/rust-lang/rust/pull/88530)
+- [#88435 Avoid invoking the hir_crate query to traverse the HIR](https://github.com/rust-lang/rust/pull/88435)
+- [#87815 encode `generics_of` for fields and ty params](https://github.com/rust-lang/rust/pull/87815)
+- [#87781 Remove box syntax from compiler and tools](https://github.com/rust-lang/rust/pull/87781)
+- [#87688 Introduce `let...else`](https://github.com/rust-lang/rust/pull/87688)
+- [#87640 Rollup of 9 pull requests](https://github.com/rust-lang/rust/pull/87640)
+- [#87587 Various refactorings of the TAIT infrastructure](https://github.com/rust-lang/rust/pull/87587)
+- [#87244 Better diagnostics with mismatched types due to implicit static lifetime](https://github.com/rust-lang/rust/pull/87244)
+- [#86898 Add fast path for Path::cmp that skips over long shared prefixes](https://github.com/rust-lang/rust/pull/86898)
+- [#86777 Include terminators in instance size estimate](https://github.com/rust-lang/rust/pull/86777)
+- [#86698 Move OnDiskCache to rustc_query_impl.](https://github.com/rust-lang/rust/pull/86698)
+- [#86588 Rollup of 8 pull requests](https://github.com/rust-lang/rust/pull/86588)
+- [#86034 Change entry point to 🛡️ against 💥 💥-payloads](https://github.com/rust-lang/rust/pull/86034)
+- [#85556 Warn about unreachable code following an expression with an uninhabited type](https://github.com/rust-lang/rust/pull/85556)
+- [#84560 Inline Iterator as IntoIterator.](https://github.com/rust-lang/rust/pull/84560)
+- [#84373 Encode spans relative to the enclosing item](https://github.com/rust-lang/rust/pull/84373)
+- [#83302 Get piece unchecked in `write`](https://github.com/rust-lang/rust/pull/83302)
+- [#80522 Split rustc_mir](https://github.com/rust-lang/rust/pull/80522)
+
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- "Perform type inference in range pattern" [rust#88090](https://github.com/rust-lang/rust/pull/88090) 
+  - nomination is for `T-lang`
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.
+
+## Oh, one more thing
+
+- @**apiraino** proposal to host T-compiler agenda meetings [on a git repo](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Hosting.20meetings.20agenda.20on.20a.20git.20repo)

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-09-23.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-09-23.md
@@ -1,0 +1,243 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-09-23
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- Tomorrow <time:2021-09-24T10:00:00-04:00>, [Compiler Team Planning meeting](https://forge.rust-lang.org/compiler/steering-meeting.html)
+- Tomorrow <time:2021-09-24T10:00:00-04:00>, Polonius Hackaton (is there a link for this topic?)
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "Tier 3 target proposal: x86_64-unknown-none (freestanding/bare-metal x86-64)" [compiler-team#462](https://github.com/rust-lang/compiler-team/issues/462)
+- Old MCPs (not seconded, take a look)
+  - "rustdoc is using rustc_ast_pretty, would it be possible to make it somewhat "stable"?" [compiler-team#403](https://github.com/rust-lang/compiler-team/issues/403) (last review activity: GH none, Zulip: +2months ago)
+  - "CI should exercise (subset of) tests under --stage 1" [compiler-team#439](https://github.com/rust-lang/compiler-team/issues/439) (last review activity: GH none, Zulip: about 1 month ago)
+  - "Accept `pc` in place of `unknown` and `unknown` in place of `pc` for `x86_64` and `i?86` targets" [compiler-team#441](https://github.com/rust-lang/compiler-team/issues/441) (last review activity: GH none, Zulip: about 3 months ago)
+  - "Non exhaustive reachable patterns lint" [compiler-team#445](https://github.com/rust-lang/compiler-team/issues/445) (last review activity: GH none, Zulip: about 2 months ago)
+  - "Add `TyKind::Const` and remove `GenericArgKind::Const`" [compiler-team#453](https://github.com/rust-lang/compiler-team/issues/453) (last review activity: GH none, Zulip: about 1 month ago)
+  - "prefer-dynamic=subset" [compiler-team#455](https://github.com/rust-lang/compiler-team/issues/455) (last review activity: GH none, Zulip: about 15 days ago)
+- Pending FCP requests (check your boxes!)
+  - "Write text output files to stdout if options like `-o -` or `--emit asm=-` are provided" [compiler-team#431](https://github.com/rust-lang/compiler-team/issues/431)
+- Things in FCP (make sure you're good with it)
+  - No FCP requests this time.
+- Accepted MCPs
+  - "Add `pie` relocation-model" [compiler-team#461](https://github.com/rust-lang/compiler-team/issues/461)
+- Finalized FCPs (disposition merge)
+  - No new finished FCP (disposition merge) this time.
+
+### WG checkins
+
+- @_WG-rls2.0_ by @**Lukas Wirth** ([previous checkin](https://hackmd.io/f45z2GqQTNW9QH0wO4lTEg?view)):
+
+> Steering issue covered by this checkin:
+>
+> - https://github.com/rust-analyzer/rust-analyzer/issues/9925
+>   This sprint has seen a lot of improvements and fixes for experimental attribute support bringing the feature closer to being enabled by default.
+>   We fixed a memory leak in our [syntax tree library](https://github.com/rust-analyzer/rowan/pull/112) as well as improving [compile times a bunch](https://github.com/rust-analyzer/rust-analyzer/pull/10069).
+>   Our parser has seen some cleanups and we started implementing IDE support for macros reusing spans for multiple output tokens.
+
+- @_WG-rfc-2229_ by @**nikomatsakis** and @**Matthew Jasper** ([previous checkin](https://hackmd.io/f45z2GqQTNW9QH0wO4lTEg?view)):
+  > This is shipping with Rust 2021, but there are some backports for a few bugs
+  > I have to prepare a patch today for one of those:
+  > https://github.com/rust-lang/rust/pull/89144
+  > So one thing is this code that helps the migration by skipping "insignificant destructors"
+  > and the other is an edge case in destructor ordering
+  > (if you capture all the fields of a struct, then we will drop them in the order of use, but we used to drop them in the order in which they appeared in the struct)
+  > (this is because the closure now has a separate variable for each field)
+  > (I'll probably add some sorting to preserve the old order "just because", but there is an interesting question of what guarantees (if any) we give around this sort of thing -- I am thinking "none")
+  > I guess that's a lang question but perhaps people here have an opinion :)
+
+## Backport nominations
+
+[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+
+- :beta: "Disable RemoveZsts in generators to avoid query cycles" [rust#88979](https://github.com/rust-lang/rust/pull/88979)
+  - fixes regression [rust#88972](https://github.com/rust-lang/rust/issues/88972) on stable-to-beta for 1.56
+- :beta: "Fix linting when trailing macro expands to a trailing semi" [rust#88996](https://github.com/rust-lang/rust/pull/88996)
+  - fixes regression [rust#87757](https://github.com/rust-lang/rust/issues/87757) on stable-to-beta for 1.56
+- No stable nominations for `T-compiler` this time.
+
+[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+
+- No beta nominations for `T-rustdoc` this time.
+- No stable nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+
+- "On macOS, make strip="symbols" not pass any options to strip" [rust#88137](https://github.com/rust-lang/rust/pull/88137)
+  - opened by @**Josh Triplett**
+  - Also `I-nominated`
+
+## Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+
+- "Distribute cg_clif as rustup component on the nightly channel" [rust#81746](https://github.com/rust-lang/rust/pull/81746) (last review activity: 7 months ago)
+- "Replace dominators algorithm with simple Lengauer-Tarjan" [rust#85013](https://github.com/rust-lang/rust/pull/85013) (last review activity: 3 months ago)
+- "Add basic checks for well-formedness of `fn`/`fn_mut` lang items" [rust#86246](https://github.com/rust-lang/rust/pull/86246) (last review activity: 3 months ago)
+- "Account for incorrect `impl Foo<const N: ty> {}` syntax" [rust#85346](https://github.com/rust-lang/rust/pull/85346) (last review activity: 2 months ago)
+- "Diagnostic tweaks" [rust#85102](https://github.com/rust-lang/rust/pull/85102) (last review activity: 2 months ago)
+- "Mir-Opt for copying enums with large discrepancies" [rust#85158](https://github.com/rust-lang/rust/pull/85158)
+- "Diverging tyvars" [rust#85558](https://github.com/rust-lang/rust/pull/85558)
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [80 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [54 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 5 P-high, 4 P-medium, 0 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 46 P-high, 83 P-medium, 10 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+
+- "regression: int_roundings conflicts with existing APIs" [rust#88971](https://github.com/rust-lang/rust/issues/88971)
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+
+- "`zvariant` fails to compile on latest nightly: size cannot be statically determined" [rust#89119](https://github.com/rust-lang/rust/issues/89119)
+  - @**Aaron Hill** opened PR [rust#89125](https://github.com/rust-lang/rust/pull/89125) (already merged in master)
+
+## Performance logs
+
+> [triage logs for 2021-09-21](https://github.com/rust-lang/rustc-perf/blob/master/triage/2021-09-21.md)
+
+A nice week: more improvements than regressions.
+
+Triage done by **@pnkfelix**.
+Revision range: [9f85cd6f2ab2769c16e89dcdddb3e11d9736b351..7743c9fadd64886d537966ba224b9c20e6014a59](https://perf.rust-lang.org/?start=9f85cd6f2ab2769c16e89dcdddb3e11d9736b351&end=7743c9fadd64886d537966ba224b9c20e6014a59&absolute=false&stat=instructions%3Au)
+
+2 Regressions, 4 Improvements, 8 Mixed; ??? of them in rollups
+44 comparisons made in total
+
+#### Regressions
+
+Point at argument instead of call for their obligations [#88719](https://github.com/rust-lang/rust/issues/88719)
+
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e4828d5b7f745a9e867a9b0cc7f080f287bcf55d&end=e36621057d9f497c822eb800934b5933c10510cf&stat=instructions:u) (up to 1.9% on `full` builds of `diesel`)
+
+Rollup of 10 pull requests [#89047](https://github.com/rust-lang/rust/issues/89047)
+
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e0c38af27cb5f6f961809601b717d6afc3b190ee&end=207d9558d00dd5cc438a6418ba96912d396e2155&stat=instructions:u) (up to 1.9% on `incr-unchanged` builds of `webrender-wrench`)
+
+#### Improvements
+
+- Avoid unnecessary formatting when trace log level is disabled [#88934](https://github.com/rust-lang/rust/issues/88934)
+- Fast reject for NeedsNonConstDrop [#88965](https://github.com/rust-lang/rust/issues/88965)
+- Avoid codegen for Result::into_ok in lang_start [#88988](https://github.com/rust-lang/rust/issues/88988)
+- Don't inline OnceCell initialization closures [#89031](https://github.com/rust-lang/rust/issues/89031)
+
+#### Mixed
+
+Const drop [#88558](https://github.com/rust-lang/rust/issues/88558)
+
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=c3c0f80d6081092faff801542dd82f0e2420152b&end=cdeba02ff71416e014f7130f75166890688be986&stat=instructions:u) (up to -1.7% on `full` builds of `externs`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=c3c0f80d6081092faff801542dd82f0e2420152b&end=cdeba02ff71416e014f7130f75166890688be986&stat=instructions:u) (up to 2.7% on `full` builds of `html5ever`)
+- Regression addressed by followup PRs [#88965](https://github.com/rust-lang/rust/issues/88965) (which has landed) and [#88963](https://github.com/rust-lang/rust/issues/88963) (which has not yet landed).
+
+Introduce a fast path that avoids the `debug_tuple` abstraction when deriving Debug for unit-like enum variants. [#88832](https://github.com/rust-lang/rust/issues/88832)
+
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=e36621057d9f497c822eb800934b5933c10510cf&end=78a46efff06558674b51c10d8d81758285746ab5&stat=instructions:u) (up to -4.5% on `full` builds of `stm32f4`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e36621057d9f497c822eb800934b5933c10510cf&end=78a46efff06558674b51c10d8d81758285746ab5&stat=instructions:u) (up to 1.3% on `incr-unchanged` builds of `ctfe-stress-4`)
+- Already [triaged by simulacrum](https://github.com/rust-lang/rust/pull/88832#issuecomment-919967148), noting that the instruction count regressions are justified because the same benchmarks do not regress in cycles.
+
+Remove concept of 'completion' from the projection cache [#88945](https://github.com/rust-lang/rust/issues/88945)
+
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=1c03f0d0ba4fee54b7aa458f4d3ad989d8bf7b34&end=e0c38af27cb5f6f961809601b717d6afc3b190ee&stat=instructions:u) (up to -0.3% on `incr-unchanged` builds of `helloworld`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=1c03f0d0ba4fee54b7aa458f4d3ad989d8bf7b34&end=e0c38af27cb5f6f961809601b717d6afc3b190ee&stat=instructions:u) (up to 0.8% on `full` builds of `wg-grammar`)
+- Wrote [comment](https://github.com/rust-lang/rust/pull/88945#issuecomment-924384164) noting that scope of regression was limited but might still be worth investigating, at least briefly.
+
+Simplify lazy DefPathHash decoding by using an on-disk hash table. [#82183](https://github.com/rust-lang/rust/issues/82183)
+
+- Very large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=23afad6e7f0ff17320411a274f3a3beb92452235&end=d6cd2c6c877110748296760aefddc21a0ea1d316&stat=instructions:u) (up to -7.7% on `incr-unchanged` builds of `deeply-nested`)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=23afad6e7f0ff17320411a274f3a3beb92452235&end=d6cd2c6c877110748296760aefddc21a0ea1d316&stat=instructions:u) (up to 1.9% on `incr-full` builds of `coercions`)
+- [Triaged](https://github.com/rust-lang/rust/pull/82183#issuecomment-924367405): the wins here massively outweigh the few slight losses.
+
+Gather module items after lowering. [#88703](https://github.com/rust-lang/rust/issues/88703)
+
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=697118d23eaa5d59940befabedcafbaceaf61a1c&end=7b5f95270f1ef7118ef4d3b47428054d23113ad5&stat=instructions:u) (up to -1.3% on `incr-unchanged` builds of `ctfe-stress-4`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=697118d23eaa5d59940befabedcafbaceaf61a1c&end=7b5f95270f1ef7118ef4d3b47428054d23113ad5&stat=instructions:u) (up to 0.8% on `incr-unchanged` builds of `tuple-stress`)
+  https://github.com/rust-lang/rust/issues/88703
+- Wrote [wishy-washy comment](https://github.com/rust-lang/rust/pull/88703#issuecomment-924388131) noting that this is indeed a mixed result and it may not be worth investigating, but didn't pull trigger on adding triaged label.
+
+Querify `FnAbi::of_{fn_ptr,instance}` as `fn_abi_of_{fn_ptr,instance}`. [#88575](https://github.com/rust-lang/rust/issues/88575)
+
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=5ecc8ad8462574354a55162a0c16b10eb95e3e70&end=91198820d7e697def79177c022b5e98b3d482ddc&stat=instructions:u) (up to -1.0% on `full` builds of `regression-31157`)
+- Large regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5ecc8ad8462574354a55162a0c16b10eb95e3e70&end=91198820d7e697def79177c022b5e98b3d482ddc&stat=instructions:u) (up to 1.4% on `incr-unchanged` builds of `regression-31157`)
+- Left [comment](https://github.com/rust-lang/rust/pull/88575#issuecomment-924402503) that didn't even bother to take time to be wishy-washy.
+
+Use <[T; N]>::map in Sharded instead of SmallVec and unsafe code [#89069](https://github.com/rust-lang/rust/issues/89069)
+
+- Small improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=db1fb85cff63ad5fffe435e17128f99f9e1d970c&end=3bb9eecf07630be796c587a4bba70c49ae6a1bae&stat=instructions:u) (up to -0.3% on `incr-unchanged` builds of `ucd`)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=db1fb85cff63ad5fffe435e17128f99f9e1d970c&end=3bb9eecf07630be796c587a4bba70c49ae6a1bae&stat=instructions:u) (up to 2.8% on `incr-full` builds of `ctfe-stress-4`)
+- Left [comment](https://github.com/rust-lang/rust/pull/89069#issuecomment-924405935); the estimated effect looks pretty different from when the PR was filed vs when it landed, but either way it is probably noise.
+
+Lower only one HIR owner at a time [#87234](https://github.com/rust-lang/rust/issues/87234)
+
+- Large improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=e7958d35ca2c898a223efe402481e0ecb854310a&end=49c0861ed0fa1d95186d88df0cd4310103e70957&stat=instructions:u) (up to -1.3% on `full` builds of `unused-warnings`)
+- Small regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=e7958d35ca2c898a223efe402481e0ecb854310a&end=49c0861ed0fa1d95186d88df0cd4310103e70957&stat=instructions:u) (up to 0.4% on `incr-unchanged` builds of `helloworld`)
+- [Triaged](https://github.com/rust-lang/rust/pull/87234#issuecomment-924407705)
+
+#### Untriaged Pull Requests
+
+- [#89125 Don't use projection cache or candidate cache in intercrate mode](https://github.com/rust-lang/rust/pull/89125)
+- [#89031 Don't inline OnceCell initialization closures](https://github.com/rust-lang/rust/pull/89031)
+- [#88945 Remove concept of 'completion' from the projection cache](https://github.com/rust-lang/rust/pull/88945)
+- [#88881 Rollup of 7 pull requests](https://github.com/rust-lang/rust/pull/88881)
+- [#88824 Rollup of 15 pull requests](https://github.com/rust-lang/rust/pull/88824)
+- [#88710 Use index newtyping for TyVid](https://github.com/rust-lang/rust/pull/88710)
+- [#88703 Gather module items after lowering.](https://github.com/rust-lang/rust/pull/88703)
+- [#88627 Do not preallocate HirIds](https://github.com/rust-lang/rust/pull/88627)
+- [#88597 Move global analyses from lowering to resolution](https://github.com/rust-lang/rust/pull/88597)
+- [#88575 Querify `FnAbi::of_{fn_ptr,instance}` as `fn_abi_of_{fn_ptr,instance}`.](https://github.com/rust-lang/rust/pull/88575)
+- [#88552 Stop allocating vtable entries for non-object-safe methods](https://github.com/rust-lang/rust/pull/88552)
+- [#88533 Concrete regions can show up in mir borrowck if the originated from there](https://github.com/rust-lang/rust/pull/88533)
+- [#88530 Shrink Session a bit](https://github.com/rust-lang/rust/pull/88530)
+- [#88435 Avoid invoking the hir_crate query to traverse the HIR](https://github.com/rust-lang/rust/pull/88435)
+- [#88308 Morph `layout_raw` query into `layout_of`.](https://github.com/rust-lang/rust/pull/88308)
+- [#87815 encode `generics_of` for fields and ty params](https://github.com/rust-lang/rust/pull/87815)
+- [#87781 Remove box syntax from compiler and tools](https://github.com/rust-lang/rust/pull/87781)
+- [#87688 Introduce `let...else`](https://github.com/rust-lang/rust/pull/87688)
+- [#87234 Lower only one HIR owner at a time](https://github.com/rust-lang/rust/pull/87234)
+- [#84373 Encode spans relative to the enclosing item](https://github.com/rust-lang/rust/pull/84373)
+- [#83698 Use undef for uninitialized bytes in constants](https://github.com/rust-lang/rust/pull/83698)
+- [#83302 Get piece unchecked in `write`](https://github.com/rust-lang/rust/pull/83302)
+- [#82183 Simplify lazy DefPathHash decoding by using an on-disk hash table.](https://github.com/rust-lang/rust/pull/82183)
+- [#80522 Split rustc_mir](https://github.com/rust-lang/rust/pull/80522)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- "On macOS, make strip="symbols" not pass any options to strip" [rust#88137](https://github.com/rust-lang/rust/pull/88137)
+  - opened by @**Josh Triplett**
+  - nominated for T-compiler by @**estebank**
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+
+- No nominated RFCs for `T-compiler` this time.

--- a/meetings-agenda/T-compiler Meeting Agenda 2021-09-30.md
+++ b/meetings-agenda/T-compiler Meeting Agenda 2021-09-30.md
@@ -1,0 +1,93 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda 2021-09-30
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- (TIP) add here non-recurrent scheduled meetings, [check the schedule calendar](https://calendar.google.com/calendar/htmlembed?src=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com)
+- (TIP) mention upcoming Rust stable releases, [check the release calendar](https://calendar.google.com/calendar/htmlembed?src=l1b1gkqvfbgunjs18nemq4c580%40group.calendar.google.com)
+- (TIP) remove this section if none are needed
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - No old proposals this time.
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - No FCP requests on compiler-team repo this time.
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - No new finished FCP (disposition merge) this time.
+
+### WG checkins
+
+@*WG-self-profile*  by @**mw**  and @**Wesley Wiser**  ([previous checkin](https://hackmd.io/VNIxtjGBT8Owfkb92Vzt6w#WG-checkins)):
+> Checkin text
+
+## Backport nominations
+
+[T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No backport nominations for `T-compiler` this time.
+
+[T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+## Most recent PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- No unreviewed PRs on `T-compiler` at this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [{{X}} T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [{{X}} of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [{{X}} T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [{{X}} of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [{{X}} P-critical, {{X}} P-high, {{X}} P-medium, {{X}} P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [{{X}} P-critical, {{X}} P-high, {{X}} P-medium, {{X}} P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [{{X}} P-critical, {{X}} P-high, {{X}} P-medium, {{X}} P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.

--- a/templates/T-compiler Meeting Agenda YYYY-MM-DD.md
+++ b/templates/T-compiler Meeting Agenda YYYY-MM-DD.md
@@ -1,0 +1,98 @@
+---
+tags: weekly, rustc
+---
+
+# T-compiler Meeting Agenda YYYY-MM-DD
+
+[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
+
+## Announcements
+
+- (TIP) add here non-recurrent scheduled meetings, [check the schedule calendar](https://calendar.google.com/calendar/htmlembed?src=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com)
+- (TIP) mention upcoming Rust stable releases, [check the release calendar](https://calendar.google.com/calendar/htmlembed?src=l1b1gkqvfbgunjs18nemq4c580%40group.calendar.google.com)
+- (TIP) remove this section if none are needed
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (not seconded, take a look)
+  - No old proposals this time.
+- Pending FCP requests (check your boxes!)
+  - No pending FCP requests this time.
+- Things in FCP (make sure you're good with it)
+  - No FCP requests on compiler-team repo this time.
+- Accepted MCPs
+  - No new accepted proposals this time.
+- Finalized FCPs (disposition merge)
+  - No new finished FCP (disposition merge) this time.
+
+### WG checkins
+
+(TIP) pick from [here](https://rust-lang.github.io/compiler-team/about/triage-meeting/#working-group-check-in)
+
+@*WG-X* checkin by @**person1** ([previous checkin](https://hackmd.io/team/rust-compiler-team?nav=overview)):
+> Checkin text
+
+@*WG-Y* checkin by @**person2** ([previous checkin](https://hackmd.io/team/rust-compiler-team?nav=overview)):
+> Checkin text
+
+## Backport nominations
+
+[T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- No backport nominations for `T-compiler` this time.
+
+[T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
+- No backport nominations for `T-rustdoc` this time.
+
+:back: / :shrug: / :hand:
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- No PRs waiting on `T-compiler` this time.
+
+## Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- No unreviewed PRs on `T-compiler` at this time.
+
+## Issues of Note
+
+### Short Summary
+
+- [{{X}} T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+)
+  - [{{X}} of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [{{X}} T-compiler P-high issues](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+)
+  - [{{X}} of those are unassigned](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [{{X}} P-critical, {{X}} P-high, {{X}} P-medium, {{X}} P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [{{X}} P-critical, {{X}} P-high, {{X}} P-medium, {{X}} P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [{{X}} P-critical, {{X}} P-high, {{X}} P-medium, {{X}} P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+- No `P-critical` issues for `T-rustdoc` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/tree/master/triage#triage-logs)
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated issues for `T-compiler` this time.
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
+- No nominated RFCs for `T-compiler` this time.


### PR DESCRIPTION
This PR stores on this git repository all T-compiler meetings agenda I could download [from HackMD](https://hackmd.io/team/rust-compiler-team?nav=overview) (the tool we currently use during T-compiler meetings). I have filtered out all the other documents.

Proposal in this [Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Hosting.20meetings.20agenda.20on.20a.20git.20repo)

Once we have an offline historical of the meetings, we can do new interesting things to make it faster to prepare the agenda (and also have a vendor-independant storage).

The consumption of the agenda during meetings will stay on HackMD, as always.

r? @pnkfelix @wesleywiser 

cc: @rust-lang/wg-prioritization 