### PR TITLE
remove invalid link to rust-lang/cargo-lockfile-sync

### DIFF
--- a/content/procedures/crates.md
+++ b/content/procedures/crates.md
@@ -172,4 +172,3 @@ This section contains the list of existing out-of-tree, compiler team-maintained
   - [`rust-lang/chalk`](https://github.com/rust-lang/chalk/)
   - [`rust-lang/polonius`](https://github.com/rust-lang/polonius/)
   - [`rust-lang/measureme`](https://github.com/rust-lang/measureme/)
-  - [`rust-lang/cargo-lockfile-sync`](https://github.com/rust-lang/cargo-lockfile-sync/)


### PR DESCRIPTION
Fixes #523 