### PR TITLE
Make triagebot stop mentioning T-compiler-contributors in its MCP messages

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,7 +1,7 @@
 [major-change]
 second_label = "final-comment-period"
 meeting_label = "to-announce"
-open_extra_text = "cc @rust-lang/compiler @rust-lang/compiler-contributors"
+open_extra_text = "cc @rust-lang/compiler"
 # can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
 zulip_stream = 233931
 zulip_ping = "T-compiler"


### PR DESCRIPTION
CC https://github.com/rust-lang/compiler-team/issues/757

T-compiler-contributors is dead, long live T-compiler!