### PR TITLE
Fix link in MCP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/major_change.md
+++ b/.github/ISSUE_TEMPLATE/major_change.md
@@ -33,4 +33,4 @@ The main points of the [Major Change Process][MCP] are as follows:
 
 You can read [more about Major Change Proposals on forge][MCP].
 
-[MCP]: https://forge.rust-lang.org/compiler/mcp.html
+[MCP]: https://forge.rust-lang.org/compiler/proposals-and-stabilization.html#how-do-i-submit-an-mcp


### PR DESCRIPTION
It was pointing to a page that was 404.