### PR TITLE
Add a redirect to forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+**UPDATE 2025-04-01**
+
+The website has been retired. All content is now available on:
+https://forge.rust-lang.org/compiler/index.html
+
 # Compiler Team
 This repository contains a static site that details the procedures, policies, working groups,
 planning documents and minutes.

--- a/layouts/partials/docs/html-head.html
+++ b/layouts/partials/docs/html-head.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=https://forge.rust-lang.org/compiler/index.html" />


### PR DESCRIPTION
This should make the link in the description of this git repository redirect to where we now have the team compiler documentation.

I wanted to do it properly with a Hugo configuration option but didn't find a way :man_shrugging: 

r? @davidtwco 

thanks!