### PR TITLE
Enable triagebot `concern`/`resolve` commands

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -7,3 +7,8 @@ zulip_stream = 233931
 zulip_ping = "T-compiler"
 
 [relabel]
+
+# Enables `concern`/`resolve` commands.
+# Documentation at https://forge.rust-lang.org/triagebot/concern.html
+[concern]
+labels = ["has-concerns"]


### PR DESCRIPTION
Testing has been conducted [here](https://github.com/rust-lang/triagebot/pull/2024#issue-3099685606).

cc @apiraino