### PR TITLE
Add landing page text #732

### DIFF
--- a/content/procedures/_index.md
+++ b/content/procedures/_index.md
@@ -2,3 +2,6 @@
 title: Procedures
 type: docs
 ---
+# Procedures of the Compiler Team #
+
+Compiler team procedures are documented on the [Rust forge](https://forge.rust-lang.org/compiler/index.html).


### PR DESCRIPTION
The text is _copied_ from content/menu/index.md:17, so this is a bit of a problem currently. I'm also not sure how much sense that even makes, since the directory pages have vastly differing content: [About](content/about/_index.md) has just a heading line, but [Minutes](content/minutes/_index.md) also has nothing.