### PR TITLE
Use blank issue title for MCP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/major_change.md
+++ b/.github/ISSUE_TEMPLATE/major_change.md
@@ -1,7 +1,7 @@
 ---
 name: Major change proposal (MCP)
 about: Propose a major change.
-title: "(My major change proposal)"
+title: ''
 labels: major-change, T-compiler
 assignees: ''
 


### PR DESCRIPTION
To hopefully make it less likely for people to forget to change their MCP issue title.

See [#t-compiler/major changes > Retroactive MCP for the Rust for Linux Ec… compiler-team#874 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Retroactive.20MCP.20for.20the.20Rust.20for.20Linux.20Ec.E2.80.A6.20compiler-team.23874/near/520992619)

r? @apiraino 