### PR TITLE
Remove the Comments section in the MCP template

### DIFF
--- a/.github/ISSUE_TEMPLATE/major_change.md
+++ b/.github/ISSUE_TEMPLATE/major_change.md
@@ -34,7 +34,3 @@ The main points of the [Major Change Process][MCP] are as follows:
 You can read [more about Major Change Proposals on forge][MCP].
 
 [MCP]: https://forge.rust-lang.org/compiler/mcp.html
-
-# Comments
-
-**This issue is not meant to be used for technical discussion. There is a Zulip stream for that. Use this issue to leave procedural comments, such as volunteering to review, indicating that you second the proposal (or third, etc), or raising a concern that you would like to be addressed.**


### PR DESCRIPTION
It is replaced by rustbot important message which does the same thing in a more visible and *hopefully* more effective manner, cf. https://github.com/rust-lang/triagebot/pull/1902

cc @apiraino *(as you suggested)*