### PR TITLE
Build URL safe links for meetings minutes

### DIFF
--- a/layouts/shortcodes/list-files.html
+++ b/layouts/shortcodes/list-files.html
@@ -2,7 +2,7 @@
 {{ range sort (readDir (.Get 0)) "Name" "desc" }}
   {{ if ne (substr .Name 0 1) "_" }}
     {{ $file_name := replace .Name (path.Ext .Name) "" }}
-    <li><a href="{{ $file_name }}">{{ $file_name }}</a></li>
+    <li><a href="{{ $file_name | urlize }}">{{ $file_name }}</a></li>
   {{ end }}
 {{ end }}
 </ul>


### PR DESCRIPTION
Follow-up to #463, solves [this comment](https://github.com/rust-lang/compiler-team/pull/463#issuecomment-926294531).

In order to have the T-compiler meetings listed with correct links, we need to static website builder to handle them correctly, Team compiler meeting notes are downloaded from HackMD in the form of files like: `T-compiler Meeting Agenda 2021-09-23.md` which will result in a 404 when handled by `hugo` for this website.

With this change, URLs with spaces will be translated to valid addresses
`/compiler-team/minutes/triage-meeting/T-compiler-Meeting-Agenda-2021-09-30/

This is needed if we want to have `hugo` handle seamlessy the team compiler notes downloaded from HackMD

In another PR I will move all team compiler meetings note to the correct place and have them appear on the website.

r? @wesleywiser 