### PR TITLE
Update compiler links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -48,8 +48,8 @@ are scheduled at a planning meeting that occurs every four weeks.
 
 [triage]: about/triage-meeting
 [steering]: about/steering-meeting
-[embed]: https://calendar.google.com/calendar/embed?src=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com
-[ics]: https://calendar.google.com/calendar/ical/6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com/public/basic.ics
+[embed]: https://calendar.google.com/calendar/embed?src=mfbugia4q2487tj9h08aimhd8e38dc8k%40import.calendar.google.com
+[ics]: https://rust-lang.github.io/calendar/compiler.ics
 [propose]: https://github.com/rust-lang/compiler-team/issues/new/choose
 
 ## Working Groups


### PR DESCRIPTION
Now using the new rust-lang/calendar version instead of Google Calendar