### PR TITLE
Add t-compiler triage meetings notes 02/25

### DIFF
--- a/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-06.md
+++ b/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-06.md
@@ -1,0 +1,355 @@
+---
+tags: weekly, rustc
+type: docs
+note_id: AXGQgEeVTPCWvQb3yeYSrA
+---
+
+# T-compiler Meeting Agenda 2025-02-06
+
+## Announcements
+
+- FIY: a discussion on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Should.20CI.20break.20if.20rust-analyzer.20tests.20fail/near/498094558) about `bootstrap` running all tests of rust-analyzer. If anyone has opinions, please join the discussion.
+- Reminder: if you see a PR/issue that seems like there might be legal implications due to copyright/IP/etc, please let us know (or at least message @_**davidtwco** or @_**Wesley Wiser** so we can pass it along).
+
+### Other WG meetings
+
+- WG-async design meeting <time:2025-02-06T19:00:00+01:00>
+- Stable MIR Weekly Meeting <time:2025-02-07T17:00:00+01:00>
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (stale MCP might be closed as per [MCP procedure](https://forge.rust-lang.org/compiler/mcp.html#when-should-major-change-proposals-be-closed))
+  - None at this time
+- Old MCPs (not seconded, take a look)
+  - "Add hygiene attributes to compile expanded source code" [compiler-team#692](https://github.com/rust-lang/compiler-team/issues/692) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20option.20to.20compile.20expanded.20ASTs.20for.20h.E2.80.A6.20compiler-team.23692)) (last review activity: 4 months ago)
+  - "Add Hotpatch flag" [compiler-team#745](https://github.com/rust-lang/compiler-team/issues/745) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20Hotpatch.20flag.20compiler-team.23745)) (last review activity: 3 months ago)
+  - "Policy change around adding new unstable flags" [compiler-team#787](https://github.com/rust-lang/compiler-team/issues/787) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Policy.20change.20around.20adding.20new.20unstable.20.E2.80.A6.20compiler-team.23787)) (last review activity: 3 months ago)
+  - "Normalize FileCheck directives" [compiler-team#789](https://github.com/rust-lang/compiler-team/issues/789) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Normalize.20FileCheck.20directives.20compiler-team.23789)) (last review activity: 3 months ago)
+  - "Demote `i686-pc-windows-gnu`" [compiler-team#822](https://github.com/rust-lang/compiler-team/issues/822) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Demote.20.60i686-pc-windows-gnu.60.20compiler-team.23822)) (last review activity: about 41 days ago)
+  - "Rename "dylib" crate type to "rdylib" (keep old name but deprecate it), and maybe do the same for "staticlib" → "cstaticlib"" [compiler-team#825](https://github.com/rust-lang/compiler-team/issues/825) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Rename.20.22dylib.22.20create.20type.20to.20.22rdylib.22.20.28k.E2.80.A6.20compiler-team.23825)) (last review activity: about 27 days ago)
+  - "Add `target_abi = "[ilp]{2,3}[3264]{2}[fdq]?"` to all RV[3264]{2}I targets" [compiler-team#830](https://github.com/rust-lang/compiler-team/issues/830) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60target_abi.20.3D.20.22.5Bilp.5D.7B2.2C3.7D.5B3264.5D.7B2.7D.5Bfd.E2.80.A6.20compiler-team.23830)) (last review activity: about 6 days ago)
+  - "Add `--print=lint-levels` to retrieve lints levels" [compiler-team#833](https://github.com/rust-lang/compiler-team/issues/833) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60--print.3Dlint-levels.60.20to.20retrieve.20lin.E2.80.A6.20compiler-team.23833)) (last review activity: about 6 days ago)
+- Pending FCP requests (check your boxes!)
+  - "sanitizers: Stabilize AddressSanitizer and LeakSanitizer for the Tier 1 targets" [rust#123617](https://github.com/rust-lang/rust/pull/123617)
+  - "Warn about C-style octal literals" [rust#131309](https://github.com/rust-lang/rust/pull/131309)
+- Things in FCP (make sure you're good with it)
+  - "Create an avr-unknown-none target" [compiler-team#800](https://github.com/rust-lang/compiler-team/issues/800) ([Zulip](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Create.20an.20avr-unknown-none.20target.20compiler-team.23800))
+  - "Clean up operator representations" [compiler-team#831](https://github.com/rust-lang/compiler-team/issues/831) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Clean.20up.20operator.20representations.20compiler-team.23831))
+  - "Do not ignore uninhabited types for function-call ABI purposes." [compiler-team#832](https://github.com/rust-lang/compiler-team/issues/832) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Do.20not.20ignore.20uninhabited.20types.20for.20funct.E2.80.A6.20compiler-team.23832))
+- Accepted MCPs
+  - No new accepted proposals this time.
+- MCPs blocked on unresolved concerns
+  - "setup typos check in CI (for rust repo)" [compiler-team#817](https://github.com/rust-lang/compiler-team/issues/817) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/setup.20typos.20check.20in.20CI.20.28for.20rust.20repo.29.20compiler-team.23817))
+    - concern: [contributor friction](https://github.com/rust-lang/compiler-team/issues/817#issuecomment-2525266792)
+  - "Retire the mailing list and make all decisions on zulip" [compiler-team#649](https://github.com/rust-lang/compiler-team/issues/649) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Retire.20the.20mailing.20list.20and.20make.20all.20deci.E2.80.A6.20compiler-team.23649))
+    - concern: [automatic-sync](https://github.com/rust-lang/compiler-team/issues/649#issuecomment-1618902660)
+  - "Add `-C hint-mostly-unused` option" [compiler-team#829](https://github.com/rust-lang/compiler-team/issues/829) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60-C.20defer-codegen.60.20option.20compiler-team.23829)) (last review activity: about 9 days ago)
+    - concern: [prior-art-does-not-motivate-fast-stabilization](https://github.com/rust-lang/compiler-team/issues/829#issuecomment-2617441734)
+  - "Add `evex512` target feature for AVX10" [compiler-team#778](https://github.com/rust-lang/compiler-team/issues/778) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60evex512.60.20target.20feature.20for.20AVX10.20compiler-team.23778)) (last review activity: 2 months ago)
+    - concern: [design-around-naming-scheme](https://github.com/rust-lang/compiler-team/issues/778#issuecomment-2514307904)
+- Finalized FCPs (disposition merge)
+  - "Add `--print host-tuple` to print host target tuple" [rust#125579](https://github.com/rust-lang/rust/pull/125579)
+  - "make unsupported_calling_conventions a hard error" [rust#129935](https://github.com/rust-lang/rust/pull/129935)
+  - "Fix ICE when passing DefId-creating args to legacy_const_generics." [rust#130443](https://github.com/rust-lang/rust/pull/130443)
+  - "Stabilize WebAssembly `multivalue`, `reference-types`, and `tail-call` target features" [rust#131080](https://github.com/rust-lang/rust/pull/131080)
+  - "Lint on combining `#[no_mangle]` and `#[export_name]`" [rust#131558](https://github.com/rust-lang/rust/pull/131558)
+- Other teams finalized FCPs
+  - "Add lint against function pointer comparisons" [rust#118833](https://github.com/rust-lang/rust/pull/118833)
+  - "Fixup Windows verbatim paths when used with the `include!` macro" [rust#125205](https://github.com/rust-lang/rust/pull/125205)
+  - "Uplift `clippy::double_neg` lint as `double_negations`" [rust#126604](https://github.com/rust-lang/rust/pull/126604)
+  - "Allow dropping `dyn Trait` principal" [rust#126660](https://github.com/rust-lang/rust/pull/126660)
+  - "atomics: allow atomic and non-atomic reads to race" [rust#128778](https://github.com/rust-lang/rust/pull/128778)
+  - "Lint against getting pointers from immediately dropped temporaries" [rust#128985](https://github.com/rust-lang/rust/pull/128985)
+  - "Do not consider match/let/ref of place that evaluates to `!` to diverge, disallow coercions from them too" [rust#129392](https://github.com/rust-lang/rust/pull/129392)
+  - "Make deprecated_cfg_attr_crate_type_name a hard error" [rust#129670](https://github.com/rust-lang/rust/pull/129670)
+  - "Stabilize expr_2021 fragment specifier in all editions" [rust#129972](https://github.com/rust-lang/rust/pull/129972)
+  - "Check elaborated projections from dyn don't mention unconstrained late bound lifetimes" [rust#130367](https://github.com/rust-lang/rust/pull/130367)
+  - "Finish stabilization of `result_ffi_guarantees`" [rust#130628](https://github.com/rust-lang/rust/pull/130628)
+  - "Stabilize const `ptr::write*` and `mem::replace`" [rust#130954](https://github.com/rust-lang/rust/pull/130954)
+  - "Stabilize s390x inline assembly" [rust#131258](https://github.com/rust-lang/rust/pull/131258)
+  - "Stabilize Arm64EC inline assembly" [rust#131781](https://github.com/rust-lang/rust/pull/131781)
+  - "Always display first line of impl blocks even when collapsed" [rust#132155](https://github.com/rust-lang/rust/pull/132155)
+  - "rework winnowing to sensibly handle global where-bounds" [rust#132325](https://github.com/rust-lang/rust/pull/132325)
+  - "mark is_val_statically_known intrinsic as stably const-callable" [rust#132449](https://github.com/rust-lang/rust/pull/132449)
+  - "Fix ICE when multiple supertrait substitutions need assoc but only one is provided" [rust#133392](https://github.com/rust-lang/rust/pull/133392)
+  - "[rustdoc] Add sans-serif font setting" [rust#133636](https://github.com/rust-lang/rust/pull/133636)
+  - "Stabilize `asm_goto` feature gate" [rust#133870](https://github.com/rust-lang/rust/pull/133870)
+  - "Consider fields to be inhabited if they are unstable" [rust#133889](https://github.com/rust-lang/rust/pull/133889)
+  - "disallow `repr()` on invalid items" [rust#133925](https://github.com/rust-lang/rust/pull/133925)
+  - "Make the wasm_c_abi future compat warning a hard error" [rust#133951](https://github.com/rust-lang/rust/pull/133951)
+  - "Stabilize target_feature_11" [rust#134090](https://github.com/rust-lang/rust/pull/134090)
+  - "fully de-stabilize all custom inner attributes" [rust#134276](https://github.com/rust-lang/rust/pull/134276)
+  - "remove long-deprecated no-op attributes no_start and crate_id" [rust#134300](https://github.com/rust-lang/rust/pull/134300)
+  - "Stabilize `feature(trait_upcasting)`" [rust#134367](https://github.com/rust-lang/rust/pull/134367)
+  - "Make cenum_impl_drop_cast a hard error" [rust#135964](https://github.com/rust-lang/rust/pull/135964)
+
+## Backport nominations
+
+[T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Ensure that we don't try to access fields on a non-struct pattern type" [rust#135222](https://github.com/rust-lang/rust/pull/135222)
+  - Authored by estebank
+  - Fixes #135209 (was evaluated P-low) but @_**Michael Goulet (compiler-errors)** says they're hitting it on stage 0 compiler ([comment](https://github.com/rust-lang/rust/pull/135222#issuecomment-2634868365))
+<!--
+/poll Approve beta:  backport of #135222?
+approve
+decline
+don't know
+-->
+- :beta: "Add a couple of missing `ensure_sufficient_stacks`" [rust#136352](https://github.com/rust-lang/rust/pull/136352)
+  - Authored by @**lqd**
+  - companion fix for #135709 (esp. to fix a test on `aarch64-linux`) ([comment](https://github.com/rust-lang/rust/pull/136352#issuecomment-2628030251))
+  - slight perf. regression rubberstamped since this backport complments closing P-critical #135671
+<!--
+/poll Approve beta:  backport of #136352?
+approve
+decline
+don't know
+-->
+- No stable nominations for `T-compiler` this time.
+
+[T-types beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-types) / [T-types stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-types)
+- No beta nominations for `T-types` this time.
+- No stable nominations for `T-types` this time.
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "typeck: taint if errors found during writeback" [rust#113125](https://github.com/rust-lang/rust/pull/113125)
+  - last [comment](https://github.com/rust-lang/rust/pull/113125#issuecomment-2429093023) from Oct 2024
+  - Was meant to fix #112824 (already closed) and #112630 (P-low). Do we want to keep it open?
+  - cc @**davidtwco** for maybe more context, probably not a big concern
+- [Issues in progress or waiting on other teams](https://hackmd.io/XYr1BrOWSiqCrl8RCWXRaQ)
+
+## Issues of Note
+
+### Short Summary
+
+- [3 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [58 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [36 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [1 P-critical, 0 P-high, 0 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 0 P-high, 1 P-medium, 1 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 34 P-high, 100 P-medium, 20 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "regression: cannot borrow ... as immutable because it is also borrowed as mutable" [rust#135671](https://github.com/rust-lang/rust/issues/135671)
+  - Discussed [last week](https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202025-01-30/near/496801412)
+  - Should be fixed by #135709 + #136352
+- "invalid opcode regression in `x86_64-unknown-linux-musl` release builds while compiling code using `generic-array`" [rust#135997](https://github.com/rust-lang/rust/issues/135997)
+  - regressed in #133324 (not in beta, though)
+  - Should be closed by #136450, now r+'ed (thanks @**Michael Goulet (compiler-errors)** and @**Ben Kimock (Saethlin)** )
+  - btw about #136450: if anyone knows GVN better can have a look either ([comment](https://github.com/rust-lang/rust/pull/136450#issuecomment-2637853202))
+- "Nightly regressed igvm crate and now emits SIGILL at opt-level higher than 1" [rust#136361](https://github.com/rust-lang/rust/issues/136361)
+  - same as #135997
+
+[T-types](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-types)
+- None
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core+)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2025-02-04](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025-02-04.md)
+
+A very quiet week with performance of primary benchmarks showing no change over all.
+
+Triage done by **@rylev**.
+Revision range: [f7538506..01e4f19c](https://perf.rust-lang.org/?start=f753850659bdf5788332525f3fe395685929c682&end=01e4f19cc8027925ffe0885a86388b700e46bfab&absolute=false&stat=instructions%3Au)
+
+**Summary**:
+
+| (instructions:u)         | mean  | range           | count |
+|:------------------------:|:-----:|:---------------:|:-----:|
+| Regressions (primary)    | 0.3%  | [0.2%, 0.6%]    | 32    |
+| Regressions (secondary)  | 0.5%  | [0.1%, 1.1%]    | 65    |
+| Improvements (primary)   | -0.5% | [-1.0%, -0.2%]  | 17    |
+| Improvements (secondary) | -3.1% | [-10.3%, -0.2%] | 20    |
+| All  (primary)           | 0.0%  | [-1.0%, 0.6%]   | 49    |
+
+
+5 Regressions, 2 Improvements, 5 Mixed; 6 of them in rollups
+49 artifact comparisons made in total
+
+#### Regressions
+
+Rollup of 10 pull requests [#136135](https://github.com/rust-lang/rust/pull/136135) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=0cffe5cb95e36d45a3e61f7b1f5a9b21eddd77b4&end=ebcf860e7345e3387b4c6961338c77424b43cbd5&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.3% | [0.2%, 0.3%] | 2     |
+| Regressions (secondary)  | 0.2% | [0.2%, 0.3%] | 9     |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | 0.3% | [0.2%, 0.3%] | 2     |
+
+
+Rollup of 9 pull requests [#136227](https://github.com/rust-lang/rust/pull/136227) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=61cc3e51f8bf5c12595a4d61a5ee9de812974b43&end=a1d7676d6a8c6ff13f9165e98cc25eeec66cb592&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.2% | [0.2%, 0.2%] | 1     |
+| Regressions (secondary)  | 0.2% | [0.2%, 0.2%] | 6     |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | 0.2% | [0.2%, 0.2%] | 1     |
+- Addressed by https://github.com/rust-lang/rust/pull/136253
+
+
+Merge `PatKind::Path` into `PatKind::Expr` [#134248](https://github.com/rust-lang/rust/pull/134248) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=0cc4f4f7b81f88df6bdd54b41d4a0b1703fd014d&end=ae5de6c759cd337ecdb2de4e94f47eaafb5d4606&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.3% | [0.2%, 0.4%] | 8     |
+| Regressions (secondary)  | 0.3% | [0.1%, 0.5%] | 9     |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | 0.3% | [0.2%, 0.4%] | 8     |
+- https://github.com/rust-lang/rust/pull/134248#issuecomment-2610453075
+
+
+Insert null checks for pointer dereferences when debug assertions are enabled [#134424](https://github.com/rust-lang/rust/pull/134424) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=7f36543a48e52912ac6664a70c0a5b9d86509eaf&end=aa4cfd0809064503c69795e8e83ad067ad9e11a1&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.3% | [0.2%, 0.5%] | 7     |
+| Regressions (secondary)  | 0.3% | [0.2%, 0.5%] | 5     |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | 0.3% | [0.2%, 0.5%] | 7     |
+- https://github.com/rust-lang/rust/pull/134424#issuecomment-2628695885
+
+
+Add a couple of missing `ensure_sufficient_stacks` [#136352](https://github.com/rust-lang/rust/pull/136352) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=a5db378dc14a40dd1580c27fb8362156446382c3&end=f2c4ccd852f68fb36dedc033239cb7c0fb1921ef&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | -    | -            | 0     |
+| Regressions (secondary)  | 0.2% | [0.2%, 0.3%] | 12    |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | -    | -            | 0     |
+- https://github.com/rust-lang/rust/pull/136352#issuecomment-2633158239
+
+#### Improvements
+
+Apply LTO config to rustdoc [#135832](https://github.com/rust-lang/rust/pull/135832) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=fdd1a3b02687817cea41f6bacae3d5fbed2b2cd0&end=77a455303bf08da8eef6236b2b4422a77cd25c42&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -0.3% | [-0.6%, -0.2%] | 9     |
+| Improvements (secondary) | -0.6% | [-1.4%, -0.2%] | 4     |
+| All  (primary)                 | -0.3% | [-0.6%, -0.2%] | 9     |
+
+
+fix autodiff compile time regression [#136413](https://github.com/rust-lang/rust/pull/136413) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=7daf4cf911c30e48c78f5e155c029397fdd82392&end=a5db378dc14a40dd1580c27fb8362156446382c3&stat=instructions:u)
+
+| (instructions:u)                   | mean   | range            | count |
+|:----------------------------------:|:------:|:----------------:|:-----:|
+| Regressions (primary)    | -      | -                | 0     |
+| Regressions (secondary)  | -      | -                | 0     |
+| Improvements (primary)   | -30.3% | [-30.6%, -29.7%] | 4     |
+| Improvements (secondary) | -30.1% | [-32.0%, -28.2%] | 2     |
+| All  (primary)                 | -30.3% | [-30.6%, -29.7%] | 4     |
+
+
+#### Mixed
+
+Rollup of 8 pull requests [#136185](https://github.com/rust-lang/rust/pull/136185) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=aa6f5ab18e67cb815f73e0d53d217bc54b0da924&end=fdd1a3b02687817cea41f6bacae3d5fbed2b2cd0&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | 0.7%  | [0.2%, 1.6%]   | 3     |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.5% | [-0.8%, -0.4%] | 6     |
+| All  (primary)                 | -     | -              | 0     |
+* https://github.com/rust-lang/rust/pull/136185#issuecomment-2635291385
+
+
+Revert #135914: Remove usages of `QueryNormalizer` in the compiler [#136011](https://github.com/rust-lang/rust/pull/136011) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=aeba3c60f506218396883cb57812de2f3e067112&end=122fb29eb639aae852b9dcba0fd7aefc691be118&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range           | count |
+|:----------------------------------:|:-----:|:---------------:|:-----:|
+| Regressions (primary)    | -     | -               | 0     |
+| Regressions (secondary)  | 0.3%  | [0.2%, 0.3%]    | 16    |
+| Improvements (primary)   | -0.4% | [-1.1%, -0.2%]  | 24    |
+| Improvements (secondary) | -5.9% | [-10.4%, -0.9%] | 10    |
+| All  (primary)                 | -0.4% | [-1.1%, -0.2%]  | 24    |
+- https://github.com/rust-lang/rust/pull/136011#issuecomment-2635292874
+
+
+Rollup of 9 pull requests [#136318](https://github.com/rust-lang/rust/pull/136318) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=a730edcd67c7cb29d4458e170d4eb290387c27c3&end=6c1d960d88dd3755548b3818630acb63fa98187e&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.3%  | [0.1%, 0.4%]   | 8     |
+| Regressions (secondary)  | 0.2%  | [0.2%, 0.2%]   | 1     |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.1% | [-0.1%, -0.1%] | 2     |
+| All  (primary)                 | 0.3%  | [0.1%, 0.4%]   | 8     |
+- It appears that #136180 is the culprit for this regression. I'm not sure it's worth addressing though.
+
+
+Rollup of 9 pull requests [#136332](https://github.com/rust-lang/rust/pull/136332) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=25a16572a36321deae83546b63f5595d75361179&end=7f36543a48e52912ac6664a70c0a5b9d86509eaf&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 43.3% | [42.1%, 44.0%] | 4     |
+| Regressions (secondary)  | 42.8% | [39.0%, 46.6%] | 2     |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.3% | [-0.3%, -0.2%] | 4     |
+| All  (primary)                 | 43.3% | [42.1%, 44.0%] | 4     |
+- Fixed by https://github.com/rust-lang/rust/pull/136413
+
+
+Rollup of 6 pull requests [#136389](https://github.com/rust-lang/rust/pull/136389) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=e08cd3cf05e5bfa3323cc21ea8f81f4a15a2f969&end=8239a37f9c0951a037cfc51763ea52a20e71e6bd&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.1%  | [0.1%, 0.1%]   | 1     |
+| Regressions (secondary)  | 0.4%  | [0.3%, 0.5%]   | 2     |
+| Improvements (primary)   | -0.3% | [-0.3%, -0.3%] | 1     |
+| Improvements (secondary) | -0.2% | [-0.3%, -0.1%] | 2     |
+| All  (primary)                 | -0.1% | [-0.3%, 0.1%]  | 2     |
+- Perf is a wash so I don't think it's worth investigating.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- "Our x86-32 target names are inconsistent" [rust#136495](https://github.com/rust-lang/rust/issues/136495)
+  - ([Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/x86-32.20target.20names/near/497467753)) @**RalfJ** would like the T-compiler attention on a number of x86 tier 3 compile target, which naming is inconsistent (or inaccurate)
+  - This PR is to gather feedbacks and opinions
+- "Pattern Migration 2024: try to suggest eliding redundant binding modifiers" [rust#136577](https://github.com/rust-lang/rust/pull/136577)
+  - @**Nadrieril** mentioned he was oriented to ask for a backport ([Zulip discussion](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Backporting.20disgnostic.20changes.3F/near/497933188))
+  - Context: the edition migration lint for match ergonomics is subpar, see https://github.com/rust-lang/rust/issues/136047 and https://github.com/rust-lang/rust/issues/136456. Given that it will likely affect many users and the details are nonobvious, it felt important (to me Nadri) to have that fix for the stable realease of the edition
+  - it's not the smallest PR; a smaller PR could maybe be done but I (Nadri) don't have the bandwidth. the current PR is almost 100% infallible span/label manipulations so hopefully that's not too risky to merge
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- No I-compiler-nominated RFCs this time.
+
+### Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "add error message for c# style named arguments" [rust#118733](https://github.com/rust-lang/rust/pull/118733) (last review activity: 13 months ago)
+  - cc: @**Esteban Küber**
+- "Add diagnostic for stack allocations of 1 GB or more" [rust#119798](https://github.com/rust-lang/rust/pull/119798) (last review activity: 13 months ago)
+  -  cc @**cjgillot**
+- "Improve parse item fallback" [rust#125388](https://github.com/rust-lang/rust/pull/125388) (last review activity: 8 months ago)
+  - cc: @**Esteban Küber**
+- "Silence errors in expressions caused by bare traits in paths in 2021 edition" [rust#125784](https://github.com/rust-lang/rust/pull/125784) (last review activity: 8 months ago)
+  - cc: @**Esteban Küber** for a rebase then to @**León Orell Liehr (fmease)** for a review
+
+Next meetings' agenda draft: [hackmd link](https://hackmd.io/636Uj8fYQHevhHgCemhndQ)

--- a/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-13.md
+++ b/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-13.md
@@ -1,0 +1,343 @@
+---
+tags: weekly, rustc
+type: docs
+note_id: 636Uj8fYQHevhHgCemhndQ
+---
+
+# T-compiler Meeting Agenda 2025-02-13
+
+## Announcements
+
+- Next week release of stable 1.85 [check the schedule calendar](https://github.com/rust-lang/calendar)
+- Reminder: if you see a PR/issue that seems like there might be legal implications due to copyright/IP/etc, please let us know (or at least message @_**davidtwco** or @_**Wesley Wiser** so we can pass it along).
+
+### Other WG meetings
+
+- WG-async design meeting <time:2025-02-13T19:00:00+01:00>
+- Stable MIR Weekly Meeting <time:2025-02-14T17:00:00+01:00>
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - No new proposals this time.
+- Old MCPs (stale MCP might be closed as per [MCP procedure](https://forge.rust-lang.org/compiler/mcp.html#when-should-major-change-proposals-be-closed))
+  - None at this time
+- Old MCPs (not seconded, take a look)
+  - "Add hygiene attributes to compile expanded source code" [compiler-team#692](https://github.com/rust-lang/compiler-team/issues/692) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20option.20to.20compile.20expanded.20ASTs.20for.20h.E2.80.A6.20compiler-team.23692)) (last review activity: 4 months ago)
+  - "Add Hotpatch flag" [compiler-team#745](https://github.com/rust-lang/compiler-team/issues/745) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20Hotpatch.20flag.20compiler-team.23745)) (last review activity: 4 months ago)
+  - "Policy change around adding new unstable flags" [compiler-team#787](https://github.com/rust-lang/compiler-team/issues/787) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Policy.20change.20around.20adding.20new.20unstable.20.E2.80.A6.20compiler-team.23787)) (last review activity: 3 months ago)
+  - "Normalize FileCheck directives" [compiler-team#789](https://github.com/rust-lang/compiler-team/issues/789) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Normalize.20FileCheck.20directives.20compiler-team.23789)) (last review activity: 3 months ago)
+  - "Rename "dylib" crate type to "rdylib" (keep old name but deprecate it), and maybe do the same for "staticlib" → "cstaticlib"" [compiler-team#825](https://github.com/rust-lang/compiler-team/issues/825) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Rename.20.22dylib.22.20create.20type.20to.20.22rdylib.22.20.28k.E2.80.A6.20compiler-team.23825)) (last review activity: about 33 days ago)
+  - "Add `target_abi = "[ilp]{2,3}[3264]{2}[fdq]?"` to all RV[3264]{2}I targets" [compiler-team#830](https://github.com/rust-lang/compiler-team/issues/830) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60target_abi.20.3D.20.22.5Bilp.5D.7B2.2C3.7D.5B3264.5D.7B2.7D.5Bfd.E2.80.A6.20compiler-team.23830)) (last review activity: about 12 days ago)
+  - "Add `--print=lint-levels` to retrieve lints levels" [compiler-team#833](https://github.com/rust-lang/compiler-team/issues/833) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60--print.3Dlint-levels.60.20to.20retrieve.20lin.E2.80.A6.20compiler-team.23833)) (last review activity: about 12 days ago)
+- Pending FCP requests (check your boxes!)
+  - "sanitizers: Stabilize AddressSanitizer and LeakSanitizer for the Tier 1 targets" [rust#123617](https://github.com/rust-lang/rust/pull/123617)
+  - "Warn about C-style octal literals" [rust#131309](https://github.com/rust-lang/rust/pull/131309)
+- Things in FCP (make sure you're good with it)
+  - "Create an avr-unknown-none target" [compiler-team#800](https://github.com/rust-lang/compiler-team/issues/800) ([Zulip](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Create.20an.20avr-unknown-none.20target.20compiler-team.23800))
+  - "Clean up operator representations" [compiler-team#831](https://github.com/rust-lang/compiler-team/issues/831) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Clean.20up.20operator.20representations.20compiler-team.23831))
+  - "Do not ignore uninhabited types for function-call ABI purposes." [compiler-team#832](https://github.com/rust-lang/compiler-team/issues/832) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Do.20not.20ignore.20uninhabited.20types.20for.20funct.E2.80.A6.20compiler-team.23832))
+  - "Give integer literals a sign instead of relying on negation expressions" [compiler-team#835](https://github.com/rust-lang/compiler-team/issues/835) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Give.20integer.20literals.20a.20sign.20instead.20of.20r.E2.80.A6.20compiler-team.23835))
+- Accepted MCPs
+  - No new accepted proposals this time.
+- MCPs blocked on unresolved concerns
+  - "setup typos check in CI (for rust repo)" [compiler-team#817](https://github.com/rust-lang/compiler-team/issues/817) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/setup.20typos.20check.20in.20CI.20.28for.20rust.20repo.29.20compiler-team.23817))
+    - concern: [contributor friction](https://github.com/rust-lang/compiler-team/issues/817#issuecomment-2525266792)
+  - "Retire the mailing list and make all decisions on zulip" [compiler-team#649](https://github.com/rust-lang/compiler-team/issues/649) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Retire.20the.20mailing.20list.20and.20make.20all.20deci.E2.80.A6.20compiler-team.23649))
+    - concern: [automatic-sync](https://github.com/rust-lang/compiler-team/issues/649#issuecomment-1618902660)
+  - "Add `-C hint-mostly-unused` option" [compiler-team#829](https://github.com/rust-lang/compiler-team/issues/829) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60-C.20defer-codegen.60.20option.20compiler-team.23829)) (last review activity: about 15 days ago)
+    - concern: [prior-art-does-not-motivate-fast-stabilization](https://github.com/rust-lang/compiler-team/issues/829#issuecomment-2617441734)
+  - "Add `evex512` target feature for AVX10" [compiler-team#778](https://github.com/rust-lang/compiler-team/issues/778) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60evex512.60.20target.20feature.20for.20AVX10.20compiler-team.23778)) (last review activity: 2 months ago)
+    - concern: [design-around-naming-scheme](https://github.com/rust-lang/compiler-team/issues/778#issuecomment-2514307904)
+- Finalized FCPs (disposition merge)
+  - "Add `--print host-tuple` to print host target tuple" [rust#125579](https://github.com/rust-lang/rust/pull/125579)
+  - "make unsupported_calling_conventions a hard error" [rust#129935](https://github.com/rust-lang/rust/pull/129935)
+  - "Fix ICE when passing DefId-creating args to legacy_const_generics." [rust#130443](https://github.com/rust-lang/rust/pull/130443)
+  - "Stabilize WebAssembly `multivalue`, `reference-types`, and `tail-call` target features" [rust#131080](https://github.com/rust-lang/rust/pull/131080)
+  - "Lint on combining `#[no_mangle]` and `#[export_name]`" [rust#131558](https://github.com/rust-lang/rust/pull/131558)
+- Other teams finalized FCPs
+  - "Add lint against function pointer comparisons" [rust#118833](https://github.com/rust-lang/rust/pull/118833)
+  - "Fixup Windows verbatim paths when used with the `include!` macro" [rust#125205](https://github.com/rust-lang/rust/pull/125205)
+  - "Uplift `clippy::double_neg` lint as `double_negations`" [rust#126604](https://github.com/rust-lang/rust/pull/126604)
+  - "Allow dropping `dyn Trait` principal" [rust#126660](https://github.com/rust-lang/rust/pull/126660)
+  - "atomics: allow atomic and non-atomic reads to race" [rust#128778](https://github.com/rust-lang/rust/pull/128778)
+  - "Lint against getting pointers from immediately dropped temporaries" [rust#128985](https://github.com/rust-lang/rust/pull/128985)
+  - "Do not consider match/let/ref of place that evaluates to `!` to diverge, disallow coercions from them too" [rust#129392](https://github.com/rust-lang/rust/pull/129392)
+  - "Make deprecated_cfg_attr_crate_type_name a hard error" [rust#129670](https://github.com/rust-lang/rust/pull/129670)
+  - "Stabilize expr_2021 fragment specifier in all editions" [rust#129972](https://github.com/rust-lang/rust/pull/129972)
+  - "Check elaborated projections from dyn don't mention unconstrained late bound lifetimes" [rust#130367](https://github.com/rust-lang/rust/pull/130367)
+  - "Finish stabilization of `result_ffi_guarantees`" [rust#130628](https://github.com/rust-lang/rust/pull/130628)
+  - "Stabilize const `ptr::write*` and `mem::replace`" [rust#130954](https://github.com/rust-lang/rust/pull/130954)
+  - "Stabilize s390x inline assembly" [rust#131258](https://github.com/rust-lang/rust/pull/131258)
+  - "Stabilize Arm64EC inline assembly" [rust#131781](https://github.com/rust-lang/rust/pull/131781)
+  - "Always display first line of impl blocks even when collapsed" [rust#132155](https://github.com/rust-lang/rust/pull/132155)
+  - "rework winnowing to sensibly handle global where-bounds" [rust#132325](https://github.com/rust-lang/rust/pull/132325)
+  - "mark is_val_statically_known intrinsic as stably const-callable" [rust#132449](https://github.com/rust-lang/rust/pull/132449)
+  - "Fix ICE when multiple supertrait substitutions need assoc but only one is provided" [rust#133392](https://github.com/rust-lang/rust/pull/133392)
+  - "[rustdoc] Add sans-serif font setting" [rust#133636](https://github.com/rust-lang/rust/pull/133636)
+  - "Stabilize `asm_goto` feature gate" [rust#133870](https://github.com/rust-lang/rust/pull/133870)
+  - "Consider fields to be inhabited if they are unstable" [rust#133889](https://github.com/rust-lang/rust/pull/133889)
+  - "disallow `repr()` on invalid items" [rust#133925](https://github.com/rust-lang/rust/pull/133925)
+  - "Make the wasm_c_abi future compat warning a hard error" [rust#133951](https://github.com/rust-lang/rust/pull/133951)
+  - "fully de-stabilize all custom inner attributes" [rust#134276](https://github.com/rust-lang/rust/pull/134276)
+  - "remove long-deprecated no-op attributes no_start and crate_id" [rust#134300](https://github.com/rust-lang/rust/pull/134300)
+  - "Stabilize `feature(trait_upcasting)`" [rust#134367](https://github.com/rust-lang/rust/pull/134367)
+  - "Reject `?Trait` bounds in various places where we unconditionally warned since 1.0" [rust#135841](https://github.com/rust-lang/rust/pull/135841)
+  - "Make cenum_impl_drop_cast a hard error" [rust#135964](https://github.com/rust-lang/rust/pull/135964)
+
+## Backport nominations
+
+[T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Pattern Migration 2024: try to suggest eliding redundant binding modifiers" [rust#136577](https://github.com/rust-lang/rust/pull/136577)
+  - Authored by dianne, Fixes a series of lints in Edition 2024 (#136047)
+  - Some data about the new lints at [comment](https://github.com/rust-lang/rust/pull/136577#issuecomment-2649496209)
+  - Discussed last week ([on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Backporting.20disgnostic.20changes.3F/near/497933188)), the general vibe was "meh" due to being large changes with the new stable release at the door
+  - T-release say they can handle but it's a lot of work ([comment](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Backporting.20disgnostic.20changes.3F/near/497933188)) and @_**Jubilee** pointed that if something behaves funny we should be there to fix quick
+  - (unsure if a lot changed - in positive or negative - since last week)
+<!--
+/poll Approve beta:  backport of #136577?
+approve
+decline
+don't know
+-->
+- :beta: "chore: update rustc-hash 2.1.0 to 2.1.1" [rust#136605](https://github.com/rust-lang/rust/pull/136605)
+  - Authored by lsunsi (issue reporter a while ago)
+  - stems from issue #135477 (a large compile time regression for some projects)
+  - Full discussion on [rust-lang/rustc-hash#55](https://github.com/rust-lang/rustc-hash/pull/55)
+  - our perf. tests seem to be mostly neutral
+<!--
+/poll Approve beta:  backport of #136605?
+approve
+decline
+don't know
+-->
+- :beta: "fix ensure_monomorphic_enough" [rust#136839](https://github.com/rust-lang/rust/pull/136839)
+  - Authored by lukas-code, nominated by @**Michael Goulet (compiler-errors)** since a simple backport and recommended before stable 1.85 starts baking (tomorrow, IIRC)
+  - Fixes MIR opts misbehaving, since When polymorphization got removed, more context in opening comment (doesn't seem to have a specific filed regression attached)
+<!--
+/poll Approve beta:  backport of #136839?
+approve
+decline
+don't know
+-->
+- :beta: "Revert "Stabilize `extended_varargs_abi_support`"" [rust#136897](https://github.com/rust-lang/rust/pull/136897)
+  - Authored by workingjubilee
+  - (**UPDATE**: already accepted by T-release, so FYI)
+  - Also nominated for discussion
+  - TL;DR we apparently stabilized and this is broken. Revert before next stable release (next week).
+- No stable nominations for `T-compiler` this time.
+
+[T-types beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-types) / [T-types stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-types)
+- No beta nominations for `T-types` this time.
+- No stable nominations for `T-types` this time.
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+ [Issues in progress or waiting on other teams](https://hackmd.io/XYr1BrOWSiqCrl8RCWXRaQ)
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [59 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [38 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 0 P-high, 0 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 34 P-high, 100 P-medium, 20 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-types](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-types)
+- No `P-critical` issues for `T-types` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core+)
+- "`rustc.exe -vV` didn't exit successfully (exit code: 0xc000007b) on `i686-pc-windows-gnu`" [rust#136795](https://github.com/rust-lang/rust/issues/136795)
+  - Handled in #136815 (thanks @_**Chris Denton**) but in the future this compile target should be demoted to tier 2 (rfcs#3771)
+
+## Performance logs
+
+> [triage logs](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025-02-10.md)
+
+A relatively neutral week, with lots of real changes but most small in
+magnitude. Most significant change is rustdoc's move of JS/CSS minification to
+build time which cut doc generation times on most benchmarks fairly
+significantly.
+
+Triage done by **@simulacrum**.
+Revision range: [01e4f19c..c03c38d5](https://perf.rust-lang.org/?start=01e4f19cc8027925ffe0885a86388b700e46bfab&end=c03c38d5c2368cd2aa0e056dba060b94fc747f4e&absolute=false&stat=instructions%3Au)
+
+**Summary**:
+
+| (instructions:u)         | mean  | range          | count |
+|:------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.5%  | [0.1%, 1.2%]   | 100   |
+| Regressions (secondary)  | 0.6%  | [0.1%, 7.3%]   | 93    |
+| Improvements (primary)   | -1.8% | [-5.7%, -0.2%] | 22    |
+| Improvements (secondary) | -2.5% | [-5.7%, -0.2%] | 36    |
+| All  (primary)           | 0.0%  | [-5.7%, 1.2%]  | 122   |
+
+
+3 Regressions, 5 Improvements, 1 Mixed; 2 of them in rollups
+32 artifact comparisons made in total
+
+#### Regressions
+
+Upgrade elsa to the newest version. [#136094](https://github.com/rust-lang/rust/pull/136094) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=07179d549659e119a0e4175629b839337c6a8c02&end=820bfffc25fee9866aa8176529091e04b8824f09&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.2%  | [0.1%, 0.4%]   | 35    |
+| Regressions (secondary)  | 0.3%  | [0.0%, 0.6%]   | 13    |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.3% | [-0.3%, -0.3%] | 1     |
+| All  (primary)                 | 0.2%  | [0.1%, 0.4%]   | 35    |
+
+See discussion
+[here](https://github.com/rust-lang/rust/pull/136094#issuecomment-2628827080).
+Some possible improvements have been identified, but starting by just getting
+elsa on regular updates again.
+
+Rollup of 7 pull requests [#136641](https://github.com/rust-lang/rust/pull/136641) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=79f82ad5e89aa421e2c765fea2098b23beb69b40&end=942db6782f4a28c55b0b75b38fd4394d0483390f&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | -    | -            | 0     |
+| Regressions (secondary)  | 3.1% | [0.0%, 8.0%] | 6     |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | -    | -            | 0     |
+
+Changes are expected, from a few contained PRs:
+- https://github.com/rust-lang/rust/pull/136073#issuecomment-2617093212
+- https://github.com/rust-lang/rust/pull/136435#issuecomment-2629382897
+
+Generally expected to only meaningfully affect stress tests rather than
+real-world code.
+
+Add amdgpu target [#134740](https://github.com/rust-lang/rust/pull/134740) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=d9a4a47b8b3dc0bdff83360cea2013200d60d49c&end=c03c38d5c2368cd2aa0e056dba060b94fc747f4e&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.7% | [0.2%, 3.8%] | 55    |
+| Regressions (secondary)  | 0.6% | [0.2%, 1.0%] | 47    |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | 0.7% | [0.2%, 3.8%] | 55    |
+
+Regressions are mostly in LLVM, seemingly due to more logic being added to
+common code (e.g., pass enumeration) that runs even on non-AMDGPU targets. This
+is also a significant size regression (+19MB on LLVM.so) but generally these
+are likely unavoidable in the short term at least given the expanded target
+set.
+
+#### Improvements
+
+librustdoc: create a helper for separating elements of an iterator instead of implementing it multiple times [#136244](https://github.com/rust-lang/rust/pull/136244) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=e5f11af042ad099102efd572743138df60764a4e&end=8df89d1cb077cd76013d3f9f5a4e92c5b5a9280c&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -0.7% | [-0.8%, -0.6%] | 2     |
+| Improvements (secondary) | -     | -              | 0     |
+| All  (primary)                 | -0.7% | [-0.8%, -0.6%] | 2     |
+
+
+Avoid calling the layout_of query in lit_to_const [#136302](https://github.com/rust-lang/rust/pull/136302) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=820bfffc25fee9866aa8176529091e04b8824f09&end=d4bdd1ed551fed0c951eb47b4be2c79d7a02d181&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.5% | [-0.6%, -0.3%] | 14    |
+| All  (primary)                 | -     | -              | 0     |
+
+rustdoc: run css and html minifier at build instead of runtime [#136253](https://github.com/rust-lang/rust/pull/136253) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=d4bdd1ed551fed0c951eb47b4be2c79d7a02d181&end=a9730c3b5f84a001c052c60c97ed0765e9ceac04&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -1.6% | [-5.5%, -0.2%] | 21    |
+| Improvements (secondary) | -3.7% | [-5.5%, -0.7%] | 22    |
+| All  (primary)                 | -1.6% | [-5.5%, -0.2%] | 21    |
+
+rustdoc: use ThinVec for generic arg parts [#136265](https://github.com/rust-lang/rust/pull/136265) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=6741521dc478182392806e816e919a36be5a2ba2&end=30865107cb8942ab8eaf9baf8d3aa2a6dec2643f&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -0.3% | [-0.5%, -0.2%] | 20    |
+| Improvements (secondary) | -0.4% | [-0.6%, -0.1%] | 18    |
+| All  (primary)                 | -0.3% | [-0.5%, -0.2%] | 20    |
+
+
+implement `eat_until` leveraging memchr in lexer [#136585](https://github.com/rust-lang/rust/pull/136585) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=2f92f050e83bf3312ce4ba73c31fe843ad3cbc60&end=79f82ad5e89aa421e2c765fea2098b23beb69b40&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -0.3% | [-0.4%, -0.1%] | 24    |
+| Improvements (secondary) | -1.6% | [-1.6%, -1.6%] | 1     |
+| All  (primary)                 | -0.3% | [-0.4%, -0.1%] | 24    |
+
+#### Mixed
+
+Rollup of 7 pull requests [#136549](https://github.com/rust-lang/rust/pull/136549) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=3f33b30e19b7597a3acbca19e46d9e308865a0fe&end=bef3c3b01f690de16738b1c9f36470fbfc6ac623&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | 0.3%  | [0.2%, 0.3%]   | 7     |
+| Improvements (primary)   | -0.3% | [-0.3%, -0.2%] | 5     |
+| Improvements (secondary) | -0.6% | [-0.8%, -0.3%] | 5     |
+| All  (primary)                 | -0.3% | [-0.3%, -0.2%] | 5     |
+
+Unclear as to exact cause, but not going to dig in further given small number
+of benchmarks affected (only primary is `libc`, and it improved).
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- "Update to rand 0.9.0" [rust#136395](https://github.com/rust-lang/rust/pull/136395)
+  - Mark raises some concerns about this upgrade, specifically about the new dependency `wit-bindgen-rt` which ships with a small binary blob ([comment](https://github.com/rust-lang/rust/pull/136395#issuecomment-2645783005))
+  - @_**Alex Crichton** says that making it buildable (and not only "reproducible") is possible though it would make maintenaince more complicated on their end ([comment](https://github.com/rust-lang/rust/pull/136395#issuecomment-2645877220)). What they're lacking is support for weak symbols on stable Rust, specifically `cabi_realloc`, defined in multiple crates across a single link unit
+  - What do we think about it? Do we want to establish a policy? ([comment](https://github.com/rust-lang/rust/pull/136395#issuecomment-2645783005))
+- "Revert "Stabilize `extended_varargs_abi_support`"" [rust#136897](https://github.com/rust-lang/rust/pull/136897)
+  - we stabilized this set of varargs. The `extern "system"` part is however broken, as per updated [comment](https://github.com/rust-lang/rust/issues/100189#issue-1330688823):
+    > extern "system", on systems where it is meaningful (i.e. distinct from extern "C" in some way), is translated to extern "stdcall" which is incompatible in varargs
+  - @**Jubilee** suggests reverting everything quickly before the release (artifacts start building tomorrow), then reapply everything expect the `system` part ([comment](https://github.com/rust-lang/rust/pull/136897#issuecomment-2652458348))
+  - [Zulip topic](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/extended_varargs_abi/near/499126726)
+- "process bug: stabilization of `extended_varargs_abi_support` without FCP?" [rust#136896](https://github.com/rust-lang/rust/issues/136896)
+  - @**Jubilee** suggest discussing the evaluation/procedural error. Both T-lang (first) and T-compiler (later) approved #116161 ([timeline](https://github.com/rust-lang/rust/issues/136896#issuecomment-2653329646)) but we don't find an FCP (i.e. a wider consensus)
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- No I-compiler-nominated RFCs this time.
+
+### Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "add error message for c# style named arguments" [rust#118733](https://github.com/rust-lang/rust/pull/118733) (last review activity: 13 months ago)
+  - cc: @**Esteban Küber**
+- "Handle `rustc_query_system` cases of `rustc::potential_query_instability` lint" [rust#131200](https://github.com/rust-lang/rust/pull/131200)
+  - cc @**cjgillot**
+- "Apple: Fix direct linking with +verbatim" [rust#132394](https://github.com/rust-lang/rust/pull/132394) (last review activity: 3 months ago)
+  - cc @**Vadim Petrochenkov** do you still want this?
+- "only use generic info when ty var belong it in orphan check" [rust#132904](https://github.com/rust-lang/rust/pull/132904) (last review activity: 3 months ago)
+  - cc @**León Orell Liehr (fmease)**
+
+Next meetings' agenda draft: [hackmd link](https://hackmd.io/XQufoZB9QzaR-rcWQS8jbg)

--- a/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-20.md
+++ b/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-20.md
@@ -1,0 +1,321 @@
+---
+tags: weekly, rustc
+type: docs
+note_id: XQufoZB9QzaR-rcWQS8jbg
+---
+
+# T-compiler Meeting Agenda 2025-02-20
+
+## Announcements
+
+- Today release of Rust stable 1.85 [blog post](https://github.com/cuviper/blog.rust-lang.org/blob/rust-1.85.0/posts/2025-02-20-Rust-1.85.0.md) with also announcement of Rust 2024 :tada:
+- Reminder: if you see a PR/issue that seems like there might be legal implications due to copyright/IP/etc, please let us know (or at least message @_**davidtwco** or @_**Wesley Wiser** so we can pass it along).
+
+### Other WG meetings
+
+- WG-async design meeting <time:2025-02-20T19:00:00+01:00>
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "`rustc_target` for rust-analyzer" [compiler-team#839](https://github.com/rust-lang/compiler-team/issues/839) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/.60rustc_target.60.20for.20rust-analyzer.20compiler-team.23839))
+- Old MCPs (stale MCP might be closed as per [MCP procedure](https://forge.rust-lang.org/compiler/mcp.html#when-should-major-change-proposals-be-closed))
+  - None at this time
+- Old MCPs (not seconded, take a look)
+  -  "Add hygiene attributes to compile expanded source code" [compiler-team#692](https://github.com/rust-lang/compiler-team/issues/692) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20option.20to.20compile.20expanded.20ASTs.20for.20h.E2.80.A6.20compiler-team.23692)) (last review activity: 5 months ago)
+  -  "Add Hotpatch flag" [compiler-team#745](https://github.com/rust-lang/compiler-team/issues/745) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20Hotpatch.20flag.20compiler-team.23745)) (last review activity: 4 months ago)
+  -  "Policy change around adding new unstable flags" [compiler-team#787](https://github.com/rust-lang/compiler-team/issues/787) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Policy.20change.20around.20adding.20new.20unstable.20.E2.80.A6.20compiler-team.23787)) (last review activity: 4 months ago)
+  -  "Normalize FileCheck directives" [compiler-team#789](https://github.com/rust-lang/compiler-team/issues/789) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Normalize.20FileCheck.20directives.20compiler-team.23789)) (last review activity: 4 months ago)
+  -  "Rename "dylib" crate type to "rdylib" (keep old name but deprecate it), and maybe do the same for "staticlib" → "cstaticlib"" [compiler-team#825](https://github.com/rust-lang/compiler-team/issues/825) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Rename.20.22dylib.22.20create.20type.20to.20.22rdylib.22.20.28k.E2.80.A6.20compiler-team.23825)) (last review activity: about 40 days ago)
+  -  "Add `--print=lint-levels` to retrieve lints levels" [compiler-team#833](https://github.com/rust-lang/compiler-team/issues/833) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60--print.3Dlint-levels.60.20to.20retrieve.20lin.E2.80.A6.20compiler-team.23833)) (last review activity: about 19 days ago)
+- Pending FCP requests (check your boxes!)
+  - "sanitizers: Stabilize AddressSanitizer and LeakSanitizer for the Tier 1 targets" [rust#123617](https://github.com/rust-lang/rust/pull/123617)
+  - "Warn about C-style octal literals" [rust#131309](https://github.com/rust-lang/rust/pull/131309)
+  - "Stabilize `-Zdwarf-version` as `-Cdwarf-version`" [rust#136926](https://github.com/rust-lang/rust/pull/136926)
+- Things in FCP (make sure you're good with it)
+  - "Add `target_abi = "[ilp]{2,3}[3264]{2}[fdq]?"` to all RV[3264]{2}I targets" [compiler-team#830](https://github.com/rust-lang/compiler-team/issues/830) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60target_abi.20.3D.20.22.5Bilp.5D.7B2.2C3.7D.5B3264.5D.7B2.7D.5Bfd.E2.80.A6.20compiler-team.23830))
+  - "Give integer literals a sign instead of relying on negation expressions" [compiler-team#835](https://github.com/rust-lang/compiler-team/issues/835) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Give.20integer.20literals.20a.20sign.20instead.20of.20r.E2.80.A6.20compiler-team.23835))
+  - "Add `--print=supported-crate-types`" [compiler-team#836](https://github.com/rust-lang/compiler-team/issues/836) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60--print.3Dsupported-crate-types.60.20compiler-team.23836))
+  - "Ban projecting into `repr(simd)` types" [compiler-team#838](https://github.com/rust-lang/compiler-team/issues/838) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Ban.20projecting.20into.20.60repr.28simd.29.60.20types.20compiler-team.23838))
+  - "Remove `i586-pc-windows-msvc`" [compiler-team#840](https://github.com/rust-lang/compiler-team/issues/840) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Remove.20.60i586-pc-windows-msvc.60.20compiler-team.23840))
+- Accepted MCPs
+  -  "Create an avr-unknown-none target" [compiler-team#800](https://github.com/rust-lang/compiler-team/issues/800) ([Zulip](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Create.20an.20avr-unknown-none.20target.20compiler-team.23800))
+  -  "Clean up operator representations" [compiler-team#831](https://github.com/rust-lang/compiler-team/issues/831) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Clean.20up.20operator.20representations.20compiler-team.23831))
+  -  "Do not ignore uninhabited types for function-call ABI purposes." [compiler-team#832](https://github.com/rust-lang/compiler-team/issues/832) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Do.20not.20ignore.20uninhabited.20types.20for.20funct.E2.80.A6.20compiler-team.23832))
+- MCPs blocked on unresolved concerns
+  - "setup typos check in CI (for rust repo)" [compiler-team#817](https://github.com/rust-lang/compiler-team/issues/817) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/setup.20typos.20check.20in.20CI.20.28for.20rust.20repo.29.20compiler-team.23817))
+    - concern: [contributor friction](https://github.com/rust-lang/compiler-team/issues/817#issuecomment-2525266792)
+  - "Retire the mailing list and make all decisions on zulip" [compiler-team#649](https://github.com/rust-lang/compiler-team/issues/649) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Retire.20the.20mailing.20list.20and.20make.20all.20deci.E2.80.A6.20compiler-team.23649))
+    - concern: [automatic-sync](https://github.com/rust-lang/compiler-team/issues/649#issuecomment-1618902660)
+  -  "Add `-C hint-mostly-unused` option" [compiler-team#829](https://github.com/rust-lang/compiler-team/issues/829) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60-C.20defer-codegen.60.20option.20compiler-team.23829)) (last review activity: about 22 days ago)
+    - concern: [prior-art-does-not-motivate-fast-stabilization](https://github.com/rust-lang/compiler-team/issues/829#issuecomment-2617441734)
+  -  "Add `evex512` target feature for AVX10" [compiler-team#778](https://github.com/rust-lang/compiler-team/issues/778) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60evex512.60.20target.20feature.20for.20AVX10.20compiler-team.23778)) (last review activity: 2 months ago)
+    - concern: [design-around-naming-scheme](https://github.com/rust-lang/compiler-team/issues/778#issuecomment-2514307904)
+- Finalized FCPs (disposition merge)
+  - "Add `--print host-tuple` to print host target tuple" [rust#125579](https://github.com/rust-lang/rust/pull/125579)
+  - "make unsupported_calling_conventions a hard error" [rust#129935](https://github.com/rust-lang/rust/pull/129935)
+  - "Fix ICE when passing DefId-creating args to legacy_const_generics." [rust#130443](https://github.com/rust-lang/rust/pull/130443)
+  - "Stabilize WebAssembly `multivalue`, `reference-types`, and `tail-call` target features" [rust#131080](https://github.com/rust-lang/rust/pull/131080)
+  - "Lint on combining `#[no_mangle]` and `#[export_name]`" [rust#131558](https://github.com/rust-lang/rust/pull/131558)
+- Other teams finalized FCPs
+  - "Add lint against function pointer comparisons" [rust#118833](https://github.com/rust-lang/rust/pull/118833)
+  - "Fixup Windows verbatim paths when used with the `include!` macro" [rust#125205](https://github.com/rust-lang/rust/pull/125205)
+  - "Uplift `clippy::double_neg` lint as `double_negations`" [rust#126604](https://github.com/rust-lang/rust/pull/126604)
+  - "Allow dropping `dyn Trait` principal" [rust#126660](https://github.com/rust-lang/rust/pull/126660)
+  - "atomics: allow atomic and non-atomic reads to race" [rust#128778](https://github.com/rust-lang/rust/pull/128778)
+  - "Lint against getting pointers from immediately dropped temporaries" [rust#128985](https://github.com/rust-lang/rust/pull/128985)
+  - "Do not consider match/let/ref of place that evaluates to `!` to diverge, disallow coercions from them too" [rust#129392](https://github.com/rust-lang/rust/pull/129392)
+  - "Make deprecated_cfg_attr_crate_type_name a hard error" [rust#129670](https://github.com/rust-lang/rust/pull/129670)
+  - "Stabilize expr_2021 fragment specifier in all editions" [rust#129972](https://github.com/rust-lang/rust/pull/129972)
+  - "Check elaborated projections from dyn don't mention unconstrained late bound lifetimes" [rust#130367](https://github.com/rust-lang/rust/pull/130367)
+  - "Finish stabilization of `result_ffi_guarantees`" [rust#130628](https://github.com/rust-lang/rust/pull/130628)
+  - "Stabilize const `ptr::write*` and `mem::replace`" [rust#130954](https://github.com/rust-lang/rust/pull/130954)
+  - "Stabilize s390x inline assembly" [rust#131258](https://github.com/rust-lang/rust/pull/131258)
+  - "Stabilize Arm64EC inline assembly" [rust#131781](https://github.com/rust-lang/rust/pull/131781)
+  - "Always display first line of impl blocks even when collapsed" [rust#132155](https://github.com/rust-lang/rust/pull/132155)
+  - "rework winnowing to sensibly handle global where-bounds" [rust#132325](https://github.com/rust-lang/rust/pull/132325)
+  - "mark is_val_statically_known intrinsic as stably const-callable" [rust#132449](https://github.com/rust-lang/rust/pull/132449)
+  - "Fix ICE when multiple supertrait substitutions need assoc but only one is provided" [rust#133392](https://github.com/rust-lang/rust/pull/133392)
+  - "[rustdoc] Add sans-serif font setting" [rust#133636](https://github.com/rust-lang/rust/pull/133636)
+  - "disallow `repr()` on invalid items" [rust#133925](https://github.com/rust-lang/rust/pull/133925)
+  - "Make the wasm_c_abi future compat warning a hard error" [rust#133951](https://github.com/rust-lang/rust/pull/133951)
+  - "fully de-stabilize all custom inner attributes" [rust#134276](https://github.com/rust-lang/rust/pull/134276)
+  - "remove long-deprecated no-op attributes no_start and crate_id" [rust#134300](https://github.com/rust-lang/rust/pull/134300)
+  - "Stabilize `feature(trait_upcasting)`" [rust#134367](https://github.com/rust-lang/rust/pull/134367)
+  - "regression: a value of type `HashMap<Pulse, u64>` cannot be built from" [rust#135669](https://github.com/rust-lang/rust/issues/135669)
+  - "Future incompatibility warning `unsupported_fn_ptr_calling_conventions`: Also warn in dependencies" [rust#135767](https://github.com/rust-lang/rust/pull/135767)
+  - "Reject `?Trait` bounds in various places where we unconditionally warned since 1.0" [rust#135841](https://github.com/rust-lang/rust/pull/135841)
+  - "Make cenum_impl_drop_cast a hard error" [rust#135964](https://github.com/rust-lang/rust/pull/135964)
+  - "Do not allow attributes on struct field rest patterns" [rust#136490](https://github.com/rust-lang/rust/pull/136490)
+
+## Backport nominations
+
+[T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Remove SSE ABI from i586-pc-windows-msvc" [rust#137149](https://github.com/rust-lang/rust/pull/137149)
+  - Authored by Noratrieb
+  - Backport suggestion to avoid people (using [just this target](https://github.com/rust-lang/rust/pull/137149#issuecomment-2661603346)) seeing this warning in the next 1.86 beta cycle
+  - Target is probably going to be removed after [MCP#840](https://github.com/rust-lang/compiler-team/issues/840)
+<!--
+/poll Approve beta: backport of #137149?
+approve
+decline
+don't know
+-->
+- No stable nominations for `T-compiler` this time.
+
+[T-types beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-types) / [T-types stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-types)
+- No beta nominations for `T-types` this time.
+- No stable nominations for `T-types` this time.
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- [Issues in progress or waiting on other teams](https://hackmd.io/XYr1BrOWSiqCrl8RCWXRaQ)
+
+## Issues of Note
+
+### Short Summary
+
+- [0 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [59 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [38 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 0 P-high, 2 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [0 P-critical, 1 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [0 P-critical, 33 P-high, 100 P-medium, 20 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- No `P-critical` issues for `T-compiler` this time.
+
+[T-types](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-types)
+- No `P-critical` issues for `T-types` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core+)
+- None
+
+## Performance logs
+
+> [triage logs for 2025-02-18](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025-02-18.md)
+
+This week's results were dominated by the update to LLVM 20 ([#135763](https://github.com/rust-lang/rust/pull/135763)),
+which brought a large number of performance improvements, as usual. There were also two other
+significant improvements, caused by improving the representation of `const` values ([#136593](https://github.com/rust-lang/rust/pull/136593)) and doing less work when formatting in `rustdoc` ([#136828](https://github.com/rust-lang/rust/pull/136828)).
+
+Triage done by **@kobzol**.
+Revision range: [c03c38d5..ce36a966](https://perf.rust-lang.org/?start=c03c38d5c2368cd2aa0e056dba060b94fc747f4e&end=ce36a966c79e109dabeef7a47fe68e5294c6d71e&absolute=false&stat=instructions%3Au)
+
+**Summary**:
+
+| (instructions:u)         | mean  | range           | count |
+|:------------------------:|:-----:|:---------------:|:-----:|
+| Regressions (primary)    | 4.4%  | [0.2%, 35.8%]   | 10    |
+| Regressions (secondary)  | 1.2%  | [0.2%, 5.0%]    | 13    |
+| Improvements (primary)   | -1.6% | [-10.5%, -0.2%] | 256   |
+| Improvements (secondary) | -1.0% | [-4.7%, -0.2%]  | 163   |
+| All  (primary)           | -1.3% | [-10.5%, 35.8%] | 266   |
+
+
+3 Regressions, 2 Improvements, 4 Mixed; 4 of them in rollups
+50 artifact comparisons made in total
+
+#### Regressions
+
+Rollup of 8 pull requests [#136918](https://github.com/rust-lang/rust/pull/136918) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=021fb9c09a19d206a37226fe6168f1cc7c984925&end=552a959051cebf8f88a8f558399baf733bec9ce0&stat=instructions:u)
+
+| (instructions:u)         | mean | range        | count |
+|:------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.9% | [0.1%, 2.1%] | 19    |
+| Regressions (secondary)  | 1.7% | [0.3%, 4.9%] | 9     |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)           | 0.9% | [0.1%, 2.1%] | 19    |
+
+- Regression on a number of `doc` benchmarkes caused by [#136829](https://github.com/rust-lang/rust/pull/136829).
+- Continuing discussion on that PR, not marking as triaged yet.
+
+Rollup of 10 pull requests [#136943](https://github.com/rust-lang/rust/pull/136943) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=ced8e650cddbafad92094b2c89dee97b8a807d9c&end=ef148cd7eb00a5a973130dc6473da71fd6c487ee&stat=instructions:u)
+
+| (instructions:u)         | mean | range        | count |
+|:------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.2% | [0.2%, 0.2%] | 1     |
+| Regressions (secondary)  | 0.6% | [0.4%, 0.7%] | 16    |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)           | 0.2% | [0.2%, 0.2%] | 1     |
+
+- Small regression on a bunch of secondary benchmarks caused by [#136901](https://github.com/rust-lang/rust/pull/136901).
+- Does not seem worthy of further work.
+- Marked as triaged.
+
+Rollup of 11 pull requests [#137001](https://github.com/rust-lang/rust/pull/137001) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=a567209daab72b7ea59eac533278064396bb0534&end=6dfeab5c9e8a17a6636c1479037baabc4b1e9562&stat=instructions:u)
+
+| (instructions:u)         | mean | range        | count |
+|:------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.8% | [0.8%, 0.9%] | 2     |
+| Regressions (secondary)  | 0.1% | [0.1%, 0.1%] | 2     |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)           | 0.8% | [0.8%, 0.9%] | 2     |
+
+- A few small regressions were caused by [#136928](https://github.com/rust-lang/rust/pull/136928).
+- That PR was a fix and the regressions were small, so no further work is needed.
+- Marked as triaged.
+
+#### Improvements
+
+valtree performance tuning [#136593](https://github.com/rust-lang/rust/pull/136593) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=54cdc751df770517e70db0588573e32e6a7b9821&end=c241e146506600f5ab7f4026ff015df8a658400e&stat=instructions:u)
+
+| (instructions:u)         | mean  | range          | count |
+|:------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -2.6% | [-5.6%, -0.2%] | 20    |
+| Improvements (secondary) | -0.3% | [-0.3%, -0.3%] | 1     |
+| All  (primary)           | -2.6% | [-5.6%, -0.2%] | 20    |
+
+- Resolves a previous perf. regression from https://github.com/rust-lang/rust/pull/136180, and then some.
+
+Do more lazy-formatting in librustdoc [#136828](https://github.com/rust-lang/rust/pull/136828) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=8c07d140e00dfa5b0988754051d07d8a91ff01f7&end=69fd5e4059f8840f09f60269bcda23dcdcb77151&stat=instructions:u)
+
+| (instructions:u)         | mean  | range           | count |
+|:------------------------:|:-----:|:---------------:|:-----:|
+| Regressions (primary)    | -     | -               | 0     |
+| Regressions (secondary)  | -     | -               | 0     |
+| Improvements (primary)   | -1.6% | [-10.3%, -0.3%] | 17    |
+| Improvements (secondary) | -0.5% | [-0.7%, -0.2%]  | 3     |
+| All  (primary)           | -1.6% | [-10.3%, -0.3%] | 17    |
+
+- A great win for doc benchmarks.
+
+#### Mixed
+
+Portable SIMD subtree update [#135701](https://github.com/rust-lang/rust/pull/135701) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=8c04e395952022a451138dc4dbead6dd6ae65203&end=4b293d99275cc63b07eec9e2de38f4b776989069&stat=instructions:u)
+
+| (instructions:u)         | mean  | range          | count |
+|:------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.5%  | [0.5%, 0.5%]   | 1     |
+| Regressions (secondary)  | 0.3%  | [0.1%, 0.6%]   | 17    |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.4% | [-0.4%, -0.4%] | 2     |
+| All  (primary)           | 0.5%  | [0.5%, 0.5%]   | 1     |
+
+- Tiny regressions in doc builds, probably caused by more documentation in portable-simd.
+- Marked as triaged.
+
+transmute should also assume non-null pointers [#136735](https://github.com/rust-lang/rust/pull/136735) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=905b1bf1ccccaf091a880b069f80dc38ad9ecad3&end=d88ffcdb8bfc6f8b917574c1693eb9764a20eff5&stat=instructions:u)
+
+| (instructions:u)         | mean  | range          | count |
+|:------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.5%  | [0.3%, 0.8%]   | 4     |
+| Regressions (secondary)  | 0.2%  | [0.2%, 0.2%]   | 1     |
+| Improvements (primary)   | -0.5% | [-1.0%, -0.2%] | 7     |
+| Improvements (secondary) | -0.2% | [-0.2%, -0.2%] | 2     |
+| All  (primary)           | -0.2% | [-1.0%, 0.8%]  | 11    |
+
+- Performance is a wash.
+- Marked as triaged.
+
+Rollup of 7 pull requests [#137163](https://github.com/rust-lang/rust/pull/137163) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=d5eb31c9347ae3c494c8d723711dacca7d1cfe8b&end=273465e1f2932a30a5b56ac95859cdc86f3f33fa&stat=instructions:u)
+
+| (instructions:u)         | mean  | range          | count |
+|:------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | 0.1%  | [0.1%, 0.1%]   | 1     |
+| Improvements (primary)   | -0.3% | [-0.3%, -0.3%] | 2     |
+| Improvements (secondary) | -     | -              | 0     |
+| All  (primary)           | -0.3% | [-0.3%, -0.3%] | 2     |
+
+- Three tiny changes, the only regression is on an incr-unchanged run of a parser stress test,
+  probably doesn't warrant further investigation.
+- Marked as triaged.
+
+Update to LLVM 20 [#135763](https://github.com/rust-lang/rust/pull/135763) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=2162e9d4b18525e4eb542fed9985921276512d7c&end=ce36a966c79e109dabeef7a47fe68e5294c6d71e&stat=instructions:u)
+
+| (instructions:u)         | mean  | range          | count |
+|:------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 5.1%  | [0.2%, 35.1%]  | 8     |
+| Regressions (secondary)  | 0.7%  | [0.4%, 1.0%]   | 10    |
+| Improvements (primary)   | -1.3% | [-4.2%, -0.2%] | 251   |
+| Improvements (secondary) | -1.0% | [-4.7%, -0.1%] | 178   |
+| All  (primary)           | -1.1% | [-4.2%, 35.1%] | 259   |
+
+- As usual, update to a new lLVM version brings a lot of performance wins, but also some regressions.
+- The single large regression was on a release (optimized) incremental build, which is not a
+configuration used much in practice. It was caused by a codegen unit becoming unnecessarily large.
+- Marked as triaged.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- "Our x86-32 target names are inconsistent" [rust#136495](https://github.com/rust-lang/rust/issues/136495)
+  - @**RalfJ** replied ([comment](https://github.com/rust-lang/rust/issues/136495#issuecomment-2656914059)) to the questions we raised during last meeting:
+    > [...] what to do with i586-pc-nto-qnx700? A target with a Pentium 4 baseline. We typically use i586 to indicate "older than i686" (with i686 meaning "Pentium 4"), so there is a direct conflict here between the vendor convention and our own convention, which will easily be confusing for Rust users.
+- "process bug: stabilization of `extended_varargs_abi_support` without FCP?" [rust#136896](https://github.com/rust-lang/rust/issues/136896)
+  - @**Jubilee** suggest discussing the evaluation/procedural error. Both T-lang (first) and T-compiler (later) approved #116161 ([timeline](https://github.com/rust-lang/rust/issues/136896#issuecomment-2653329646)) but we don't find an FCP (i.e. a wider consensus)
+  - Specifically, was this just a slip or is there an actual procedural "bug" (see [comment](https://github.com/rust-lang/rust/issues/136896#issuecomment-2654440700))?
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- No I-compiler-nominated RFCs this time.
+
+### Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "add error message for c# style named arguments" [rust#118733](https://github.com/rust-lang/rust/pull/118733) (last review activity: 13 months ago)
+  - cc: @**Esteban Küber**
+- "Handle `rustc_query_system` cases of `rustc::potential_query_instability` lint" [rust#131200](https://github.com/rust-lang/rust/pull/131200)
+  - cc @**cjgillot**
+- "Apple: Fix direct linking with +verbatim" [rust#132394](https://github.com/rust-lang/rust/pull/132394) (last review activity: 3 months ago)
+  - cc @**Vadim Petrochenkov** do you still want this?
+- "only use generic info when ty var belong it in orphan check" [rust#132904](https://github.com/rust-lang/rust/pull/132904) (last review activity: 3 months ago)
+  - cc @**León Orell Liehr (fmease)**
+- "JumpThreading: fix bitwise not on non-booleans" [rust#131203](https://github.com/rust-lang/rust/pull/131203) (last review activity: 3 months ago)
+  - cc @**cjgillot**
+
+Next meetings' agenda draft: [hackmd link](https://hackmd.io/lLvBu4pvTpq8mYUSJjeUTw)

--- a/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-27.md
+++ b/content/minutes/triage-meeting/T-compiler Meeting Agenda 2025-02-27.md
@@ -1,0 +1,328 @@
+---
+tags: weekly, rustc
+type: docs
+note_id: lLvBu4pvTpq8mYUSJjeUTw
+---
+
+# T-compiler Meeting Agenda 2025-02-27
+
+## Announcements
+
+- T-compiler steering meeting at <time:2025-02-27T16:00:00+01:00>
+- Reminder: if you see a PR/issue that seems like there might be legal implications due to copyright/IP/etc, please let us know (or at least message @_**davidtwco** or @_**Wesley Wiser** so we can pass it along).
+
+### Other WG meetings
+
+- WG-async design meeting <time:2025-02-27T19:00:00+01:00>
+- Stable MIR Weekly Meeting <time:2025-02-28T17:00:00+01:00>
+
+## MCPs/FCPs
+
+- New MCPs (take a look, see if you like them!)
+  - "Compile UI tests as libraries by default" [compiler-team#842](https://github.com/rust-lang/compiler-team/issues/842) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Compile.20UI.20tests.20as.20libraries.20by.20default.20compiler-team.23842))
+- Old MCPs (not seconded, take a look)
+  - "Add hygiene attributes to compile expanded source code" [compiler-team#692](https://github.com/rust-lang/compiler-team/issues/692) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20option.20to.20compile.20expanded.20ASTs.20for.20h.E2.80.A6.20compiler-team.23692)) (last review activity: 5 months ago)
+  - "Add Hotpatch flag" [compiler-team#745](https://github.com/rust-lang/compiler-team/issues/745) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20Hotpatch.20flag.20compiler-team.23745)) (last review activity: 4 months ago)
+  - "Policy change around adding new unstable flags" [compiler-team#787](https://github.com/rust-lang/compiler-team/issues/787) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Policy.20change.20around.20adding.20new.20unstable.20.E2.80.A6.20compiler-team.23787)) (last review activity: 4 months ago)
+  - "Normalize FileCheck directives" [compiler-team#789](https://github.com/rust-lang/compiler-team/issues/789) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Normalize.20FileCheck.20directives.20compiler-team.23789)) (last review activity: 4 months ago)
+  - "Rename "dylib" crate type to "rdylib" (keep old name but deprecate it), and maybe do the same for "staticlib" → "cstaticlib"" [compiler-team#825](https://github.com/rust-lang/compiler-team/issues/825) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Rename.20.22dylib.22.20create.20type.20to.20.22rdylib.22.20.28k.E2.80.A6.20compiler-team.23825)) (last review activity: about 48 days ago)
+  - "`rustc_target` for rust-analyzer" [compiler-team#839](https://github.com/rust-lang/compiler-team/issues/839) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/.60rustc_target.60.20for.20rust-analyzer.20compiler-team.23839)) (last review activity: about 5 days ago)
+- Pending FCP requests (check your boxes!)
+  - "sanitizers: Stabilize AddressSanitizer and LeakSanitizer for the Tier 1 targets" [rust#123617](https://github.com/rust-lang/rust/pull/123617)
+  - "Warn about C-style octal literals" [rust#131309](https://github.com/rust-lang/rust/pull/131309)
+  - "Stabilize `-Zdwarf-version` as `-Cdwarf-version`" [rust#136926](https://github.com/rust-lang/rust/pull/136926)
+- Things in FCP (make sure you're good with it)
+  - "Add `target_abi = "[ilp]{2,3}[3264]{2}[fdq]?"` to all RV[3264]{2}I targets" [compiler-team#830](https://github.com/rust-lang/compiler-team/issues/830) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60target_abi.20.3D.20.22.5Bilp.5D.7B2.2C3.7D.5B3264.5D.7B2.7D.5Bfd.E2.80.A6.20compiler-team.23830))
+  - "Add `--print=crate-root-lint-levels` to retrieve lints levels" [compiler-team#833](https://github.com/rust-lang/compiler-team/issues/833) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60--print.3Dlint-levels.60.20to.20retrieve.20lin.E2.80.A6.20compiler-team.23833))
+  - "Give integer literals a sign instead of relying on negation expressions" [compiler-team#835](https://github.com/rust-lang/compiler-team/issues/835) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Give.20integer.20literals.20a.20sign.20instead.20of.20r.E2.80.A6.20compiler-team.23835))
+    - PR #136860 being reviewed
+  - "Add `--print=supported-crate-types`" [compiler-team#836](https://github.com/rust-lang/compiler-team/issues/836) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60--print.3Dsupported-crate-types.60.20compiler-team.23836))
+  - "Ban projecting into `repr(simd)` types" [compiler-team#838](https://github.com/rust-lang/compiler-team/issues/838) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Ban.20projecting.20into.20.60repr.28simd.29.60.20types.20compiler-team.23838))
+  - "Remove `i586-pc-windows-msvc`" [compiler-team#840](https://github.com/rust-lang/compiler-team/issues/840) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Remove.20.60i586-pc-windows-msvc.60.20compiler-team.23840))
+- Accepted MCPs
+  - No new accepted proposals this time.
+- MCPs blocked on unresolved concerns
+  - "Proposal for Adapt Stack Protector for Rust" [compiler-team#841](https://github.com/rust-lang/compiler-team/issues/841) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/.28My.20major.20change.20proposal.29.20compiler-team.23841))
+    - concern: [inhibit-opts](https://github.com/rust-lang/compiler-team/issues/841#issuecomment-2683562830)
+    - concern: [impl-at-mir-level](https://github.com/rust-lang/compiler-team/issues/841#issuecomment-2683562830)
+    - concern: [lose-debuginfo-data](https://github.com/rust-lang/compiler-team/issues/841#issuecomment-2683562830)
+  - "setup typos check in CI (for rust repo)" [compiler-team#817](https://github.com/rust-lang/compiler-team/issues/817) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/setup.20typos.20check.20in.20CI.20.28for.20rust.20repo.29.20compiler-team.23817))
+    - concern: [contributor friction](https://github.com/rust-lang/compiler-team/issues/817#issuecomment-2525266792)
+  - "Retire the mailing list and make all decisions on zulip" [compiler-team#649](https://github.com/rust-lang/compiler-team/issues/649) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Retire.20the.20mailing.20list.20and.20make.20all.20deci.E2.80.A6.20compiler-team.23649))
+    - concern: [automatic-sync](https://github.com/rust-lang/compiler-team/issues/649#issuecomment-1618902660)
+  - "Add `-C hint-mostly-unused` option" [compiler-team#829](https://github.com/rust-lang/compiler-team/issues/829) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60-C.20defer-codegen.60.20option.20compiler-team.23829)) (last review activity: about 30 days ago)
+    - concern: [prior-art-does-not-motivate-fast-stabilization](https://github.com/rust-lang/compiler-team/issues/829#issuecomment-2617441734)
+  - "Add `evex512` target feature for AVX10" [compiler-team#778](https://github.com/rust-lang/compiler-team/issues/778) ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/233931-xxx/topic/Add.20.60evex512.60.20target.20feature.20for.20AVX10.20compiler-team.23778)) (last review activity: 2 months ago)
+    - concern: [design-around-naming-scheme](https://github.com/rust-lang/compiler-team/issues/778#issuecomment-2514307904)
+- Finalized FCPs (disposition merge)
+  - "Add `--print host-tuple` to print host target tuple" [rust#125579](https://github.com/rust-lang/rust/pull/125579)
+  - "make unsupported_calling_conventions a hard error" [rust#129935](https://github.com/rust-lang/rust/pull/129935)
+  - "Fix ICE when passing DefId-creating args to legacy_const_generics." [rust#130443](https://github.com/rust-lang/rust/pull/130443)
+  - "Stabilize WebAssembly `multivalue`, `reference-types`, and `tail-call` target features" [rust#131080](https://github.com/rust-lang/rust/pull/131080)
+  - "Lint on combining `#[no_mangle]` and `#[export_name]`" [rust#131558](https://github.com/rust-lang/rust/pull/131558)
+- Other teams finalized FCPs
+  - "Add lint against function pointer comparisons" [rust#118833](https://github.com/rust-lang/rust/pull/118833)
+  - "Fixup Windows verbatim paths when used with the `include!` macro" [rust#125205](https://github.com/rust-lang/rust/pull/125205)
+  - "Uplift `clippy::double_neg` lint as `double_negations`" [rust#126604](https://github.com/rust-lang/rust/pull/126604)
+  - "Allow dropping `dyn Trait` principal" [rust#126660](https://github.com/rust-lang/rust/pull/126660)
+  - "atomics: allow atomic and non-atomic reads to race" [rust#128778](https://github.com/rust-lang/rust/pull/128778)
+  - "Lint against getting pointers from immediately dropped temporaries" [rust#128985](https://github.com/rust-lang/rust/pull/128985)
+  - "Do not consider match/let/ref of place that evaluates to `!` to diverge, disallow coercions from them too" [rust#129392](https://github.com/rust-lang/rust/pull/129392)
+  - "Make deprecated_cfg_attr_crate_type_name a hard error" [rust#129670](https://github.com/rust-lang/rust/pull/129670)
+  - "Stabilize expr_2021 fragment specifier in all editions" [rust#129972](https://github.com/rust-lang/rust/pull/129972)
+  - "Check elaborated projections from dyn don't mention unconstrained late bound lifetimes" [rust#130367](https://github.com/rust-lang/rust/pull/130367)
+  - "Finish stabilization of `result_ffi_guarantees`" [rust#130628](https://github.com/rust-lang/rust/pull/130628)
+  - "Stabilize const `ptr::write*` and `mem::replace`" [rust#130954](https://github.com/rust-lang/rust/pull/130954)
+  - "Stabilize s390x inline assembly" [rust#131258](https://github.com/rust-lang/rust/pull/131258)
+  - "Stabilize Arm64EC inline assembly" [rust#131781](https://github.com/rust-lang/rust/pull/131781)
+  - "Always display first line of impl blocks even when collapsed" [rust#132155](https://github.com/rust-lang/rust/pull/132155)
+  - "rework winnowing to sensibly handle global where-bounds" [rust#132325](https://github.com/rust-lang/rust/pull/132325)
+  - "mark is_val_statically_known intrinsic as stably const-callable" [rust#132449](https://github.com/rust-lang/rust/pull/132449)
+  - "Fix ICE when multiple supertrait substitutions need assoc but only one is provided" [rust#133392](https://github.com/rust-lang/rust/pull/133392)
+  - "[rustdoc] Add sans-serif font setting" [rust#133636](https://github.com/rust-lang/rust/pull/133636)
+  - "disallow `repr()` on invalid items" [rust#133925](https://github.com/rust-lang/rust/pull/133925)
+  - "Make the wasm_c_abi future compat warning a hard error" [rust#133951](https://github.com/rust-lang/rust/pull/133951)
+  - "fully de-stabilize all custom inner attributes" [rust#134276](https://github.com/rust-lang/rust/pull/134276)
+  - "remove long-deprecated no-op attributes no_start and crate_id" [rust#134300](https://github.com/rust-lang/rust/pull/134300)
+  - "Stabilize `feature(trait_upcasting)`" [rust#134367](https://github.com/rust-lang/rust/pull/134367)
+  - "Future incompatibility warning `unsupported_fn_ptr_calling_conventions`: Also warn in dependencies" [rust#135767](https://github.com/rust-lang/rust/pull/135767)
+  - "Reject `?Trait` bounds in various places where we unconditionally warned since 1.0" [rust#135841](https://github.com/rust-lang/rust/pull/135841)
+  - "Make cenum_impl_drop_cast a hard error" [rust#135964](https://github.com/rust-lang/rust/pull/135964)
+  - "Do not deduplicate list of associated types provided by dyn principal" [rust#136458](https://github.com/rust-lang/rust/pull/136458)
+  - "Do not allow attributes on struct field rest patterns" [rust#136490](https://github.com/rust-lang/rust/pull/136490)
+  - "Make `ptr_cast_add_auto_to_object` lint into hard error" [rust#136764](https://github.com/rust-lang/rust/pull/136764)
+
+## Backport nominations
+
+[T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+- :beta: "Improve behavior of `IF_LET_RESCOPE` around temporaries and place expressions" [rust#137444](https://github.com/rust-lang/rust/pull/137444)
+  - Authored by compiler-errors
+  - Fixes #137411 (a false positive about a drop for `hashbrown::HashMap::get`)
+  - nominated by @**oli** (probably to get it sooner to users)
+<!--
+/poll Approve beta:  backport of #137444?
+approve
+decline
+don't know
+-->
+- :beta: "Don't infer attributes of virtual calls based on the function body" [rust#137669](https://github.com/rust-lang/rust/pull/137669)
+  - Authored by DianQK
+  - Fixes #137646, a P-critical LLVM miscompilation. Reviewed and in a rollup queue.
+<!--
+/poll Approve beta:  backport of #137669?
+approve
+decline
+don't know
+-->
+- No stable nominations for `T-compiler` this time.
+
+[T-types beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-types) / [T-types stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-types)
+- No beta nominations for `T-types` this time.
+- No stable nominations for `T-types` this time.
+
+## PRs S-waiting-on-team
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+- "Better errors with bad/missing identifiers in MBEs" [rust#118939](https://github.com/rust-lang/rust/pull/118939)
+- "Uplift `clippy::invalid_null_ptr_usage` lint" [rust#119220](https://github.com/rust-lang/rust/pull/119220)
+- "Implement RFC 3349, mixed utf8 literals" [rust#120286](https://github.com/rust-lang/rust/pull/120286)
+- "Emit a warning if a `match` is too complex" [rust#122685](https://github.com/rust-lang/rust/pull/122685)
+- "privacy: normalize associated types before visiting" [rust#126076](https://github.com/rust-lang/rust/pull/126076)
+- "Warn about C-style octal literals" [rust#131309](https://github.com/rust-lang/rust/pull/131309)
+- "Tracking Issue for `bare_link_kind`" [rust#132061](https://github.com/rust-lang/rust/issues/132061)
+- "Add lint against (some) interior mutable consts" [rust#132146](https://github.com/rust-lang/rust/pull/132146)
+- "Lint on fn pointers comparisons in external macros" [rust#134536](https://github.com/rust-lang/rust/pull/134536)
+- "aarch64-softfloat: forbid enabling the neon target feature" [rust#135160](https://github.com/rust-lang/rust/pull/135160)
+- "Add `explicit_extern_abis` Feature and Enforce Explicit ABIs" [rust#135340](https://github.com/rust-lang/rust/pull/135340)
+- "Stabilize `-Zdwarf-version` as `-Cdwarf-version`" [rust#136926](https://github.com/rust-lang/rust/pull/136926)
+- [Issues in progress or waiting on other teams](https://hackmd.io/XYr1BrOWSiqCrl8RCWXRaQ)
+
+## Issues of Note
+
+### Short Summary
+
+- [1 T-compiler P-critical issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical)
+  - [0 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-critical+no%3Aassignee)
+- [57 T-compiler P-high issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high)
+  - [36 of those are unassigned](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AT-compiler+label%3AP-high+no%3Aassignee)
+- [0 P-critical, 0 P-high, 2 P-medium, 1 P-low regression-from-stable-to-beta](https://github.com/rust-lang/rust/labels/regression-from-stable-to-beta)
+- [1 P-critical, 0 P-high, 1 P-medium, 0 P-low regression-from-stable-to-nightly](https://github.com/rust-lang/rust/labels/regression-from-stable-to-nightly)
+- [1 P-critical, 32 P-high, 100 P-medium, 20 P-low regression-from-stable-to-stable](https://github.com/rust-lang/rust/labels/regression-from-stable-to-stable)
+
+### P-critical
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+- "Miscompilation caused by incorrectly-deduced readonly on virtual call" [rust#137646](https://github.com/rust-lang/rust/issues/137646)
+  - Fixed by #137669 (beta nominated)
+
+[T-types](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-types)
+- No `P-critical` issues for `T-types` this time.
+
+### P-high regressions
+
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+- No `P-high` beta regressions this time.
+
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core+)
+- No unassigned `P-high` nightly regressions this time.
+
+## Performance logs
+
+> [triage logs for 2025-02-25](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025-02-25.md)
+
+Fairly quiet week with the exception of an improvement to the very often used Iter::next function which can now be inlined leading to a myriad of performance improvements.
+
+Triage done by **@rylev**.
+Revision range: [ce36a966..f5729cfe](https://perf.rust-lang.org/?start=ce36a966c79e109dabeef7a47fe68e5294c6d71e&end=f5729cfed3c45e061e8a443677fc1d5ef9277df7&absolute=false&stat=instructions%3Au)
+
+**Summary**:
+
+| (instructions:u)         | mean  | range          | count |
+|:------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.4%  | [0.2%, 1.0%]   | 37    |
+| Regressions (secondary)  | 0.7%  | [0.2%, 8.6%]   | 54    |
+| Improvements (primary)   | -0.5% | [-1.4%, -0.1%] | 88    |
+| Improvements (secondary) | -0.6% | [-2.3%, -0.1%] | 87    |
+| All  (primary)           | -0.2% | [-1.4%, 1.0%]  | 125   |
+
+
+1 Regression, 1 Improvement, 7 Mixed; 2 of them in rollups
+40 artifact comparisons made in total
+
+#### Regressions
+
+Remove `NtVis` and `NtTy` [#133436](https://github.com/rust-lang/rust/pull/133436) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=b87eda7fdf8034c52b3abef52b443b8573484eda&end=b6d3be4948e92fce0236cbbe22b55c55f6950269&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions (primary)    | 0.4% | [0.2%, 1.0%] | 18    |
+| Regressions (secondary)  | 0.6% | [0.3%, 0.9%] | 11    |
+| Improvements (primary)   | -    | -            | 0     |
+| Improvements (secondary) | -    | -            | 0     |
+| All  (primary)                 | 0.4% | [0.2%, 1.0%] | 18    |
+- [Necessary perf hit](https://github.com/rust-lang/rust/pull/133436#issuecomment-2502075751)
+
+
+#### Improvements
+
+librustdoc: Use `pulldown-cmark-escape` for HTML escaping [#137285](https://github.com/rust-lang/rust/pull/137285) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=e0be1a02626abef2878cb7f4aaef7ae409477112&end=f43e549b88698568581a9d329c7582e3708ac187&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -0.3% | [-0.6%, -0.2%] | 14    |
+| Improvements (secondary) | -0.5% | [-1.5%, -0.1%] | 5     |
+| All  (primary)                 | -0.3% | [-0.6%, -0.2%] | 14    |
+
+
+#### Mixed
+
+improve cold_path() [#133852](https://github.com/rust-lang/rust/pull/133852) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=aaa861493456e8a10e552dd208f85486de772007&end=3b022d8ceea570db9730be34d964f0cc663a567f&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.4%  | [0.1%, 0.9%]   | 7     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -0.7% | [-0.7%, -0.7%] | 1     |
+| Improvements (secondary) | -     | -              | 0     |
+| All  (primary)                 | 0.2%  | [-0.7%, 0.9%]  | 8     |
+- Expected perf regressions that were [deemed worth it](https://github.com/rust-lang/rust/pull/133852#issuecomment-2657312984)
+
+
+Rollup of 9 pull requests [#137295](https://github.com/rust-lang/rust/pull/137295) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=4e1356b95972c1a52acb9f0dd078687132ec02be&end=6d3c050de81c8858e28b0e59cc9398d840edfbff&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | 1.0%  | [1.0%, 1.0%]   | 1     |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.3% | [-0.3%, -0.3%] | 1     |
+| All  (primary)                 | -     | -              | 0     |
+- Perf results are too small for this to be worth investigating.
+
+
+Emit `trunc nuw` for unchecked shifts and `to_immediate_scalar` [#137058](https://github.com/rust-lang/rust/pull/137058) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=eeb9035117dc85fa4abe8e2abb09285fd65b0263&end=c62239aeb3ba7781a6d7f7055523c1e8c22b409c&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | -     | -              | 0     |
+| Regressions (secondary)  | 0.7%  | [0.4%, 1.3%]   | 16    |
+| Improvements (primary)   | -0.5% | [-0.8%, -0.4%] | 4     |
+| Improvements (secondary) | -0.1% | [-0.1%, -0.1%] | 1     |
+| All  (primary)                 | -0.5% | [-0.8%, -0.4%] | 4     |
+- Usually small changes in stress tests don't necessarily lead to perf investigations.
+- Asked the author for insight on whether this is worth investigating.
+
+
+Simplify `slice::Iter::next` enough that it inlines [#136771](https://github.com/rust-lang/rust/pull/136771) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=28b83ee59698ae069f5355b8e03f976406f410f5&end=f04bbc60f8c353ee5ba0677bc583ac4a88b2c180&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.4%  | [0.4%, 0.4%]   | 2     |
+| Regressions (secondary)  | 8.8%  | [8.8%, 8.8%]   | 1     |
+| Improvements (primary)   | -0.4% | [-1.4%, -0.1%] | 123   |
+| Improvements (secondary) | -0.5% | [-2.3%, -0.1%] | 70    |
+| All  (primary)                 | -0.4% | [-1.4%, 0.4%]  | 125   |
+- Perf improvements vastly outweigh the regressions
+
+
+Update host LLVM to 20.1 on CI [#137189](https://github.com/rust-lang/rust/pull/137189) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=46420c96070b4c4bd8242f16d5806b8f26a57016&end=07697360aee0cebcb4e304236ba1884d8dde5469&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.1%  | [0.1%, 0.1%]   | 1     |
+| Regressions (secondary)  | -     | -              | 0     |
+| Improvements (primary)   | -0.3% | [-0.3%, -0.2%] | 7     |
+| Improvements (secondary) | -0.4% | [-0.4%, -0.4%] | 1     |
+| All  (primary)                 | -0.2% | [-0.3%, 0.1%]  | 8     |
+- This is actually quite small perf difference for an LLVM change
+
+
+New attribute parsing infrastructure [#135726](https://github.com/rust-lang/rust/pull/135726) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=617aad8c2e8783f6df8e5d1f8bb1e4bcdc70aa7b&end=7d8c6e781d347e087c7d30ea393d7dcd725ed623&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.4%  | [0.2%, 0.8%]   | 38    |
+| Regressions (secondary)  | 0.6%  | [0.3%, 1.3%]   | 43    |
+| Improvements (primary)   | -4.1% | [-4.1%, -4.1%] | 1     |
+| Improvements (secondary) | -0.7% | [-2.4%, -0.3%] | 8     |
+| All  (primary)                 | 0.3%  | [-4.1%, 0.8%]  | 39    |
+- See [here](https://github.com/rust-lang/rust/pull/137610#issuecomment-2682489608) for explanation for why there was a perf regression here.
+
+
+Rollup of 11 pull requests [#137573](https://github.com/rust-lang/rust/pull/137573) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=7d8c6e781d347e087c7d30ea393d7dcd725ed623&end=f5729cfed3c45e061e8a443677fc1d5ef9277df7&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions (primary)    | 0.5%  | [0.3%, 0.7%]   | 3     |
+| Regressions (secondary)  | 1.0%  | [1.0%, 1.0%]   | 1     |
+| Improvements (primary)   | -     | -              | 0     |
+| Improvements (secondary) | -0.4% | [-0.4%, -0.4%] | 1     |
+| All  (primary)                 | 0.5%  | [0.3%, 0.7%]   | 3     |
+- Results are too small to warrant an investigation.
+
+## Nominated Issues
+
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- "Our x86-32 target names are inconsistent" [rust#136495](https://github.com/rust-lang/rust/issues/136495)
+  - Removed compiler nomination, I (@_**apiraino**) think all questions should be addressed but please feel free to raise a hand if it's not the case
+
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+- No I-compiler-nominated RFCs this time.
+
+### Oldest PRs waiting for review
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+- "Add diagnostic for stack allocations of 1 GB or more" [rust#119798](https://github.com/rust-lang/rust/pull/119798)
+  - cc @**cjgillot**
+- "Improve parse item fallback" [rust#125388](https://github.com/rust-lang/rust/pull/125388) (last review activity: 9 months ago)
+  - cc @**Esteban Küber**
+- "Silence errors in expressions caused by bare traits in paths in 2021 edition" [rust#125784](https://github.com/rust-lang/rust/pull/125784) (last review activity: 8 months ago)
+  - cc: @**Esteban Küber** for a rebase then cc: @_**León Orell Liehr (fmease)**
+- "collect doc alias as tips during resolution" [rust#127721](https://github.com/rust-lang/rust/pull/127721) (last review activity: 7 months ago)
+  - cc @**Esteban Küber**
+- "Improve dead code analysis for structs and traits defined locally" [rust#128637](https://github.com/rust-lang/rust/pull/128637)
+  - cc: @cjgillot
+
+Next meetings' agenda draft: [hackmd link](https://hackmd.io/AqtUB3juQeSDl44sGZTLRQ)


### PR DESCRIPTION
This will be the last batch of meetings notes added to the repository.

From now they will just be linked from their HackMD location
https://hackmd.io/team/rust-compiler-team?nav=overview&tags=%5B%22weekly%22%5D&tagtree-filter=true: