### PR TITLE
Remove T-libs-api tag from search query in agenda

### DIFF
--- a/templates/T-compiler Meeting Agenda YYYY-MM-DD.md
+++ b/templates/T-compiler Meeting Agenda YYYY-MM-DD.md
@@ -58,7 +58,7 @@ type: docs
 
 ## Oldest PRs waiting for review
 
-[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler+-label%3AT-lang+-label%3AT-infra+-label%3AT-release+-label%3AT-libs+-label%3AT-libs-api)
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler+-label%3AT-lang+-label%3AT-infra+-label%3AT-release+-label%3AT-libs)
 - No unreviewed PRs on `T-compiler` at this time.
 
 ## Issues of Note


### PR DESCRIPTION
Poking around the org for changes that might be useful with [RFC 3984](https://github.com/rust-lang/rfcs/pull/3984).

This basically doesn't matter, but I noticed it, so, here you go.