### PR TITLE
Mention the Unstable Book in the MCP tracking issue template

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -29,14 +29,16 @@ This is a tracking issue for MCP "${mcp_title}" (rust-lang/compiler-team#${mcp_n
 ### Steps
 
 - [ ] Implement the MCP
-- [ ] Adjust documentation
+- [ ] Adjust the documentation
   - [ ] In the [Rust Compiler Development Guide] if applicable (e.g., for refactorings)
   - [ ] In the [Rust Forge] if applicable (e.g., for policy changes)
   - [ ] In the [rustc book] if applicable (e.g., for target tier or CLI changes)
+  - [ ] In the [Unstable Book] if applicable (e.g., for unstable CLI changes)
 
 [Rust Compiler Development Guide]: https://rustc-dev-guide.rust-lang.org/
 [Rust Forge]: https://forge.rust-lang.org/compiler/index.html
 [rustc book]: https://doc.rust-lang.org/rustc/index.html
+[Unstable Book]: https://doc.rust-lang.org/unstable-book
 
 ### Unresolved questions
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/154171 made me realize that the Unstable Book can also be relevant for T-compiler MCPs since it tracks unstable compiler flags and compiler-internal env vars (while the rustc book is relevant for "insta-stable" CLI changes only), I somehow totally forgot about that.

Follow-up to https://github.com/rust-lang/compiler-team/pull/939 and https://github.com/rust-lang/compiler-team/pull/933.