### PR TITLE
Enable auto-closing of MCP in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -6,6 +6,8 @@ open_extra_text = "cc @rust-lang/compiler"
 # can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
 zulip_stream = 233931
 zulip_ping = "T-compiler"
+waiting_period = 10 # in days
+auto_closing = true
 
 [relabel]
 


### PR DESCRIPTION
Proposed at [#t-compiler > Automatic closing of MCP after second @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Automatic.20closing.20of.20MCP.20after.20second/near/524306690)